### PR TITLE
Ajout de calculs deterministes et piste de calcul dans la cloture

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ npm run closing    # Génère tout d'un coup (états financiers + FEC + PDFs)
 
 | Script / Template | Génère |
 |-------------------|--------|
+| `calc.js` | Calculs déterministes (CCA, amortissements, IS, TVA simplifiée, prorata) |
 | `generate-statements.js` | Bilan, Compte de résultat, Balance |
 | `generate-fec.js` | FEC 18 colonnes (art. L. 47 A-I LPF) |
 | `generate-pdfs.js` | PDFs professionnels avec en-tête société |

--- a/comptable/SKILL.md
+++ b/comptable/SKILL.md
@@ -140,9 +140,12 @@ Consulter selon le besoin :
 |--------|-------|
 | `scripts/fetch_company.py <SIREN>` | Recherche info entreprise via API |
 | `scripts/update_data.py` | Vérifier fraîcheur des données et télécharger MAJ |
+| `scripts/calc.js` | Calculs déterministes (CCA, amortissement, IS, acomptes TVA simplifié, prorata) |
 | `scripts/generate-statements.js` | Générer Bilan, Compte de résultat, Balance |
 | `scripts/generate-fec.js` | Générer le FEC |
 | `scripts/generate-pdfs.js` | Convertir les états financiers en PDFs |
+
+Règle de calcul : pour tout calcul chiffré (TVA, IS, amortissement, prorata, CCA), utiliser `node scripts/calc.js` plutôt qu'un calcul mental.
 
 ## Templates
 

--- a/comptable/references/closing.md
+++ b/comptable/references/closing.md
@@ -153,6 +153,7 @@ Annuité = Valeur brute / Durée
 ```
 
 **Prorata temporis:** Première et dernière année au prorata.
+Base civile retenue ici : 365 jours, conforme à la pratique fiscale usuelle pour l'amortissement des immobilisations.
 
 ```
 Annuité N = (Valeur / Durée) × (Jours utilisés / 365)

--- a/comptable/references/closing.md
+++ b/comptable/references/closing.md
@@ -155,7 +155,7 @@ Annuité = Valeur brute / Durée
 **Prorata temporis:** Première et dernière année au prorata.
 
 ```
-Annuité N = (Valeur / Durée) × (Jours utilisés / 360)
+Annuité N = (Valeur / Durée) × (Jours utilisés / 365)
 ```
 
 #### Dégressif (Option)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Skills et outils pour la comptabilité française",
   "private": true,
   "scripts": {
+    "calc": "node scripts/calc.js",
+    "test:calc": "node scripts/test-deterministic-calculations.js",
     "fec": "node scripts/generate-fec.js",
     "statements": "node scripts/generate-statements.js",
     "pdfs": "node scripts/generate-pdfs.js",

--- a/scripts/calc.js
+++ b/scripts/calc.js
@@ -95,8 +95,7 @@ function parseRateToBps(value, name) {
   if (!/^-?\d+(\.\d+)?$/.test(raw)) fail("taux invalide pour --" + name + ": " + value);
   const num = Number(raw);
   if (Number.isNaN(num)) fail("taux invalide pour --" + name + ": " + value);
-  const percent = Math.abs(num) <= 1 ? num * 100 : num;
-  return Math.round(percent * 100); // 1% = 100 bps
+  return BigInt(Math.round(num * 100)); // 1% = 100 bps
 }
 
 function roundDivSigned(numer, denom) {
@@ -214,7 +213,7 @@ function cmdIS(args) {
   const rows = [["Resultat fiscal", formatCents(resultatFiscal)]];
 
   if (args.taux !== undefined) {
-    const tauxBps = BigInt(parseRateToBps(args.taux, "taux"));
+    const tauxBps = parseRateToBps(args.taux, "taux");
     totalIS = roundDivSigned(resultatFiscal * tauxBps, 10000n);
     mode = "taux unique";
     rows.push(["Mode", mode]);
@@ -225,8 +224,8 @@ function cmdIS(args) {
     args["taux-normal"] !== undefined ||
     args.plafond !== undefined
   ) {
-    const tauxReduitBps = BigInt(parseRateToBps(args["taux-reduit"] ?? 15, "taux-reduit"));
-    const tauxNormalBps = BigInt(parseRateToBps(args["taux-normal"] ?? 25, "taux-normal"));
+    const tauxReduitBps = parseRateToBps(args["taux-reduit"] ?? 15, "taux-reduit");
+    const tauxNormalBps = parseRateToBps(args["taux-normal"] ?? 25, "taux-normal");
     const plafondAnnuel = parseAmountToCents(args.plafond ?? 42500, "plafond");
     const joursExercice = args["jours-exercice"] !== undefined
       ? BigInt(parseIntStrict(args["jours-exercice"], "jours-exercice"))
@@ -317,4 +316,19 @@ function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  cmdAmortissementLineaire,
+  cmdCCA,
+  cmdIS,
+  cmdProrata,
+  cmdTVAAcomptesRS,
+  formatCents,
+  parseAmountToCents,
+  parseRateToBps,
+  prorateAnnualThreshold,
+  roundDivSigned,
+};

--- a/scripts/calc.js
+++ b/scripts/calc.js
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+
+/**
+ * Calculateur comptable/fiscal deterministe.
+ *
+ * Objectif:
+ * - Eviter les calculs "a la main" par le LLM
+ * - Centraliser les formules utilisees dans le skill comptable
+ *
+ * Usage:
+ *   node scripts/calc.js <commande> [--param valeur]
+ *
+ * Commandes:
+ *   cca
+ *     --total 1200
+ *     --jours-n-plus-1 92
+ *     --jours-totaux 365
+ *
+ *   amortissement-lineaire
+ *     --valeur 3000
+ *     --duree 3
+ *     [--jours-utilises 200]
+ *     [--base-jours 365]
+ *
+ *   is
+ *     --resultat-fiscal 50000
+ *     [--taux 25]                          // taux unique (%)
+ *     [--taux-reduit 15 --plafond 42500 --taux-normal 25]
+ *     [--jours-exercice 365]
+ *
+ *   tva-acomptes-rs
+ *     --tva-n-1 12000
+ *
+ *   prorata
+ *     --montant 1000
+ *     --jours 50
+ *     [--base 365]
+ */
+
+function fail(msg) {
+  console.error("Erreur: " + msg);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token.startsWith("--")) {
+      const eq = token.indexOf("=");
+      if (eq > 2) {
+        const key = token.slice(2, eq);
+        const value = token.slice(eq + 1);
+        args[key] = value;
+        continue;
+      }
+      const key = token.slice(2);
+      const value = argv[i + 1];
+      if (!value || value.startsWith("--")) {
+        args[key] = true;
+      } else {
+        args[key] = value;
+        i++;
+      }
+    } else {
+      args._.push(token);
+    }
+  }
+  return args;
+}
+
+function parseIntStrict(value, name) {
+  if (value === undefined) fail("parametre manquant --" + name);
+  if (!/^-?\d+$/.test(String(value))) fail("entier invalide pour --" + name + ": " + value);
+  return Number(value);
+}
+
+function parseAmountToCents(value, name) {
+  if (value === undefined) fail("parametre manquant --" + name);
+  const raw = String(value).trim().replace(/\s/g, "").replace(",", ".");
+  if (!/^-?\d+(\.\d{1,2})?$/.test(raw)) {
+    fail("montant invalide pour --" + name + ": " + value);
+  }
+  const neg = raw.startsWith("-");
+  const abs = neg ? raw.slice(1) : raw;
+  const [euros, decimals = ""] = abs.split(".");
+  const centsStr = euros + decimals.padEnd(2, "0");
+  const cents = BigInt(centsStr);
+  return neg ? -cents : cents;
+}
+
+function parseRateToBps(value, name) {
+  if (value === undefined) fail("parametre manquant --" + name);
+  const raw = String(value).trim().replace(",", ".");
+  if (!/^-?\d+(\.\d+)?$/.test(raw)) fail("taux invalide pour --" + name + ": " + value);
+  const num = Number(raw);
+  if (Number.isNaN(num)) fail("taux invalide pour --" + name + ": " + value);
+  const percent = Math.abs(num) <= 1 ? num * 100 : num;
+  return Math.round(percent * 100); // 1% = 100 bps
+}
+
+function roundDivSigned(numer, denom) {
+  if (denom <= 0n) fail("denominateur doit etre > 0");
+  if (numer >= 0n) return (numer + denom / 2n) / denom;
+  return -((-numer + denom / 2n) / denom);
+}
+
+function prorateAnnualThreshold(thresholdCents, exerciseDays) {
+  if (exerciseDays === null) return thresholdCents;
+  if (exerciseDays <= 0n) fail("--jours-exercice doit etre > 0");
+  return roundDivSigned(thresholdCents * exerciseDays, 365n);
+}
+
+function formatCents(cents) {
+  const neg = cents < 0n;
+  const abs = neg ? -cents : cents;
+  const euros = abs / 100n;
+  const dec = (abs % 100n).toString().padStart(2, "0");
+  const text = euros.toString() + "," + dec + " EUR";
+  return neg ? "-" + text : text;
+}
+
+function printResult(title, rows) {
+  console.log(title);
+  console.log("=".repeat(title.length));
+  for (const [k, v] of rows) {
+    console.log(k + ": " + v);
+  }
+}
+
+function cmdCCA(args) {
+  const total = parseAmountToCents(args.total, "total");
+  const joursN1 = BigInt(parseIntStrict(args["jours-n-plus-1"], "jours-n-plus-1"));
+  const joursTotaux = BigInt(parseIntStrict(args["jours-totaux"], "jours-totaux"));
+  if (joursN1 < 0n) fail("--jours-n-plus-1 doit etre >= 0");
+  if (joursTotaux <= 0n) fail("--jours-totaux doit etre > 0");
+
+  const cca = roundDivSigned(total * joursN1, joursTotaux);
+  printResult("Calcul CCA", [
+    ["Formule", "CCA = Montant total x (Jours N+1 / Jours totaux)"],
+    ["Montant total", formatCents(total)],
+    ["Jours N+1", String(joursN1)],
+    ["Jours totaux", String(joursTotaux)],
+    ["CCA", formatCents(cca)],
+  ]);
+}
+
+function cmdProrata(args) {
+  const montant = parseAmountToCents(args.montant, "montant");
+  const jours = BigInt(parseIntStrict(args.jours, "jours"));
+  const base = BigInt(parseIntStrict(args.base || 365, "base"));
+  if (jours < 0n) fail("--jours doit etre >= 0");
+  if (base <= 0n) fail("--base doit etre > 0");
+
+  const value = roundDivSigned(montant * jours, base);
+  printResult("Calcul Prorata", [
+    ["Formule", "Montant prorata = Montant x (Jours / Base)"],
+    ["Montant", formatCents(montant)],
+    ["Jours", String(jours)],
+    ["Base", String(base)],
+    ["Resultat", formatCents(value)],
+  ]);
+}
+
+function cmdAmortissementLineaire(args) {
+  const valeur = parseAmountToCents(args.valeur, "valeur");
+  const duree = BigInt(parseIntStrict(args.duree, "duree"));
+  if (duree <= 0n) fail("--duree doit etre > 0");
+
+  const annuitePleine = roundDivSigned(valeur, duree);
+  const joursUtilises = args["jours-utilises"] !== undefined
+    ? BigInt(parseIntStrict(args["jours-utilises"], "jours-utilises"))
+    : null;
+  const baseJours = BigInt(parseIntStrict(args["base-jours"] || 365, "base-jours"));
+  if (baseJours <= 0n) fail("--base-jours doit etre > 0");
+
+  if (joursUtilises !== null && joursUtilises < 0n) fail("--jours-utilises doit etre >= 0");
+
+  const dotation = joursUtilises === null
+    ? annuitePleine
+    : roundDivSigned(annuitePleine * joursUtilises, baseJours);
+
+  const rows = [
+    ["Formule annuite", "Annuite = Valeur brute / Duree"],
+    ["Valeur brute", formatCents(valeur)],
+    ["Duree", String(duree) + " an(s)"],
+    ["Annuite pleine", formatCents(annuitePleine)],
+  ];
+
+  if (joursUtilises !== null) {
+    rows.push(["Formule prorata", "Dotation = Annuite x (Jours utilises / Base jours)"]);
+    rows.push(["Jours utilises", String(joursUtilises)]);
+    rows.push(["Base jours", String(baseJours)]);
+    rows.push(["Dotation periode", formatCents(dotation)]);
+  } else {
+    rows.push(["Dotation periode", formatCents(dotation)]);
+  }
+
+  printResult("Calcul Amortissement Lineaire", rows);
+}
+
+function cmdIS(args) {
+  const resultatFiscal = parseAmountToCents(args["resultat-fiscal"], "resultat-fiscal");
+  if (resultatFiscal <= 0n) {
+    printResult("Calcul IS", [
+      ["Resultat fiscal", formatCents(resultatFiscal)],
+      ["IS", "0,00 EUR (resultat fiscal <= 0)"],
+    ]);
+    return;
+  }
+
+  let totalIS = 0n;
+  let mode = "";
+  const rows = [["Resultat fiscal", formatCents(resultatFiscal)]];
+
+  if (args.taux !== undefined) {
+    const tauxBps = BigInt(parseRateToBps(args.taux, "taux"));
+    totalIS = roundDivSigned(resultatFiscal * tauxBps, 10000n);
+    mode = "taux unique";
+    rows.push(["Mode", mode]);
+    rows.push(["Taux", args.taux + " %"]);
+    rows.push(["Formule", "IS = Resultat fiscal x Taux"]);
+  } else if (
+    args["taux-reduit"] !== undefined ||
+    args["taux-normal"] !== undefined ||
+    args.plafond !== undefined
+  ) {
+    const tauxReduitBps = BigInt(parseRateToBps(args["taux-reduit"] ?? 15, "taux-reduit"));
+    const tauxNormalBps = BigInt(parseRateToBps(args["taux-normal"] ?? 25, "taux-normal"));
+    const plafondAnnuel = parseAmountToCents(args.plafond ?? 42500, "plafond");
+    const joursExercice = args["jours-exercice"] !== undefined
+      ? BigInt(parseIntStrict(args["jours-exercice"], "jours-exercice"))
+      : null;
+    const plafond = prorateAnnualThreshold(plafondAnnuel, joursExercice);
+
+    const trancheReduite = resultatFiscal < plafond ? resultatFiscal : plafond;
+    const trancheNormale = resultatFiscal > plafond ? (resultatFiscal - plafond) : 0n;
+    const isReduit = roundDivSigned(trancheReduite * tauxReduitBps, 10000n);
+    const isNormal = roundDivSigned(trancheNormale * tauxNormalBps, 10000n);
+    totalIS = isReduit + isNormal;
+    mode = "deux tranches";
+
+    rows.push(["Mode", mode]);
+    rows.push(["Plafond annuel taux reduit", formatCents(plafondAnnuel)]);
+    if (joursExercice !== null) {
+      rows.push(["Jours exercice", String(joursExercice)]);
+    }
+    rows.push(["Plafond taux reduit applique", formatCents(plafond)]);
+    rows.push(["Taux reduit", String(args["taux-reduit"] ?? 15) + " %"]);
+    rows.push(["Taux normal", String(args["taux-normal"] ?? 25) + " %"]);
+    rows.push(["Tranche reduite", formatCents(trancheReduite)]);
+    rows.push(["Tranche normale", formatCents(trancheNormale)]);
+    rows.push(["IS tranche reduite", formatCents(isReduit)]);
+    rows.push(["IS tranche normale", formatCents(isNormal)]);
+  } else {
+    fail("pour la commande is, fournir --taux OU (--taux-reduit/--taux-normal/--plafond)");
+  }
+
+  rows.push(["IS total", formatCents(totalIS)]);
+  printResult("Calcul IS", rows);
+}
+
+function cmdTVAAcomptesRS(args) {
+  const tvaN1 = parseAmountToCents(args["tva-n-1"], "tva-n-1");
+  const a1 = roundDivSigned(tvaN1 * 55n, 100n);
+  const a2 = roundDivSigned(tvaN1 * 40n, 100n);
+  const total = a1 + a2;
+
+  printResult("Calcul Acomptes TVA Regime Simplifie", [
+    ["TVA N-1", formatCents(tvaN1)],
+    ["Acompte juillet (55%)", formatCents(a1)],
+    ["Acompte decembre (40%)", formatCents(a2)],
+    ["Total acomptes", formatCents(total)],
+  ]);
+}
+
+function help() {
+  console.log("Calculateur comptable/fiscal deterministe");
+  console.log("");
+  console.log("Usage: node scripts/calc.js <commande> [--param valeur]");
+  console.log("");
+  console.log("Commandes:");
+  console.log("  cca");
+  console.log("  amortissement-lineaire");
+  console.log("  is");
+  console.log("  tva-acomptes-rs");
+  console.log("  prorata");
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const cmd = args._[0];
+
+  if (!cmd || cmd === "help" || cmd === "--help" || cmd === "-h") {
+    help();
+    return;
+  }
+
+  switch (cmd) {
+    case "cca":
+      cmdCCA(args);
+      break;
+    case "amortissement-lineaire":
+      cmdAmortissementLineaire(args);
+      break;
+    case "is":
+      cmdIS(args);
+      break;
+    case "tva-acomptes-rs":
+      cmdTVAAcomptesRS(args);
+      break;
+    case "prorata":
+      cmdProrata(args);
+      break;
+    default:
+      fail("commande inconnue: " + cmd + ". Lancez: node scripts/calc.js --help");
+  }
+}
+
+main();

--- a/scripts/test-deterministic-calculations.js
+++ b/scripts/test-deterministic-calculations.js
@@ -5,6 +5,7 @@ const path = require("path");
 const { execFileSync } = require("child_process");
 
 const ROOT = path.join(__dirname, "..");
+const CALC_SCRIPT = path.join(ROOT, "scripts", "calc.js");
 
 function runNodeScript(scriptPath, args) {
   return execFileSync(process.execPath, [scriptPath, ...args], {
@@ -13,8 +14,44 @@ function runNodeScript(scriptPath, args) {
   });
 }
 
-function testCliProratedReducedRate() {
-  const output = runNodeScript(path.join(ROOT, "scripts", "calc.js"), [
+function runCalc(args) {
+  return runNodeScript(CALC_SCRIPT, args);
+}
+
+function testCCA() {
+  const output = runCalc(["cca", "--total=1200", "--jours-n-plus-1=92", "--jours-totaux=365"]);
+  assert.match(output, /CCA: 302,47 EUR/);
+}
+
+function testAmortissementLineaire() {
+  const output = runCalc([
+    "amortissement-lineaire",
+    "--valeur=3000",
+    "--duree=3",
+    "--jours-utilises=200",
+    "--base-jours=365",
+  ]);
+  assert.match(output, /Annuite pleine: 1000,00 EUR/);
+  assert.match(output, /Dotation periode: 547,95 EUR/);
+}
+
+function testISTauxUnique() {
+  const output = runCalc(["is", "--resultat-fiscal=10000", "--taux=25"]);
+  assert.match(output, /IS total: 2500,00 EUR/);
+}
+
+function testISTauxOneMeansOnePercent() {
+  const output = runCalc(["is", "--resultat-fiscal=1000", "--taux=1"]);
+  assert.match(output, /IS total: 10,00 EUR/);
+}
+
+function testISNegative() {
+  const output = runCalc(["is", "--resultat-fiscal=-1000", "--taux=25"]);
+  assert.match(output, /IS: 0,00 EUR \(resultat fiscal <= 0\)/);
+}
+
+function testISProratedReducedRate() {
+  const output = runCalc([
     "is",
     "--resultat-fiscal=50000",
     "--taux-reduit=15",
@@ -26,8 +63,26 @@ function testCliProratedReducedRate() {
   assert.match(output, /IS total: 10380,83 EUR/);
 }
 
+function testTVAAcomptesRS() {
+  const output = runCalc(["tva-acomptes-rs", "--tva-n-1=12000"]);
+  assert.match(output, /Acompte juillet \(55%\): 6600,00 EUR/);
+  assert.match(output, /Total acomptes: 11400,00 EUR/);
+}
+
+function testProrata() {
+  const output = runCalc(["prorata", "--montant=1000", "--jours=50", "--base=365"]);
+  assert.match(output, /Resultat: 136,99 EUR/);
+}
+
 function main() {
-  testCliProratedReducedRate();
+  testCCA();
+  testAmortissementLineaire();
+  testISTauxUnique();
+  testISTauxOneMeansOnePercent();
+  testISNegative();
+  testISProratedReducedRate();
+  testTVAAcomptesRS();
+  testProrata();
   console.log("Deterministic calculation tests passed.");
 }
 

--- a/scripts/test-deterministic-calculations.js
+++ b/scripts/test-deterministic-calculations.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const assert = require("assert");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const ROOT = path.join(__dirname, "..");
+
+function runNodeScript(scriptPath, args) {
+  return execFileSync(process.execPath, [scriptPath, ...args], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+}
+
+function testCliProratedReducedRate() {
+  const output = runNodeScript(path.join(ROOT, "scripts", "calc.js"), [
+    "is",
+    "--resultat-fiscal=50000",
+    "--taux-reduit=15",
+    "--taux-normal=25",
+    "--jours-exercice=182",
+  ]);
+
+  assert.match(output, /Plafond taux reduit applique: 21191,78 EUR/);
+  assert.match(output, /IS total: 10380,83 EUR/);
+}
+
+function main() {
+  testCliProratedReducedRate();
+  console.log("Deterministic calculation tests passed.");
+}
+
+main();


### PR DESCRIPTION
## Résumé

Ajout d'un script de calcul déterministe pour les formules comptables et fiscales simples utilisées par le skill `comptable`.

## Changements

- ajout de `scripts/calc.js` pour :
  - CCA
  - amortissement linéaire avec prorata
  - IS (taux unique ou taux réduit)
  - acomptes TVA au régime simplifié
  - prorata
- correction du prorata d''amortissement en `/365` dans `comptable/references/closing.md`
- mise à jour de `README.md` et `comptable/SKILL.md` pour référencer le script
- ajout d''un test ciblé : `npm run test:calc`

## Vérification

- `npm run test:calc`