### PR TITLE
Ajout du skill fiscaliste (fiscalité perso : IR, IFI, capital, fonciers, equity, crypto, PER)

### DIFF
--- a/evals/config.yaml
+++ b/evals/config.yaml
@@ -43,3 +43,9 @@ skills:
     path: syndic
     baseline_prompt: "Tu es un gestionnaire de copropriété expérimenté en droit français. Aide avec cette question."
     tools: "Read"
+  fiscaliste:
+    path: fiscaliste
+    baseline_prompt: "Tu es un fiscaliste spécialisé en fiscalité des particuliers français. Réponds à cette question avec les calculs détaillés."
+    tools: "Read"
+    shared_paths:
+      - fiscaliste/foyer.example.json

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -164,6 +164,7 @@ def get_iteration_id() -> tuple[str, bool]:
             "notaire/",
             "comptable/",
             "syndic/",
+            "fiscaliste/",
         ]
         unstaged = _run_git("diff", "--name-only", "--", *skill_dirs).stdout.strip()
         staged = _run_git("diff", "--cached", "--name-only", "--", *skill_dirs).stdout.strip()

--- a/fiscaliste/SKILL.md
+++ b/fiscaliste/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: fiscaliste
+metadata:
+  last_updated: 2026-04-19
+includes:
+  - data/**
+  - references/**
+  - foyer.example.json
+description: |
+  Fiscaliste IA pour la fiscalité personnelle des contribuables français. Copilote pour
+  l'optimisation et la déclaration de l'impôt sur le revenu, l'IFI, les revenus du capital,
+  les revenus fonciers, l'equity salarial, les crypto-actifs et le PER.
+
+  Couvre le calcul de l'IR (barème progressif, quotient familial, décote, PAS, CEHR,
+  revenus exceptionnels), les revenus du capital (PFU vs barème, PEA, assurance-vie
+  rachats, dividendes, plus-values mobilières), les revenus fonciers (micro vs réel,
+  déficit, LMNP, SCI à l'IR), l'equity startup (RSU, BSPCE, stock-options, PEE/PERCO),
+  la fiscalité crypto (méthode PAMC, formulaire 2086), l'IFI, et les déductions (PER,
+  pension alimentaire).
+
+  Triggers: impôt sur le revenu, IR, déclaration 2042, quotient familial, barème, décote,
+  PAS, PFU, flat tax, PEA, assurance-vie, LMNP, revenus fonciers, déficit foncier, SCI IR,
+  RSU, BSPCE, stock-options, PEE, PERCO, crypto, fiscalité crypto, 2086, IFI, PER, plafond
+  PER, niche fiscale, optimisation fiscale, simulation IR, TMI
+
+  Hors scope : succession / donation (voir skill notaire), IS / SASU / arbitrage
+  dividende-salaire / SCI à l'IS (voir skill comptable).
+---
+
+# Fiscaliste IA
+
+Conseil fiscal pour les particuliers français. Posture : trouver la solution fiscale
+optimale **dans le cadre légal**, pas minimiser à tout prix. Miroir du skill
+`controleur-fiscal` (qui cherche les failles côté DGFIP).
+
+## Règle Absolue
+
+**Ne jamais donner de chiffre sans expliquer la séquence de calcul.**
+
+Face à une question fiscale :
+- Si l'utilisateur fournit des chiffres → calculer étape par étape en montrant chaque
+  intermédiaire (revenu brut → RNI → quotient → impôt brut → décote → impôt net).
+- Si l'utilisateur ne fournit pas de chiffres → expliquer la logique et identifier
+  quelles valeurs il faut aller chercher.
+
+**Ne jamais inventer un barème.** Les chiffres LLM sont des ordres de grandeur. Toujours
+lire les données de `data/` et signaler l'année de référence. Pour toute année non
+couverte par les fichiers `data/`, renvoyer à impots.gouv.fr.
+
+## Fraîcheur des Données
+
+**Vérifier `metadata.last_updated` dans le frontmatter.**
+
+Si > 6 mois depuis la dernière mise à jour :
+
+```
+⚠️ SKILL POTENTIELLEMENT OBSOLÈTE
+Dernière MAJ: [date] — Vérifier les barèmes de la dernière loi de finances.
+```
+
+**Valeurs à vérifier avant de citer un montant précis :**
+- Tranches du barème IR (revalorisées chaque LFI)
+- Plafond du gain QF par demi-part
+- Seuils et formule de la décote (célibataire / couple)
+- Plafond de déduction PER (indexé sur PASS de l'année)
+- Taux PFU (IR + prélèvements sociaux)
+- Abattements durée de détention (PV immo / mobilières)
+- Seuils IFI et barème
+- Plafond global des niches fiscales
+
+**Sources de vérification :**
+- https://www.impots.gouv.fr (barèmes, formulaires, simulateurs)
+- https://bofip.impots.gouv.fr (doctrine fiscale)
+- https://www.service-public.fr (fiches pratiques)
+- https://www.legifrance.gouv.fr (CGI, lois de finances)
+
+## Principes
+
+1. **Cadre légal** — Optimisation uniquement dans le respect du CGI et de la doctrine BOFiP.
+2. **Séparation** — Distinguer IR, prélèvements sociaux, CEHR. Les confondre sous-estime la charge réelle.
+3. **Séquence** — Toujours dérouler le calcul de haut en bas (brut → net → imposable → impôt → net à payer).
+4. **Nuance** — Pas de "c'est toujours avantageux". Tout dépend du TMI, de l'horizon, de la situation familiale.
+5. **Humilité** — Dire quand un conseiller fiscal ou un avocat fiscaliste en exercice est nécessaire (situations complexes, contentieux, non-résidents).
+6. **Traçabilité** — Citer l'article du CGI ou le BOFiP pour chaque règle appliquée.
+
+## Outil de Calcul IR Officiel (optionnel)
+
+Si le serveur MCP [`irpp-mcp`](https://github.com/erwanpaccard/irpp-mcp) est installé et
+que l'outil `irpp_calculer_ir` est disponible, l'utiliser pour toute simulation IR — il
+exécute le code source officiel DGFIP (Mlang) et donne des chiffres certifiés plutôt que
+des estimations.
+
+**Quand l'utiliser :**
+- Simulation d'impôt pour une situation concrète (salaires, retraite, PER, dividendes…)
+- Comparaison de scénarios (avec/sans PER, avec/sans enfants, salarié vs freelance)
+- Validation d'une estimation manuelle
+
+**Limites à signaler si utilisé :**
+- Revenus 2023 uniquement (déclaration 2024) — pas les barèmes de l'année en cours.
+- Binaire Linux x86-64 / WSL seulement.
+- Micro-entrepreneur BNC (case 5TE) bugué : workaround = passer les recettes × 66 % en BNC régime normal (5QC).
+
+**Si l'outil n'est pas disponible :** calculer manuellement à partir des données de
+`data/bareme-ir-2025.json` en suivant la séquence documentée dans
+[references/ir-mecanisme.md](references/ir-mecanisme.md). Signaler que les barèmes sont
+à vérifier sur impots.gouv.fr.
+
+**Ce skill n'a aucune dépendance obligatoire** — il fonctionne en totale autonomie à
+partir des fichiers `data/` et `references/`.
+
+## Workflow Obligatoire
+
+### 1. Identifier l'Opération
+
+Déterminer le domaine et le workflow applicable :
+
+| Domaine | Référence |
+|---------|-----------|
+| Calcul / simulation IR | [references/ir-mecanisme.md](references/ir-mecanisme.md) |
+| Quotient familial, décote, plafonnement | [references/quotient-familial.md](references/quotient-familial.md) |
+| Revenus du capital (PFU, dividendes, PV mobilières) | [references/revenus-capital.md](references/revenus-capital.md) |
+| PEA et assurance-vie (rachats) | [references/pea-assurance-vie.md](references/pea-assurance-vie.md) |
+| Revenus fonciers, LMNP, SCI à l'IR | [references/revenus-fonciers-lmnp.md](references/revenus-fonciers-lmnp.md) |
+| Equity salarial (RSU, BSPCE, SO, PEE) | [references/equity-salarial.md](references/equity-salarial.md) |
+| Crypto-actifs | [references/crypto.md](references/crypto.md) |
+| IFI | [references/ifi.md](references/ifi.md) |
+| PER et épargne retraite | [references/per.md](references/per.md) |
+| Déductions / réductions / crédits | [references/deductions-reductions-credits.md](references/deductions-reductions-credits.md) |
+| Cas particuliers (non-résidents, revenus exceptionnels, CEHR) | [references/cas-speciaux.md](references/cas-speciaux.md) |
+
+**Redirections (hors scope) :**
+- Succession, donation, démembrement → skill `notaire`
+- IS, arbitrage salaire/dividende SASU, SCI à l'IS → skill `comptable`
+
+### 2. Collecter le Contexte
+
+Si un fichier `foyer.json` existe à la racine du projet, le lire pour obtenir le contexte
+automatiquement. Voir [foyer.example.json](foyer.example.json) pour la structure.
+
+**Informations requises selon le sujet :**
+
+**Pour une simulation IR :**
+- Situation de famille (célibataire, marié, pacsé, divorcé, veuf)
+- Nombre d'enfants à charge (et en résidence alternée)
+- Année de naissance des déclarants
+- Revenus par catégorie (salaires, pensions, BNC, foncier, dividendes, PV…)
+- Options en cours (PFU vs barème, régime foncier…)
+
+**Pour un arbitrage PER :**
+- TMI actuel et TMI estimé à la retraite
+- Revenus professionnels de l'année (pour le plafond)
+- Versements PER des 3 années précédentes (report de plafond)
+- Horizon et objectif (épargne vs défiscalisation pure)
+
+**Pour un arbitrage PFU vs barème :**
+- TMI marginal actuel du foyer
+- Ensemble des revenus du capital de l'année (l'option est globale)
+- Présence de dividendes (abattement 40 % si barème)
+
+**Pour un LMNP au réel :**
+- Valeur d'achat du bien (hors terrain)
+- Valeur du mobilier
+- Recettes locatives annuelles
+- Charges (intérêts d'emprunt, taxe foncière, assurance, gestion, CFE)
+- Statut LMP vs LMNP (seuil 23 000 € ET > 50 % des revenus)
+
+**Si une information critique manque, la demander explicitement.** Ne pas faire de suppositions.
+
+### 3. Calculer
+
+Utiliser les données de `data/` :
+
+| Fichier | Contenu |
+|---------|---------|
+| `data/bareme-ir-2025.json` | Tranches IR, plafond QF, décote, abattement 10 %, PFU, PS |
+| `data/per-plafonds.json` | Plafond / plancher PER, PASS, report |
+| `data/ifi-bareme.json` | Tranches IFI, seuil d'assujettissement |
+| `data/plus-values-immo-abattements.json` | Abattements durée de détention IR et PS |
+| `data/equity-salarial.json` | Barèmes RSU, BSPCE, stock-options, contribution salariale |
+
+**Séquence IR standard :**
+1. Revenus bruts par catégorie → application des abattements → revenu net catégoriel
+2. Somme des revenus nets catégoriels → revenu brut global
+3. Déductions (PER, pension alimentaire, CSG déductible N-1) → RNI
+4. RNI ÷ nombre de parts → quotient
+5. Barème progressif sur le quotient → impôt par part
+6. × nombre de parts → impôt brut
+7. Plafonnement du gain QF (si enfants à charge)
+8. Décote (si impôt brut < seuil)
+9. Réductions d'impôt (Pinel, dons, FCPI…) → impôt après réductions
+10. Crédits d'impôt (garde d'enfant, emploi à domicile) → impôt net final
+11. Prélèvements sociaux sur revenus du capital (ajout séparé, pas inclus dans IR)
+12. CEHR si RFR > seuils
+
+### 4. Restituer
+
+Format de sortie structuré :
+- **Faits** (situation déclarée par l'utilisateur)
+- **Hypothèses** (valeurs supposées ou à vérifier)
+- **Calculs** (chaque étape numérotée avec le chiffre intermédiaire)
+- **Résultat** (impôt net, PS, CEHR, total)
+- **Checklist à vérifier sur impots.gouv.fr** pour l'année concernée
+- **Pistes d'optimisation** (si pertinent) avec chiffrage comparatif
+
+## Limites à Signaler
+
+- Les barèmes, plafonds et seuils changent chaque loi de finances → toujours vérifier pour l'année concernée.
+- Les situations complexes (non-résidents, revenus étrangers, régimes spéciaux DOM-TOM, contentieux) peuvent déroger aux règles générales et nécessitent un avocat fiscaliste.
+- Ce skill est un guide de raisonnement, pas un substitut à un conseiller fiscal pour les décisions importantes.
+- Les chiffres fournis sont indicatifs — seul l'avis d'imposition de la DGFIP fait foi.

--- a/fiscaliste/SKILL.md
+++ b/fiscaliste/SKILL.md
@@ -12,11 +12,11 @@ description: |
   les revenus fonciers, l'equity salarial, les crypto-actifs et le PER.
 
   Couvre le calcul de l'IR (barème progressif, quotient familial, décote, PAS, CEHR,
-  revenus exceptionnels), les revenus du capital (PFU vs barème, PEA, assurance-vie
-  rachats, dividendes, plus-values mobilières), les revenus fonciers (micro vs réel,
-  déficit, LMNP, SCI à l'IR), l'equity startup (RSU, BSPCE, stock-options, PEE/PERCO),
-  la fiscalité crypto (méthode PAMC, formulaire 2086), l'IFI, et les déductions (PER,
-  pension alimentaire).
+  revenus exceptionnels), la déclaration 2042 et ses annexes, les revenus du capital
+  (PFU vs barème, PEA, assurance-vie rachats, dividendes, plus-values mobilières), les
+  revenus fonciers (micro vs réel, déficit, LMNP, SCI à l'IR), l'equity startup (RSU,
+  BSPCE, stock-options, PEE/PERCO), la fiscalité crypto (méthode PAMC, formulaire 2086),
+  l'IFI, et les déductions (PER, pension alimentaire).
 
   Triggers: impôt sur le revenu, IR, déclaration 2042, quotient familial, barème, décote,
   PAS, PFU, flat tax, PEA, assurance-vie, LMNP, revenus fonciers, déficit foncier, SCI IR,
@@ -43,36 +43,109 @@ Face à une question fiscale :
 - Si l'utilisateur ne fournit pas de chiffres → expliquer la logique et identifier
   quelles valeurs il faut aller chercher.
 
-**Ne jamais inventer un barème.** Les chiffres LLM sont des ordres de grandeur. Toujours
-lire les données de `data/` et signaler l'année de référence. Pour toute année non
-couverte par les fichiers `data/`, renvoyer à impots.gouv.fr.
+**Ne jamais inventer un barème.** Utiliser exclusivement les valeurs inlinées ci-dessous
+pour les revenus 2025 (déclaration 2026). Pour toute autre année, renvoyer à impots.gouv.fr.
 
 ## Fraîcheur des Données
 
-**Vérifier `metadata.last_updated` dans le frontmatter.**
-
-Si > 6 mois depuis la dernière mise à jour :
+**Vérifier `metadata.last_updated` dans le frontmatter.** Si > 6 mois :
 
 ```
 ⚠️ SKILL POTENTIELLEMENT OBSOLÈTE
 Dernière MAJ: [date] — Vérifier les barèmes de la dernière loi de finances.
 ```
 
-**Valeurs à vérifier avant de citer un montant précis :**
-- Tranches du barème IR (revalorisées chaque LFI)
-- Plafond du gain QF par demi-part
-- Seuils et formule de la décote (célibataire / couple)
-- Plafond de déduction PER (indexé sur PASS de l'année)
-- Taux PFU (IR + prélèvements sociaux)
-- Abattements durée de détention (PV immo / mobilières)
-- Seuils IFI et barème
-- Plafond global des niches fiscales
+**Sources de vérification** : impots.gouv.fr, bofip.impots.gouv.fr, service-public.fr, legifrance.gouv.fr.
 
-**Sources de vérification :**
-- https://www.impots.gouv.fr (barèmes, formulaires, simulateurs)
-- https://bofip.impots.gouv.fr (doctrine fiscale)
-- https://www.service-public.fr (fiches pratiques)
-- https://www.legifrance.gouv.fr (CGI, lois de finances)
+## Valeurs de Référence — Revenus 2025 (déclaration 2026)
+
+### Barème IR (par part)
+
+| Tranche | Taux |
+|---------|------|
+| 0 € à 11 600 € | 0 % |
+| 11 600 € à 29 579 € | 11 % |
+| 29 579 € à 84 577 € | 30 % |
+| 84 577 € à 181 917 € | 41 % |
+| > 181 917 € | 45 % |
+
+*Tranches LFI 2026 (revenus 2025, indexation +0,9 %). Source : art. 197 CGI.*
+
+### Quotient familial
+
+- **Plafond du gain par demi-part supplémentaire : 1 807 €** (enfant à charge)
+- Parent isolé (case T) : plafond 4 273 € pour la première part liée à l'enfant
+- Veuf avec enfant à charge : plafond 4 273 €
+
+### Décote (plancher à 0)
+
+- **Célibataire** : si impôt brut < 1 982 € → décote = 897 − 0,4525 × impôt brut
+- **Couple** : si impôt brut < 3 277 € → décote = 1 483 − 0,4525 × impôt brut
+
+### Abattements
+
+| Revenu | Case 2042 | Abattement |
+|--------|-----------|------------|
+| Salaires | 1AJ/1BJ | 10 % (min 509 €, max 14 555 €) ou frais réels |
+| Pensions / retraites | 1AS/1BS | 10 % (min 450 €, max 4 446 €) par foyer |
+| **Chômage (ARE)** | 1AP/1BP | **Aucun** (piège classique : ne jamais mettre en 1AJ) |
+| Dividendes (option barème) | 2DC | 40 % |
+| Dividendes (PFU) | 2DC | Aucun |
+| Micro-BNC | 5TE | 34 % (plafond 77 700 €) |
+| Micro-foncier (nu) | 4BE | 30 % (plafond 15 000 €) |
+| Micro-BIC LMNP longue durée | 5ND | 50 % (plafond 77 700 €) |
+| Micro-BIC LMNP meublé tourisme non classé | 5ND | 30 % (plafond 15 000 €) |
+| Micro-BIC LMNP meublé tourisme classé | 5NG | 50 % (plafond 77 700 €) |
+
+### PFU et prélèvements sociaux
+
+- **PFU global : 30 %** (12,8 % IR + 17,2 % PS) pour les revenus 2025
+- **Prélèvements sociaux sur revenus du capital : 17,2 %** (revenus 2025)
+- **CSG déductible : 6,8 %** — **uniquement si option barème** sur revenus du capital N-1
+- **Option barème globale** : concerne TOUS les revenus du capital de l'année
+- LFSS 2026 a porté le taux PS à 18,6 % à compter du 1er janvier 2026 — ne s'applique PAS aux revenus 2025 déclarés en 2026 (encaissement antérieur).
+
+### PER (versements 2025)
+
+- **Plancher de déduction : 4 710 €** (10 % × PASS 2025 = 47 100 €)
+- **Plafond de déduction : 37 680 €** (10 % × 8 × PASS 2025)
+- **Plafond personnalisé : 10 %** des revenus professionnels N-1 (après abattement 10 %)
+- **Report** : plafonds non utilisés des 3 années précédentes mobilisables (FIFO ancien en premier)
+- **Mutualisation couple** : case à cocher sur 2042
+
+### IFI
+
+- **Seuil d'assujettissement : 1 300 000 €** (patrimoine immobilier net au 1er janvier)
+- **Abattement résidence principale : 30 %** sur la valeur vénale
+- **Barème** : 0 % (0-800 k€), 0,5 % (800 k€-1,3 M€), 0,7 % (1,3-2,57 M€), 1 % (2,57-5 M€), 1,25 % (5-10 M€), 1,5 % (>10 M€)
+- **Décote d'entrée** (1,3-1,4 M€) : 17 500 − 1,25 % × patrimoine net
+- **Plafonnement 75 %** : IR + IFI + PS ≤ 75 % des revenus N-1
+
+### CEHR (Contribution Exceptionnelle Hauts Revenus)
+
+Base : RFR, pas RNI. S'ajoute à l'IR net.
+
+| Situation | Tranche 3 % | Tranche 4 % |
+|-----------|-------------|-------------|
+| Célibataire | 250 000 € — 500 000 € | > 500 000 € |
+| Couple | 500 000 € — 1 000 000 € | > 1 000 000 € |
+
+### Crypto (PAMC)
+
+- **Exonération totale** si cessions annuelles ≤ **305 €** (seuil en montant brut, pas en PV)
+- Au-delà : imposition PFU 30 % sur TOUTE la PV (pas seulement l'excédent)
+- Formulaire 2086 obligatoire dès 1 € de cession > 305 €
+
+### Assurance-vie — rachats après 8 ans
+
+- **Abattement annuel** : 4 600 € (célibataire) / **9 200 € (couple)** — sur la quote-part de gains imposable
+- **Seuil 150 000 €** de versements nets (tous contrats AV du foyer) : au-delà, PFU 30 % sur la fraction
+
+### Fiches précises
+
+Pour les détails (exemples chiffrés, conditions, cas particuliers), voir les fichiers
+`references/*.md`. Les fichiers `data/*.json` contiennent les mêmes valeurs en format
+machine.
 
 ## Principes
 
@@ -83,39 +156,13 @@ Dernière MAJ: [date] — Vérifier les barèmes de la dernière loi de finances
 5. **Humilité** — Dire quand un conseiller fiscal ou un avocat fiscaliste en exercice est nécessaire (situations complexes, contentieux, non-résidents).
 6. **Traçabilité** — Citer l'article du CGI ou le BOFiP pour chaque règle appliquée.
 
-## Outil de Calcul IR Officiel (optionnel)
-
-Si le serveur MCP [`irpp-mcp`](https://github.com/erwanpaccard/irpp-mcp) est installé et
-que l'outil `irpp_calculer_ir` est disponible, l'utiliser pour toute simulation IR — il
-exécute le code source officiel DGFIP (Mlang) et donne des chiffres certifiés plutôt que
-des estimations.
-
-**Quand l'utiliser :**
-- Simulation d'impôt pour une situation concrète (salaires, retraite, PER, dividendes…)
-- Comparaison de scénarios (avec/sans PER, avec/sans enfants, salarié vs freelance)
-- Validation d'une estimation manuelle
-
-**Limites à signaler si utilisé :**
-- Revenus 2023 uniquement (déclaration 2024) — pas les barèmes de l'année en cours.
-- Binaire Linux x86-64 / WSL seulement.
-- Micro-entrepreneur BNC (case 5TE) bugué : workaround = passer les recettes × 66 % en BNC régime normal (5QC).
-
-**Si l'outil n'est pas disponible :** calculer manuellement à partir des données de
-`data/bareme-ir-2025.json` en suivant la séquence documentée dans
-[references/ir-mecanisme.md](references/ir-mecanisme.md). Signaler que les barèmes sont
-à vérifier sur impots.gouv.fr.
-
-**Ce skill n'a aucune dépendance obligatoire** — il fonctionne en totale autonomie à
-partir des fichiers `data/` et `references/`.
-
 ## Workflow Obligatoire
 
 ### 1. Identifier l'Opération
 
-Déterminer le domaine et le workflow applicable :
-
 | Domaine | Référence |
 |---------|-----------|
+| **Déclaration annuelle 2042 (workflow complet)** | [references/declaration-workflow.md](references/declaration-workflow.md) |
 | Calcul / simulation IR | [references/ir-mecanisme.md](references/ir-mecanisme.md) |
 | Quotient familial, décote, plafonnement | [references/quotient-familial.md](references/quotient-familial.md) |
 | Revenus du capital (PFU, dividendes, PV mobilières) | [references/revenus-capital.md](references/revenus-capital.md) |
@@ -137,55 +184,17 @@ Déterminer le domaine et le workflow applicable :
 Si un fichier `foyer.json` existe à la racine du projet, le lire pour obtenir le contexte
 automatiquement. Voir [foyer.example.json](foyer.example.json) pour la structure.
 
-**Informations requises selon le sujet :**
-
-**Pour une simulation IR :**
-- Situation de famille (célibataire, marié, pacsé, divorcé, veuf)
-- Nombre d'enfants à charge (et en résidence alternée)
-- Année de naissance des déclarants
-- Revenus par catégorie (salaires, pensions, BNC, foncier, dividendes, PV…)
-- Options en cours (PFU vs barème, régime foncier…)
-
-**Pour un arbitrage PER :**
-- TMI actuel et TMI estimé à la retraite
-- Revenus professionnels de l'année (pour le plafond)
-- Versements PER des 3 années précédentes (report de plafond)
-- Horizon et objectif (épargne vs défiscalisation pure)
-
-**Pour un arbitrage PFU vs barème :**
-- TMI marginal actuel du foyer
-- Ensemble des revenus du capital de l'année (l'option est globale)
-- Présence de dividendes (abattement 40 % si barème)
-
-**Pour un LMNP au réel :**
-- Valeur d'achat du bien (hors terrain)
-- Valeur du mobilier
-- Recettes locatives annuelles
-- Charges (intérêts d'emprunt, taxe foncière, assurance, gestion, CFE)
-- Statut LMP vs LMNP (seuil 23 000 € ET > 50 % des revenus)
-
 **Si une information critique manque, la demander explicitement.** Ne pas faire de suppositions.
 
-### 3. Calculer
+### 3. Calculer — Séquence IR Standard
 
-Utiliser les données de `data/` :
-
-| Fichier | Contenu |
-|---------|---------|
-| `data/bareme-ir-2025.json` | Tranches IR, plafond QF, décote, abattement 10 %, PFU, PS |
-| `data/per-plafonds.json` | Plafond / plancher PER, PASS, report |
-| `data/ifi-bareme.json` | Tranches IFI, seuil d'assujettissement |
-| `data/plus-values-immo-abattements.json` | Abattements durée de détention IR et PS |
-| `data/equity-salarial.json` | Barèmes RSU, BSPCE, stock-options, contribution salariale |
-
-**Séquence IR standard :**
 1. Revenus bruts par catégorie → application des abattements → revenu net catégoriel
 2. Somme des revenus nets catégoriels → revenu brut global
 3. Déductions (PER, pension alimentaire, CSG déductible N-1) → RNI
 4. RNI ÷ nombre de parts → quotient
 5. Barème progressif sur le quotient → impôt par part
 6. × nombre de parts → impôt brut
-7. Plafonnement du gain QF (si enfants à charge)
+7. Plafonnement du gain QF (si enfants à charge) — **toujours comparer gain réel vs gain max (N × 1 802 €)**
 8. Décote (si impôt brut < seuil)
 9. Réductions d'impôt (Pinel, dons, FCPI…) → impôt après réductions
 10. Crédits d'impôt (garde d'enfant, emploi à domicile) → impôt net final
@@ -201,6 +210,59 @@ Format de sortie structuré :
 - **Résultat** (impôt net, PS, CEHR, total)
 - **Checklist à vérifier sur impots.gouv.fr** pour l'année concernée
 - **Pistes d'optimisation** (si pertinent) avec chiffrage comparatif
+
+## Rappels Obligatoires par Sujet
+
+Ces points sont systématiquement vérifiés par les utilisateurs exigeants — ne jamais les omettre.
+
+### Pour toute simulation IR
+
+- Vérifier le plafonnement QF : calculer l'impôt avec et sans les enfants, puis comparer
+  le gain réel au plafond théorique (nb_demi_parts × 1 807 €).
+- Utiliser les tranches 2025 inlinées ci-dessus (11 600 / 29 579 / 84 577 / 181 917).
+- Tester la décote (seuil 1 982 € célib / 3 277 € couple) même si non applicable.
+
+### Pour un PER
+
+- Rappeler que c'est un **report d'imposition**, pas une exonération.
+- TMI sortie < TMI entrée = gain ; TMI sortie ≥ TMI entrée = neutre ou perte.
+- **Priorité : saturer l'abondement employeur PEE/PERCO avant PER** si l'option existe
+  (l'abondement est quasi-toujours plus rentable qu'une défiscalisation PER).
+
+### Pour des RSU
+
+- Gain d'acquisition = **SALAIRE** (case 1TT), abattement 10 % applicable sur le total salaires.
+- PV de cession ultérieure = **distincte**, imposée au PFU 30 % au moment de la revente.
+- Toujours distinguer ces deux phases dans la réponse.
+- Mentionner la contribution salariale 10 % si plan qualifiant.
+- CSG 9,7 % sur le gain d'acquisition RSU.
+- Envisager le quotient pour revenus exceptionnels si le vesting est massif vs salaire habituel.
+
+### Pour un LMNP
+
+- Micro-BIC **longue durée** : abattement **50 %**, plafond **77 700 €**.
+- Micro-BIC **meublé tourisme non classé** : abattement **30 %**, plafond 15 000 € (Loi Le Meur).
+- Micro-BIC **meublé tourisme classé** : abattement 50 %, plafond 77 700 €.
+- Seuil LMP : recettes > **23 000 €** ET > 50 % des autres revenus pro du foyer.
+- Déficit LMNP au réel : **non imputable sur le revenu global** (reportable 10 ans sur BIC non pro).
+
+### Pour un arbitrage PFU vs barème
+
+- Chiffrer les deux scénarios systématiquement.
+- Rappeler que l'option barème est **globale** (tous revenus du capital) et **irrévocable pour l'année**.
+- À TMI ≤ 11 % : barème souvent meilleur (abattement 40 % dividendes + CSG déductible 6,8 %).
+- À TMI ≥ 30 % : PFU souvent meilleur.
+
+### Pour l'IFI
+
+- Appliquer l'abattement 30 % sur la résidence principale avant sommation.
+- Tester la décote d'entrée 1,3-1,4 M€.
+- Vérifier le plafonnement 75 % (IR + IFI + PS ≤ 75 % des revenus N-1).
+
+### Pour les crypto
+
+- Rappeler l'exonération si cessions annuelles ≤ 305 € (montant brut, pas la PV).
+- Au-delà : imposition sur TOUT (pas seulement l'excédent).
 
 ## Limites à Signaler
 

--- a/fiscaliste/data/bareme-ir-2025.json
+++ b/fiscaliste/data/bareme-ir-2025.json
@@ -1,0 +1,66 @@
+{
+  "_meta": {
+    "revenus": 2025,
+    "declaration": 2026,
+    "lfi": "Loi n°2026-103 du 19 février 2026",
+    "indexation_bareme_ir": "+0.9%",
+    "sources": [
+      "https://bofip.impots.gouv.fr/bofip/14954-PGP.html/ACTU-2026-00022",
+      "https://www.service-public.gouv.fr/particuliers/actualites/A18045"
+    ],
+    "a_mettre_a_jour": "Chaque année après publication de la LFI (décembre-janvier). Remplacer ce fichier par bareme-ir-XXXX.json."
+  },
+
+  "bareme_ir": {
+    "description": "Tranches appliquées par part de quotient familial (revenus 2025, déclaration 2026)",
+    "tranches": [
+      { "jusqu_a": 11600, "taux": 0.00 },
+      { "de": 11600, "a": 29579, "taux": 0.11 },
+      { "de": 29579, "a": 84577, "taux": 0.30 },
+      { "de": 84577, "a": 181917, "taux": 0.41 },
+      { "au_dela": 181917, "taux": 0.45 }
+    ]
+  },
+
+  "quotient_familial": {
+    "plafond_gain_par_demi_part": 1807,
+    "description": "Avantage fiscal maximum par demi-part supplémentaire liée aux enfants à charge. Au-delà du seuil de revenu, le gain QF stagne."
+  },
+
+  "decote": {
+    "seuil_celibataire": 1982,
+    "seuil_couple": 3277,
+    "plafond_celibataire": 897,
+    "plafond_couple": 1483,
+    "formule_celibataire": "décote = 897 - (0.4525 × impôt_brut) si impôt_brut < 1982",
+    "formule_couple": "décote = 1483 - (0.4525 × impôt_brut) si impôt_brut < 3277",
+    "note": "La décote ne peut pas rendre l'impôt négatif. Source : BOI-IR-LIQ-20-20-30."
+  },
+
+  "abattement_salaires_10pct": {
+    "taux": 0.10,
+    "minimum": 509,
+    "maximum": 14555,
+    "description": "Abattement forfaitaire automatique sur traitements et salaires (case 1AJ). ATTENTION terminologie : 1AJ = salaire net imposable du bulletin, AVANT cet abattement. Le RNI = 1AJ × 0.9 (dans la plage standard)."
+  },
+
+  "abattement_pensions_10pct": {
+    "taux": 0.10,
+    "minimum": 450,
+    "maximum": 4446,
+    "description": "Abattement sur pensions et retraites (case 1AS). Plafond par foyer."
+  },
+
+  "cehr": {
+    "description": "Contribution Exceptionnelle sur les Hauts Revenus — basée sur le RFR, pas le RNI. S'ajoute à l'IR net.",
+    "seuils_celibataire": [
+      { "de": 250000, "a": 500000, "taux": 0.03 },
+      { "au_dela": 500000, "taux": 0.04 }
+    ],
+    "seuils_couple": [
+      { "de": 500000, "a": 1000000, "taux": 0.03 },
+      { "au_dela": 1000000, "taux": 0.04 }
+    ],
+    "note": "Valeurs de référence — vérifier en cas de LFI modifiant le dispositif."
+  }
+}

--- a/fiscaliste/data/equity-salarial.json
+++ b/fiscaliste/data/equity-salarial.json
@@ -1,0 +1,96 @@
+{
+  "_meta": {
+    "revenus": 2025,
+    "declaration": 2026,
+    "sources": [
+      "BOI-RSA-ES (actionnariat salarié)",
+      "BOI-RPPM-PVBMI (BSPCE)"
+    ]
+  },
+
+  "rsu": {
+    "description": "Restricted Stock Units — attributions gratuites d'actions",
+    "gain_acquisition": {
+      "definition": "Valeur de l'action à la date d'acquisition (vesting)",
+      "imposition": "Traitements et salaires, au barème progressif, case 1TT ou 1UT",
+      "cotisations_sociales": "Oui : CSG/CRDS 9.7% sur les revenus d'activité + contribution salariale 10% (plafond d'attribution à vérifier)",
+      "note_plans_qualifiants": "Plans qualifiants (loi Macron) : régime de faveur pour la fraction ≤ plafond annuel (PASS/2 puis PASS selon régime) — imposition comme PV mobilière au PFU + abattement 50% possible"
+    },
+    "plus_value_cession": {
+      "definition": "Valeur cession − valeur vesting",
+      "imposition": "PFU 30% (ou barème sur option)",
+      "note": "Distincte du gain d'acquisition. Seulement si la cession se fait après le vesting."
+    },
+    "piege_classique": "Traiter le gain RSU comme une PV mobilière classique — erreur majeure : il est d'abord soumis à cotisations sociales et IR comme du salaire."
+  },
+
+  "stock_options": {
+    "description": "Options de souscription ou d'achat d'actions",
+    "rabais_excedentaire": {
+      "definition": "Différence entre prix de marché à l'attribution et prix d'exercice, au-delà de 5%",
+      "imposition": "Salaire à l'acquisition"
+    },
+    "gain_levee": {
+      "plans_pre_2012": "Régime spécifique (barème de faveur selon durée détention)",
+      "plans_post_2012": "Salaire avec régime spécifique — contribution salariale 10%",
+      "note": "Consulter le plan pour déterminer le régime applicable"
+    },
+    "contribution_salariale": 0.10,
+    "note_contribution": "Taux 10% sur les gains d'acquisition des plans qualifiants"
+  },
+
+  "bspce": {
+    "description": "Bons de Souscription de Parts de Créateur d'Entreprise — réservés aux startups éligibles",
+    "difference_cle_rsu": "Pas de gain d'acquisition imposable comme salaire. Imposition uniquement à la cession.",
+    "gain_cession": {
+      "definition": "Prix de vente des actions − prix d'exercice des BSPCE",
+      "anciennete_3_ans_plus": {
+        "taux": 0.30,
+        "detail": "12.8% IR + 17.2% PS (équivalent PFU)"
+      },
+      "anciennete_moins_3_ans": {
+        "taux": 0.50,
+        "detail": "30% IR + 20% PS — pénalité forte si départ précoce"
+      },
+      "note_anciennete": "Anciennete du salarié dans la société à la date de cession"
+    },
+    "conditions_eligibilite_societe": [
+      "SA ou SAS française",
+      "Immatriculée depuis moins de 15 ans",
+      "Non cotée OU cotée sur compartiment dédié aux PME",
+      "Soumise à l'IS",
+      "Capital détenu à 25% minimum par des personnes physiques",
+      "Non issue d'une restructuration (fusion, scission, reprise d'activité)"
+    ],
+    "requalification_salaire": "Si conditions non remplies : requalification en salaires → imposition barème + cotisations sociales, traitement BEAUCOUP plus défavorable"
+  },
+
+  "pee_perco": {
+    "description": "Plans d'Épargne Entreprise et Plans d'Épargne Retraite Collective — enveloppes collectives",
+    "pee": {
+      "abondement_employeur": "Exonéré IR et PS dans les plafonds — AVANTAGE MAJEUR vs versement direct",
+      "plafond_abondement_pee_2025": 3709,
+      "plafond_base": "8% × PASS par bénéficiaire (à vérifier annuellement)",
+      "blocage": "5 ans sauf cas de déblocage anticipé (mariage, naissance 3e enfant, achat RP, divorce avec enfant à charge, fin contrat travail, surendettement, invalidité, décès, violences conjugales)",
+      "sortie": "Après 5 ans : exonération IR, PS sur les gains uniquement",
+      "dividendes_reinvestis": "Exonérés IR tant qu'ils restent dans l'enveloppe"
+    },
+    "perco_pero": {
+      "description": "Équivalent PER collectif",
+      "sortie_retraite": "Rente ou capital, même fiscalité que PER individuel",
+      "abondement_employeur": "Exonéré IR et PS dans les plafonds (plafond distinct du PEE)",
+      "plafond_abondement_perco_2025": 7418,
+      "plafond_base": "16% × PASS par bénéficiaire"
+    },
+    "arbitrage_vs_per_individuel": "PEE / PERCO = abondement employeur (levier immédiat +30% à +300%). PER individuel = déduction du RNI. À combiner : abonder d'abord PEE/PERCO pour capter l'abondement, puis PER individuel."
+  },
+
+  "quotient_revenus_exceptionnels": {
+    "description": "Lissage fiscal pour revenus ponctuels exceptionnels (vesting massif, prime exceptionnelle, indemnité départ)",
+    "mecanisme": "Revenu exceptionnel divisé par coefficient (généralement 4), ajouté au revenu ordinaire, impôt supplémentaire multiplié par le même coefficient",
+    "coefficient_defaut": 4,
+    "avantage_utile_si": "Le revenu exceptionnel ferait franchir une/plusieurs tranches marginales",
+    "inutile_si": "Foyer déjà au TMI maximum (45%) — coefficient n'apporte rien car taux marginal identique quelle que soit la division",
+    "note": "À mentionner systématiquement en cas de vesting RSU important, cession d'entreprise, ou entrée de revenus très supérieure à l'ordinaire"
+  }
+}

--- a/fiscaliste/data/ifi-bareme.json
+++ b/fiscaliste/data/ifi-bareme.json
@@ -1,0 +1,54 @@
+{
+  "_meta": {
+    "revenus": 2025,
+    "declaration": 2026,
+    "source": "BOI-PAT-IFI"
+  },
+
+  "ifi": {
+    "description": "Impôt sur la Fortune Immobilière — dû si patrimoine immobilier net > seuil d'assujettissement au 1er janvier",
+    "seuil_assujettissement": 1300000,
+    "bareme_commence_a": 800000,
+    "note_seuil": "Une fois dépassé 1 300 000 €, le barème s'applique à partir de 800 000 € (pas à partir de 1 300 000 €)",
+
+    "tranches": [
+      { "de": 0, "a": 800000, "taux": 0.00 },
+      { "de": 800000, "a": 1300000, "taux": 0.005 },
+      { "de": 1300000, "a": 2570000, "taux": 0.007 },
+      { "de": 2570000, "a": 5000000, "taux": 0.01 },
+      { "de": 5000000, "a": 10000000, "taux": 0.0125 },
+      { "au_dela": 10000000, "taux": 0.015 }
+    ],
+
+    "decote": {
+      "plage": "Entre 1 300 000 € et 1 400 000 €",
+      "formule": "17 500 € − (1.25% × valeur_patrimoine_net)",
+      "description": "Mécanisme de lissage à l'entrée du barème"
+    }
+  },
+
+  "abattements_exonerations": {
+    "residence_principale": 0.30,
+    "residence_principale_note": "Abattement de 30% sur la valeur vénale de la résidence principale",
+    "biens_professionnels": "Exonérés s'ils constituent l'outil de travail (conditions strictes : fonction de direction, rémunération >50% revenus pro)",
+    "bois_forets_terres_agricoles": "Exonération partielle sous engagement (25% imposable avec engagement de 30 ans)",
+    "lmp": "Les biens LMP peuvent être exonérés comme biens professionnels sous conditions de recettes et revenus",
+    "location_longue_duree_bail_rural": "Exonération partielle sous conditions"
+  },
+
+  "passif_deductible": {
+    "emprunts_immobiliers": "Capital restant dû au 1er janvier",
+    "emprunts_travaux": "Dettes liées à des travaux sur immeubles taxables",
+    "impots_afferents_immobilier": "Taxe foncière, droits de succession/donation, IFI N-1",
+    "non_deductible": [
+      "Emprunts in fine → amortissement fictif appliqué (déduction limitée)",
+      "Dettes personnelles non liées à l'immobilier",
+      "Emprunts familiaux sans formalisme (article 885 T)"
+    ]
+  },
+
+  "plafonnement": {
+    "description": "Plafonnement IR + IFI + PS à 75% des revenus de l'année N-1",
+    "note": "Si le total IR + IFI + PS dépasse 75% des revenus, l'IFI est réduit de l'excédent"
+  }
+}

--- a/fiscaliste/data/niches-fiscales.json
+++ b/fiscaliste/data/niches-fiscales.json
@@ -1,0 +1,80 @@
+{
+  "_meta": {
+    "revenus": 2025,
+    "declaration": 2026,
+    "source": "BOI-IR-LIQ-20-20-10"
+  },
+
+  "plafonnement_global": {
+    "description": "Cap annuel sur l'ensemble des avantages fiscaux (réductions et crédits) issus de dispositifs de défiscalisation. Au-delà du plafond, l'excédent est perdu (pas reportable).",
+    "plafond_metropole": 10000,
+    "plafond_investissements_outre_mer": 18000,
+    "note": "Le plafond s'applique APRÈS calcul de toutes les réductions, pas avant. Piège classique : cumuler Pinel + FCPI + outre-mer sans vérifier le plafond global."
+  },
+
+  "dispositifs_dans_plafond": {
+    "note": "Dispositifs entrant dans le plafond global de 10 000 €",
+    "liste": [
+      "Pinel (réduction d'impôt pour investissement locatif)",
+      "Denormandie",
+      "Loc'Avantages",
+      "FCPI / FIP (souscription)",
+      "Malraux (dans certaines conditions)",
+      "Monuments historiques (partiellement)",
+      "Investissement forestier",
+      "Investissement corse"
+    ]
+  },
+
+  "dispositifs_hors_plafond": {
+    "note": "Dispositifs exclus du plafond global — à vérifier systématiquement",
+    "liste": [
+      "Dons aux associations (réduction 66% ou 75% selon type)",
+      "Emploi à domicile (crédit d'impôt 50%)",
+      "Garde d'enfant hors domicile (crédit d'impôt 50%)",
+      "Girardin industriel outre-mer (sous conditions)",
+      "Cotisations syndicales (crédit d'impôt 66%)",
+      "Investissement outre-mer (certaines catégories)"
+    ]
+  },
+
+  "exemples_avantages_classiques": {
+    "dons_associations": {
+      "taux_reduction_standard": 0.66,
+      "taux_reduction_dons_aide_personnes": 0.75,
+      "plafond_assiette_standard": "20% du revenu imposable",
+      "plafond_dons_aide_personnes": 1000,
+      "note_aide_personnes": "Plafond majoré pour dons aux associations venant en aide aux personnes en difficulté (Restos du Cœur, Secours Populaire, etc.)"
+    },
+    "emploi_a_domicile": {
+      "taux_credit": 0.50,
+      "plafond_depenses_general": 12000,
+      "majoration_enfants": "+1 500 € par enfant à charge (plafond max 15 000 €)",
+      "note": "Crédit d'impôt — remboursé même si impôt nul"
+    },
+    "garde_enfant_exterieur": {
+      "taux_credit": 0.50,
+      "plafond_depenses_par_enfant": 3500,
+      "age_limite": "Enfant de moins de 6 ans au 1er janvier"
+    }
+  },
+
+  "distinction_mecanismes": {
+    "description": "Distinction fondamentale entre déduction, réduction et crédit",
+    "deduction": {
+      "sapplique_sur": "Revenu imposable (avant calcul de l'impôt)",
+      "remboursable_si_excedent": "Non applicable",
+      "exemples": ["PER", "Pension alimentaire", "CSG déductible"]
+    },
+    "reduction": {
+      "sapplique_sur": "Impôt calculé",
+      "remboursable_si_excedent": "Non — impôt minimum = 0",
+      "exemples": ["Pinel", "Dons", "Malraux", "FCPI"]
+    },
+    "credit": {
+      "sapplique_sur": "Impôt calculé",
+      "remboursable_si_excedent": "Oui — remboursé si > impôt dû",
+      "exemples": ["Emploi à domicile", "Garde d'enfant", "Cotisations syndicales"]
+    }
+  }
+}

--- a/fiscaliste/data/pea-assurance-vie.json
+++ b/fiscaliste/data/pea-assurance-vie.json
@@ -1,0 +1,72 @@
+{
+  "_meta": {
+    "revenus": 2025,
+    "declaration": 2026,
+    "sources": [
+      "BOI-RPPM-RCM-40-50 (PEA)",
+      "BOI-RPPM-RCM-20-10-20-50 (AV)"
+    ]
+  },
+
+  "pea_classique": {
+    "description": "Plan d'Épargne en Actions — enveloppe fiscale actions européennes",
+    "plafond_versements": 150000,
+    "plafond_enfant_majeur_rattache": 20000,
+    "note_pea_pme": "PEA-PME plafond séparé (225 000 €) et plafond combiné PEA + PEA-PME à 225 000 €",
+
+    "avant_5_ans": {
+      "retrait": "Tout retrait entraîne clôture du plan",
+      "imposition_gains": "PFU 30% (ou barème sur option)",
+      "exceptions_cloture_sans_penalite": [
+        "Licenciement, invalidité, mise à la retraite",
+        "Création/reprise d'entreprise (réinvestissement dans les 3 mois)"
+      ]
+    },
+
+    "apres_5_ans": {
+      "retrait": "Libre sans clôture",
+      "imposition_ir": "EXONÉRATION TOTALE d'IR sur les gains",
+      "ps_dus": "Prélèvements sociaux 17.2% dus sur les gains à chaque retrait",
+      "note_historique_taux_ps": "Les gains acquis avant certaines dates peuvent bénéficier de taux PS historiques plus faibles (taux par couches)"
+    },
+
+    "comparaison_av": {
+      "pea_avantage": "Fiscalité plus légère après 5 ans (pas d'IR), bon pour performance actions européennes",
+      "av_avantage": "Plus flexible (fonds euros, UC variées), abattement annuel sur gains à la sortie après 8 ans, avantage successoral",
+      "strategie_cumul": "PEA pour performance actions européennes, AV pour diversification et transmission — les deux enveloppes sont complémentaires"
+    }
+  },
+
+  "assurance_vie_rachats": {
+    "description": "Fiscalité des rachats de vivant (distincte de la transmission — voir skill notaire)",
+
+    "principe_proportionnalite": {
+      "formule": "quote_part_gains_imposable = (gains_totaux / valeur_totale_contrat) × montant_racheté",
+      "piege": "Un rachat partiel NE sort PAS d'abord le capital non imposable. La règle de proportionnalité s'applique toujours."
+    },
+
+    "abattement_annuel_apres_8_ans": {
+      "celibataire_veuf_divorce": 4600,
+      "couple_imposition_commune": 9200,
+      "description": "Abattement sur la quote-part de gains dans le rachat. S'applique UNIQUEMENT après 8 ans de détention du contrat (pas des versements).",
+      "renouvelable": "Chaque année civile (pas dans les 12 mois glissants)"
+    },
+
+    "taux_selon_versements": {
+      "versements_avant_27_sept_2017": {
+        "description": "Taux dégressif selon ancienneté du contrat (PFL optionnel ou barème)",
+        "moins_4_ans": "PFL 35% OU barème",
+        "4_a_8_ans": "PFL 15% OU barème",
+        "8_ans_plus": "PFL 7.5% OU barème (après abattement)"
+      },
+      "versements_apres_27_sept_2017": {
+        "description": "PFU sur les gains, avec modulation selon encours et ancienneté",
+        "contrat_moins_8_ans": "PFU 30% (12.8% IR + 17.2% PS)",
+        "contrat_plus_8_ans_encours_moins_150k": "PFU 24.7% (7.5% IR + 17.2% PS) après abattement annuel",
+        "contrat_plus_8_ans_encours_plus_150k": "PFU 30% (12.8% IR + 17.2% PS) pour la fraction au-delà de 150 000 € de versements nets"
+      }
+    },
+
+    "option_bareme_avantageuse_si": "TMI ≤ 11% — le barème peut être meilleur que le PFU après 8 ans (car abattement annuel + taux IR faible)"
+  }
+}

--- a/fiscaliste/data/per-plafonds.json
+++ b/fiscaliste/data/per-plafonds.json
@@ -1,0 +1,41 @@
+{
+  "_meta": {
+    "revenus": 2025,
+    "declaration": 2026,
+    "pass_2024": 46368,
+    "pass_2025": 47100,
+    "pass_2026": 48060,
+    "sources": [
+      "https://www.urssaf.fr/accueil/actualites/plafond-annuel-securite-sociale.html",
+      "BOI-IR-BASE-20-50-20"
+    ]
+  },
+
+  "per_individuel": {
+    "description": "Plafond de déduction PER pour les versements 2025 (déclaration 2026)",
+    "calcul": "10% des revenus professionnels nets (salaires après abattement 10%, BNC, BIC) de l'année N-1",
+    "plancher_euros": 4710,
+    "plancher_base": "10% × PASS 2025 (47 100 €) — garanti même sans revenus",
+    "plafond_absolu_euros": 37680,
+    "plafond_absolu_base": "10% × 8 × PASS 2025",
+    "report": {
+      "description": "Plafonds non utilisés des 3 années précédentes mobilisables",
+      "ordre": "Utiliser le plafond N en premier, puis les plafonds N-3, N-2, N-1 (ordre FIFO le plus ancien en premier)"
+    },
+    "mutualisation_couple": "Les époux/pacsés soumis à imposition commune peuvent mutualiser leurs plafonds (case à cocher sur 2042)"
+  },
+
+  "sortie_per": {
+    "versements_deduits_entree": "Imposés à la sortie comme revenu (pension ou capital selon choix)",
+    "versements_non_deduits": "Sortie partiellement exonérée — seuls les gains sont imposés (PFU)",
+    "cas_sortie_anticipee": "Autorisée pour : achat résidence principale, accidents de la vie (décès conjoint, invalidité, surendettement, fin droits chômage, cessation activité non salariée)"
+  },
+
+  "arbitrage_per": {
+    "description": "Le PER est un report d'imposition, pas une exonération. L'avantage net dépend du différentiel TMI entrée / sortie.",
+    "gagnant": "TMI entrée > TMI sortie → gain net",
+    "perdant": "TMI entrée < TMI sortie → perte nette (rare mais possible si carrière ascendante ou sortie en capital massif)",
+    "neutre": "TMI égaux → gain = seulement la capitalisation sur l'économie d'impôt (effet levier)",
+    "piege_sortie_capital": "Sortie en capital = imposition du capital versé + imposition séparée des gains au PFU. Bien distinguer versements (barème) et gains (PFU)."
+  }
+}

--- a/fiscaliste/data/pfu-prelevements-sociaux.json
+++ b/fiscaliste/data/pfu-prelevements-sociaux.json
@@ -1,0 +1,44 @@
+{
+  "_meta": {
+    "revenus": 2025,
+    "declaration": 2026,
+    "sources": [
+      "LFSS n°2025-1403 du 30 décembre 2025 — hausse PS de 17.2% à 18.6% au 1er janvier 2026",
+      "https://bofip.impots.gouv.fr/bofip/"
+    ]
+  },
+
+  "pfu": {
+    "description": "Prélèvement Forfaitaire Unique (flat tax) sur les revenus du capital. Taux global comprenant IR + PS.",
+    "taux_global": 0.314,
+    "detail_ir": 0.128,
+    "detail_ps": 0.186,
+    "exceptions_taux_172": [
+      "AV et contrats de capitalisation anciens",
+      "CEL/PEL ouverts avant le 31/12/2017",
+      "PEP"
+    ]
+  },
+
+  "prelevements_sociaux": {
+    "description": "CSG + CRDS + prélèvement de solidarité sur les revenus du capital",
+    "taux_revenus_capital": 0.186,
+    "taux_exceptions": 0.172,
+    "dont_csg_deductible_si_bareme": 0.068,
+    "note_csg": "La CSG déductible (6.8%) ne s'applique QUE si option barème progressif. Zéro déductible sous PFU. Elle s'impute en N+1 sur le RNI. Fraction à vérifier suite à la hausse LFSS 2026.",
+    "taux_plus_values_immo": 0.172
+  },
+
+  "dividendes_option_bareme": {
+    "abattement": 0.40,
+    "condition": "Uniquement si option barème progressif globale. Sous PFU : zéro abattement.",
+    "description": "Abattement sur dividendes avant imposition au barème. Option globale : concerne TOUS les revenus du capital de l'année."
+  },
+
+  "arbitrage_pfu_vs_bareme": {
+    "description": "Règle d'orientation rapide — à affiner selon composition des revenus",
+    "tmi_faible_bareme_avantageux": "TMI 0% ou 11%, le barème est presque toujours meilleur (tranche basse + abattement 40% sur dividendes + CSG déductible)",
+    "tmi_eleve_pfu_avantageux": "TMI 30%+, le PFU à 30% (12.8% IR + 17.2% PS) est souvent meilleur pour intérêts et plus-values. Pour dividendes : arbitrage à faire (abattement 40% peut compenser)",
+    "rappel_option_globale": "L'option barème est globale et irrévocable pour l'année — engage TOUS les revenus du capital"
+  }
+}

--- a/fiscaliste/data/pfu-prelevements-sociaux.json
+++ b/fiscaliste/data/pfu-prelevements-sociaux.json
@@ -3,29 +3,24 @@
     "revenus": 2025,
     "declaration": 2026,
     "sources": [
-      "LFSS n°2025-1403 du 30 décembre 2025 — hausse PS de 17.2% à 18.6% au 1er janvier 2026",
-      "https://bofip.impots.gouv.fr/bofip/"
+      "https://bofip.impots.gouv.fr/",
+      "LFSS 2026 (portant le taux PS à 18.6% à compter du 1er janvier 2026, ne s'applique PAS aux revenus 2025)"
     ]
   },
 
   "pfu": {
-    "description": "Prélèvement Forfaitaire Unique (flat tax) sur les revenus du capital. Taux global comprenant IR + PS.",
-    "taux_global": 0.314,
+    "description": "Prélèvement Forfaitaire Unique (flat tax) sur les revenus du capital 2025. Taux global comprenant IR + PS.",
+    "taux_global": 0.30,
     "detail_ir": 0.128,
-    "detail_ps": 0.186,
-    "exceptions_taux_172": [
-      "AV et contrats de capitalisation anciens",
-      "CEL/PEL ouverts avant le 31/12/2017",
-      "PEP"
-    ]
+    "detail_ps": 0.172,
+    "note_lfss_2026": "LFSS 2026 a relevé le taux global PS de 17.2% à 18.6% à compter du 1er janvier 2026. N'impacte que les revenus perçus à partir de 2026. Les revenus 2025 restent à 17.2%."
   },
 
   "prelevements_sociaux": {
-    "description": "CSG + CRDS + prélèvement de solidarité sur les revenus du capital",
-    "taux_revenus_capital": 0.186,
-    "taux_exceptions": 0.172,
+    "description": "CSG + CRDS + prélèvement de solidarité sur les revenus du capital (revenus 2025)",
+    "taux_revenus_capital": 0.172,
     "dont_csg_deductible_si_bareme": 0.068,
-    "note_csg": "La CSG déductible (6.8%) ne s'applique QUE si option barème progressif. Zéro déductible sous PFU. Elle s'impute en N+1 sur le RNI. Fraction à vérifier suite à la hausse LFSS 2026.",
+    "note_csg": "La CSG déductible (6.8%) ne s'applique QUE si option barème progressif. Zéro déductible sous PFU. Elle s'impute en N+1 sur le RNI.",
     "taux_plus_values_immo": 0.172
   },
 

--- a/fiscaliste/data/plus-values-immo-abattements.json
+++ b/fiscaliste/data/plus-values-immo-abattements.json
@@ -1,0 +1,59 @@
+{
+  "_meta": {
+    "revenus": 2025,
+    "declaration": 2026,
+    "source": "BOI-RFPI-PVI"
+  },
+
+  "regime_general": {
+    "description": "Plus-value immobilière des particuliers — deux grilles distinctes (IR et PS) avec durées différentes",
+    "taux_ir": 0.19,
+    "taux_ps": 0.172,
+    "taux_total_sans_abattement": 0.362,
+    "formule": "Plus-value imposable = prix_cession − prix_acquisition_majoré (frais acquisition + travaux) avec application des abattements durée de détention"
+  },
+
+  "abattements_ir": {
+    "description": "Abattement pour durée de détention sur l'IR (19%)",
+    "note": "La détention se compte depuis la date d'acquisition jusqu'à la cession. Exonération totale IR à 22 ans.",
+    "tranches": [
+      { "annees": "0 à 5", "taux_par_annee": 0.00 },
+      { "annees": "6 à 21", "taux_par_annee": 0.06 },
+      { "annees": "22", "taux_par_annee": 0.04 },
+      { "exoneration_totale_annees": 22 }
+    ]
+  },
+
+  "abattements_ps": {
+    "description": "Abattement pour durée de détention sur les prélèvements sociaux (17.2%)",
+    "note": "Grille plus progressive. Exonération totale PS à 30 ans.",
+    "tranches": [
+      { "annees": "0 à 5", "taux_par_annee": 0.00 },
+      { "annees": "6 à 21", "taux_par_annee": 0.0165 },
+      { "annees": "22", "taux_par_annee": 0.016 },
+      { "annees": "23 à 30", "taux_par_annee": 0.09 },
+      { "exoneration_totale_annees": 30 }
+    ]
+  },
+
+  "exonerations": {
+    "residence_principale": "Exonération totale IR + PS à condition d'occuper effectivement le bien à la date de cession (pas de mise en location préalable)",
+    "premiere_cession_logement_autre_que_rp": "Exonération sous conditions de remploi (construction/acquisition d'une RP dans les 24 mois), pas de détention d'une RP dans les 4 ans",
+    "expatries": "Exonération partielle pour les non-résidents qui vendent leur ancienne résidence en France",
+    "petit_prix": "Exonération si prix ≤ 15 000 € (par quote-part si indivision)",
+    "duree_detention": "≥ 22 ans pour l'IR, ≥ 30 ans pour les PS"
+  },
+
+  "prix_acquisition_majore": {
+    "description": "Le prix d'acquisition peut être majoré pour réduire la PV taxable",
+    "frais_acquisition": "7.5% forfaitaire OU frais réels sur justificatifs (notaire, droits enregistrement)",
+    "travaux": "15% forfaitaire si détention ≥ 5 ans, OU travaux réels sur justificatifs (construction, reconstruction, agrandissement, amélioration) - si non déjà déduits des revenus fonciers"
+  },
+
+  "surtaxe_pv_importantes": {
+    "description": "Surtaxe sur les plus-values immobilières imposables > 50 000 €",
+    "seuil_declenchement": 50000,
+    "taux_progressif": "2% à 6% selon le montant de la PV imposable (après abattements)",
+    "application": "Cumulative avec IR + PS"
+  }
+}

--- a/fiscaliste/data/plus-values-mobilieres-crypto.json
+++ b/fiscaliste/data/plus-values-mobilieres-crypto.json
@@ -1,0 +1,74 @@
+{
+  "_meta": {
+    "revenus": 2025,
+    "declaration": 2026,
+    "sources": [
+      "BOI-RPPM-PVBMI",
+      "BOI-RPPM-PVBMC-30 (crypto)"
+    ]
+  },
+
+  "plus_values_mobilieres": {
+    "description": "Plus-values de cession de titres (actions, parts de société, OPC)",
+    "regime_defaut": "PFU 30% (12.8% IR + 17.2% PS) sur le gain net",
+    "option_bareme": "Possible, globale pour tous revenus du capital. Avantage : abattements durée de détention si titres acquis avant 2018.",
+
+    "abattements_duree_detention_avant_2018": {
+      "description": "UNIQUEMENT si option barème progressif ET titres acquis avant le 1er janvier 2018",
+      "abattement_droit_commun": [
+        { "duree_annees": "≥ 2 et < 8", "taux": 0.50 },
+        { "duree_annees": "≥ 8", "taux": 0.65 }
+      ],
+      "abattement_renforce_pme": [
+        { "duree_annees": "≥ 1 et < 4", "taux": 0.50 },
+        { "duree_annees": "≥ 4 et < 8", "taux": 0.65 },
+        { "duree_annees": "≥ 8", "taux": 0.85 }
+      ],
+      "note": "L'abattement s'applique à l'IR uniquement, pas aux prélèvements sociaux"
+    },
+
+    "abattement_dirigeant_retraite": {
+      "montant_fixe": 500000,
+      "description": "Abattement fixe pour dirigeants de PME partant à la retraite, sur la plus-value de cession de leurs titres",
+      "conditions": "Conditions strictes : durée de fonction, taille de la société, cessation des fonctions, etc. Voir BOI-RPPM-PVBMI-20-30.",
+      "validite": "Dispositif temporairement prorogé — vérifier échéance actuelle"
+    },
+
+    "moins_values": {
+      "imputation": "Imputables sur les plus-values de même nature (mobilières) de l'année et des 10 années suivantes",
+      "ordre_imputation": "PV de l'année d'abord, puis PV des 10 années suivantes dans l'ordre"
+    }
+  },
+
+  "crypto_actifs": {
+    "description": "Régime des particuliers — occasionnel (non professionnel)",
+    "fait_generateur": [
+      "Cession contre monnaie fiat (€, USD)",
+      "Cession contre biens ou services",
+      "Échange crypto-to-crypto : NON imposable (sursis d'imposition, article 150 VH bis)"
+    ],
+
+    "methode_pamc": {
+      "description": "Prix d'Acquisition Moyen Pondéré en Continu",
+      "formule": "plus_value = prix_cession − (valeur_totale_portefeuille × montant_cession / valeur_portefeuille_avant_cession)",
+      "note": "Nécessite de tracer l'historique complet du portefeuille depuis le premier achat"
+    },
+
+    "taux": {
+      "regime_defaut": "PFU 30% (12.8% IR + 17.2% PS)",
+      "option_bareme": "Possible depuis revenus 2023 (LFI 2022) — avantageuse si TMI ≤ 11%"
+    },
+
+    "formulaire": {
+      "principal": "2086 — détail de chaque cession",
+      "report_2042": "Report du total sur la 2042 C (cases 3AN gain / 3BN perte)"
+    },
+
+    "exoneration": {
+      "seuil_annuel": 305,
+      "note": "Cessions cumulées ≤ 305 € par an → exonération totale. Au-delà : imposition intégrale (pas seulement la fraction au-delà)"
+    },
+
+    "activite_habituelle": "Requalification possible en BIC si activité habituelle/professionnelle — fiscalité plus lourde (cotisations sociales TNS)"
+  }
+}

--- a/fiscaliste/data/regimes-fonciers-lmnp.json
+++ b/fiscaliste/data/regimes-fonciers-lmnp.json
@@ -1,0 +1,91 @@
+{
+  "_meta": {
+    "revenus": 2025,
+    "declaration": 2026,
+    "reforme_applicable": "Loi Le Meur (nov. 2024), applicable aux revenus 2025",
+    "source": "BOI-BIC-CHAMP-40"
+  },
+
+  "micro_foncier": {
+    "description": "Régime simplifié pour revenus fonciers non meublés (location nue)",
+    "seuil_recettes_brutes": 15000,
+    "abattement": 0.30,
+    "note": "Revenus fonciers bruts ≤ 15 000 € → micro-foncier éligible, abattement 30% automatique. Au-delà : régime réel obligatoire. Exclusions : SCI, monument historique, Pinel, Borloo, etc."
+  },
+
+  "regime_reel_foncier": {
+    "description": "Revenus fonciers nets = recettes − charges déductibles",
+    "charges_deductibles": [
+      "Intérêts d'emprunt (imputables uniquement sur revenus fonciers)",
+      "Travaux (entretien, réparation, amélioration — pas construction ni agrandissement)",
+      "Taxe foncière (hors TEOM)",
+      "Primes d'assurance",
+      "Frais de gestion",
+      "Charges de copropriété (fraction non récupérable)"
+    ],
+    "deficit_foncier": {
+      "imputation_revenu_global": 10700,
+      "note_travaux_renovation_energetique": "Plafond temporairement doublé à 21 400 € pour travaux de rénovation énergétique globale (loi climat)",
+      "imputation_revenus_fonciers": "Reportable 10 ans au-delà du plafond annuel",
+      "exception_interets": "Les intérêts d'emprunt NE sont JAMAIS imputables sur le revenu global, uniquement sur les revenus fonciers"
+    }
+  },
+
+  "micro_bic_lmnp": {
+    "description": "Régime micro pour locations meublées non professionnelles",
+    "reforme_le_meur": "Distinction désormais classé / non classé (et non résidence principale ou non). Applicable revenus 2025.",
+
+    "lmnp_longue_duree": {
+      "seuil": 77700,
+      "abattement": 0.50,
+      "note": "Location meublée longue durée (bail >9 mois) — inchangé"
+    },
+
+    "meuble_tourisme_classe": {
+      "seuil": 77700,
+      "abattement": 0.50,
+      "note": "Meublés de tourisme classés (catégorie étoilée) — inchangé"
+    },
+
+    "meuble_tourisme_non_classe": {
+      "seuil": 15000,
+      "abattement": 0.30,
+      "note": "Seuil et abattement abaissés par la loi Le Meur. Au-delà de 15 000 € : régime réel obligatoire."
+    }
+  },
+
+  "lmnp_reel": {
+    "description": "Permet l'amortissement du bien + mobilier + charges",
+    "amortissement": {
+      "bien_immobilier": "Environ 2-3% par an sur 25-40 ans (hors terrain, terrain non amortissable)",
+      "mobilier": "10-20% par an sur 5-10 ans",
+      "gros_travaux": "Amortissables sur leur durée d'usage"
+    },
+    "resultat_fiscal": "Recettes − charges − amortissements. Souvent nul ou déficitaire.",
+    "deficit_lmnp": "NON imputable sur le revenu global (contrairement au LMP). Reportable sur les BIC des 10 années suivantes."
+  },
+
+  "lmp_vs_lmnp": {
+    "description": "Bascule en LMP (Loueur Meublé Professionnel)",
+    "seuils_cumulatifs": {
+      "seuil_recettes": 23000,
+      "condition_revenus": "ET recettes meublées > 50% des autres revenus professionnels du foyer (salaires, BNC, BIC, revenus dirigeants)",
+      "note": "Les DEUX conditions doivent être remplies. Seuil 23 000 € non renouvelable — application dès dépassement."
+    },
+    "consequences_lmp": {
+      "deficits": "Imputables sur le revenu global (contrairement au LMNP)",
+      "plus_values": "Régime des plus-values professionnelles avec exonération totale possible après 5 ans d'activité sous conditions de recettes",
+      "cotisations_sociales": "Cotisations TNS sur le bénéfice (SSI) — charge significative vs LMNP",
+      "ifi": "Biens LMP exonérés d'IFI comme biens professionnels (sous conditions)"
+    },
+    "bascule_involontaire": "Attention : passage LMP possible en cas de hausse des recettes meublées OU baisse des autres revenus professionnels. À surveiller annuellement."
+  },
+
+  "sci_ir": {
+    "description": "SCI à l'IR (régime par défaut, transparence fiscale)",
+    "principe": "Les revenus et charges remontent directement dans la déclaration des associés au prorata des parts",
+    "nature_revenus": "Revenus fonciers classiques (micro ou réel selon total fonciers du foyer)",
+    "cession_parts_ou_bien": "Plus-values immobilières des particuliers (régime des particuliers)",
+    "note_sci_is": "SCI à l'IS → voir skill `comptable` (hors scope du fiscaliste)"
+  }
+}

--- a/fiscaliste/evals/evals.json
+++ b/fiscaliste/evals/evals.json
@@ -1,0 +1,151 @@
+{
+  "skill_name": "fiscaliste",
+  "evals": [
+    {
+      "id": 1,
+      "name": "ir-celibataire-salaire-simple",
+      "prompt": "Je suis célibataire, sans enfant, mon salaire net imposable (case 1AJ) est de 50 000 €. Pas d'autres revenus. Calcule mon impôt sur le revenu pour les revenus 2025.",
+      "expected_output": "Calcul complet avec abattement 10% (= RNI 45 000 €), application du barème progressif tranche par tranche, décote si applicable, impôt net final. Mention de la checklist à vérifier sur impots.gouv.fr.",
+      "files": [],
+      "assertions": [
+        "Le skill applique l'abattement forfaitaire 10% sur les salaires (RNI = 50 000 × 0.9 = 45 000 €)",
+        "Le barème progressif est appliqué tranche par tranche (0%, 11%, 30%)",
+        "Les tranches utilisées proviennent de data/bareme-ir-2025.json",
+        "L'impôt brut pour 45 000 € avec 1 part est calculé (environ 6 623 €)",
+        "La décote est testée mais non applicable (impôt brut > 1 982 €)",
+        "L'année de référence des données (revenus 2025, déclaration 2026) est mentionnée",
+        "Pas de prélèvements sociaux calculés (pas de revenus du capital)",
+        "Le calcul est structuré étape par étape"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "ir-marie-2-enfants-plafonnement-qf",
+      "prompt": "Je suis marié avec 2 enfants à charge. Nos salaires imposables sont 80 000 € et 60 000 €. Pas d'autres revenus. Calcule notre impôt 2025 et explique si les enfants nous aident vraiment.",
+      "expected_output": "Calcul avec 3 parts (2 + 0,5 + 0,5), abattement 10% sur chaque salaire, application barème, PUIS vérification du plafonnement QF (2 demi-parts × 1 807 € = 3 614 €). Doit comparer impôt avec et sans enfants pour vérifier que le plafond n'est pas dépassé.",
+      "files": [],
+      "assertions": [
+        "Le skill identifie 3 parts fiscales (2 base + 0,5 × 2 enfants)",
+        "L'abattement 10% est appliqué sur chaque salaire séparément",
+        "Le skill calcule l'impôt avec 3 parts ET avec 2 parts pour comparer",
+        "Le plafonnement QF est testé : gain réel vs gain max (2 × 1 807 = 3 614 €)",
+        "Le skill indique si le plafond QF est actif ou non dans ce cas",
+        "La réponse explique que les enfants aident mais que le gain est plafonné par demi-part",
+        "Les valeurs proviennent de data/bareme-ir-2025.json"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "per-arbitrage-tmi",
+      "prompt": "Je gagne 90 000 € bruts (80 000 € imposables 1AJ). Mon conseiller me propose de verser 8 000 € sur un PER. C'est vraiment utile ou juste un report d'imposition ?",
+      "expected_output": "Économie immédiate calculée (8 000 × TMI 30% = 2 400 €). Discussion honnête du mécanisme de report : sortie imposée à la retraite. Recommandation dépend du TMI futur estimé. Plafond PER 10% des revenus pro. Rappel PEE/PERCO en priorité si disponible.",
+      "files": [],
+      "assertions": [
+        "L'économie immédiate 8 000 × 30% = 2 400 € est calculée",
+        "Le skill explique que c'est un REPORT d'imposition, pas une exonération",
+        "Le TMI futur à la retraite est mentionné comme variable clé",
+        "Le plafond PER 10% des revenus professionnels est mentionné (ici 8 000 € est en dessous)",
+        "Le skill rappelle qu'il faut saturer l'abondement employeur PEE/PERCO en priorité si disponible",
+        "La réponse nuance : pas toujours avantageux, dépend de la situation"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "pfu-vs-bareme-dividendes",
+      "prompt": "Célibataire, salaires 30 000 € net imposable. Je reçois 5 000 € de dividendes. Je choisis PFU ou barème ?",
+      "expected_output": "Calcul des deux scénarios. Sous PFU : 5 000 × 30% = 1 500 €. Sous barème : abattement 40% = 3 000 € imposables, TMI salaires 30% zone (mais attention, RNI 27 000 est dans tranche 11%, ajout de 3 000 € reste en 11%), donc IR barème sur dividendes ~330 € + PS 17,2% sur 5 000 = 860 €, total ~1 190 €. Barème plus favorable ici. Plus CSG déductible 6,8% × 5 000 × 11% = 37 € en N+1.",
+      "files": [],
+      "assertions": [
+        "Les deux scénarios (PFU et barème) sont chiffrés",
+        "Sous barème : abattement 40% sur dividendes est appliqué (3 000 € imposables)",
+        "Le TMI du foyer après ajout des dividendes est correctement identifié",
+        "Les PS 17,2% sont calculés dans les deux cas",
+        "Le skill rappelle que l'option barème est GLOBALE (tous revenus du capital)",
+        "La recommandation est cohérente avec le TMI : à TMI 11%, le barème est souvent meilleur pour les dividendes"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "lmnp-micro-vs-reel",
+      "prompt": "J'ai un appartement loué meublé, recettes 18 000 €/an (longue durée). Je suis au micro-BIC avec abattement 50%. Un ami me dit que je devrais passer au réel. Bonne idée ?",
+      "expected_output": "Micro-BIC = 18 000 × 50% = 9 000 € imposables. Au réel : amortissement bien (ex: bien à 200k€ hors terrain → amortissement ~6 000 €/an) + charges → résultat souvent nul ou déficitaire. Nuance : déficit LMNP non imputable sur revenu global. Évoquer bascule LMP si recettes > 23 000 € ET > 50% autres revenus pro.",
+      "files": [],
+      "assertions": [
+        "Le skill reconnaît le régime micro-BIC LMNP longue durée (abattement 50%, seuil 77 700 €)",
+        "Le calcul micro est donné (18 000 × 50% = 9 000 € de base imposable)",
+        "Le skill explique le principe du réel : amortissements + charges",
+        "Le skill rappelle que le déficit LMNP n'est PAS imputable sur le revenu global",
+        "La règle de bascule LMP (23 000 € ET > 50% autres revenus pro) est mentionnée",
+        "La recommandation est nuancée : ça dépend de la valeur du bien et des charges réelles"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "rsu-vesting-quotient",
+      "prompt": "J'ai reçu un vesting RSU de 100 000 € cette année. Mon salaire habituel est 60 000 €. Je dois payer combien d'impôts et puis-je utiliser le quotient pour revenus exceptionnels ?",
+      "expected_output": "Gain acquisition 100 000 € = imposé comme salaire (1TT). Total imposable salaires : 160 000 € + abattement 10%. CSG 9,7% sur RSU + contribution salariale 10% éventuelle. Quotient : comparer impôt avec/sans quotient (coefficient 4). À 160k€ on est en TMI 41%, quotient peut lisser si on revient en 30% sans RSU. La PV ultérieure (cession après vesting) sera imposée séparément au PFU.",
+      "files": [],
+      "assertions": [
+        "Le skill identifie le gain RSU comme SALAIRE (pas comme PV mobilière)",
+        "L'abattement 10% salaire s'applique sur le total salaires + RSU",
+        "La CSG 9,7% sur le gain RSU est mentionnée",
+        "La contribution salariale 10% sur plans qualifiants est évoquée",
+        "Le mécanisme du quotient (coefficient 4) est expliqué",
+        "Le skill chiffre (ou explique comment chiffrer) les 2 scénarios avec/sans quotient",
+        "Le skill distingue gain d'acquisition (salaire) et future PV de cession (PFU)"
+      ]
+    },
+    {
+      "id": 7,
+      "name": "crypto-pamc-exoneration",
+      "prompt": "J'ai vendu 250 € de Bitcoin cette année avec une PV de 40 €. Je dois déclarer ?",
+      "expected_output": "Exonération totale car cessions annuelles ≤ 305 €. Pas de déclaration 2086 requise. Au-delà de 305 €, imposition intégrale (pas seulement la fraction).",
+      "files": [],
+      "assertions": [
+        "Le skill identifie le seuil d'exonération de 305 € de cessions annuelles",
+        "Le skill confirme l'exonération totale dans ce cas (250 € ≤ 305 €)",
+        "Le skill précise que le seuil s'applique sur le montant brut des cessions, pas sur la PV",
+        "Le skill avertit que dépasser 305 € déclencherait l'imposition sur TOUT (pas seulement l'excédent)"
+      ]
+    },
+    {
+      "id": 8,
+      "name": "ifi-assujettissement-decote",
+      "prompt": "Mon patrimoine immobilier net au 1er janvier : résidence principale 900 000 € + appartement locatif 500 000 €, emprunt restant 200 000 € sur le locatif. Dois-je payer l'IFI ?",
+      "expected_output": "Résidence principale : 900 000 × (1 − 0,30) = 630 000 € (abattement 30%). Locatif : 500 000 − 200 000 = 300 000 €. Patrimoine net taxable = 930 000 €. Sous le seuil d'assujettissement (1 300 000 €) → pas d'IFI dû.",
+      "files": [],
+      "assertions": [
+        "L'abattement 30% sur la résidence principale est appliqué (630 000 € pris en compte)",
+        "L'emprunt est déduit de la valeur du bien locatif",
+        "Le total patrimoine net taxable est calculé (930 000 €)",
+        "Le skill conclut que le seuil d'assujettissement (1 300 000 €) n'est pas atteint",
+        "Pas d'IFI dû, pas de déclaration 2042-IFI",
+        "Les données proviennent de data/ifi-bareme.json"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "redirection-succession-vers-notaire",
+      "prompt": "Mon père est décédé. Comment calcule-t-on les droits de succession pour ses héritiers ?",
+      "expected_output": "Sujet hors scope du fiscaliste. Le skill doit rediriger vers le skill notaire qui gère succession, donation et démembrement.",
+      "files": [],
+      "assertions": [
+        "Le skill identifie que la succession est hors de son scope",
+        "Le skill redirige explicitement vers le skill notaire",
+        "Le skill ne tente pas de calculer les droits de succession lui-même"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "redirection-sasu-vers-comptable",
+      "prompt": "Je veux comparer rémunération en salaire vs dividendes dans ma SASU. Peux-tu m'aider ?",
+      "expected_output": "Sujet hors scope du fiscaliste (arbitrage IS / salaire / dividendes dirigeant). Le skill doit rediriger vers le skill comptable pour la partie société, et peut compléter sur l'IR perso du dirigeant si demandé.",
+      "files": [],
+      "assertions": [
+        "Le skill identifie que l'arbitrage SASU salaire/dividendes est hors de son scope",
+        "Le skill redirige explicitement vers le skill comptable",
+        "Le skill peut proposer de compléter sur l'IR perso du dirigeant si l'utilisateur le souhaite"
+      ]
+    }
+  ]
+}

--- a/fiscaliste/evals/evals.json
+++ b/fiscaliste/evals/evals.json
@@ -10,8 +10,8 @@
       "assertions": [
         "Le skill applique l'abattement forfaitaire 10% sur les salaires (RNI = 50 000 × 0.9 = 45 000 €)",
         "Le barème progressif est appliqué tranche par tranche (0%, 11%, 30%)",
-        "Les tranches utilisées proviennent de data/bareme-ir-2025.json",
-        "L'impôt brut pour 45 000 € avec 1 part est calculé (environ 6 623 €)",
+        "Les tranches 2025 correctes sont utilisées (11 600 / 29 579 / 84 577 / 181 917)",
+        "L'impôt brut pour 45 000 € avec 1 part est calculé (environ 6 604 €)",
         "La décote est testée mais non applicable (impôt brut > 1 982 €)",
         "L'année de référence des données (revenus 2025, déclaration 2026) est mentionnée",
         "Pas de prélèvements sociaux calculés (pas de revenus du capital)",
@@ -31,7 +31,7 @@
         "Le plafonnement QF est testé : gain réel vs gain max (2 × 1 807 = 3 614 €)",
         "Le skill indique si le plafond QF est actif ou non dans ce cas",
         "La réponse explique que les enfants aident mais que le gain est plafonné par demi-part",
-        "Les valeurs proviennent de data/bareme-ir-2025.json"
+        "Les valeurs 2025 correctes sont utilisées (tranches, plafond QF 1 807 €)"
       ]
     },
     {
@@ -41,10 +41,10 @@
       "expected_output": "Économie immédiate calculée (8 000 × TMI 30% = 2 400 €). Discussion honnête du mécanisme de report : sortie imposée à la retraite. Recommandation dépend du TMI futur estimé. Plafond PER 10% des revenus pro. Rappel PEE/PERCO en priorité si disponible.",
       "files": [],
       "assertions": [
-        "L'économie immédiate 8 000 × 30% = 2 400 € est calculée",
+        "L'économie immédiate est calculée en appliquant le TMI 30% au montant effectivement déductible",
         "Le skill explique que c'est un REPORT d'imposition, pas une exonération",
         "Le TMI futur à la retraite est mentionné comme variable clé",
-        "Le plafond PER 10% des revenus professionnels est mentionné (ici 8 000 € est en dessous)",
+        "Le plafond PER 10% des revenus professionnels nets est correctement appliqué (72 000 × 10% = 7 200 €, donc 800 € non déductibles sur les 8 000 versés)",
         "Le skill rappelle qu'il faut saturer l'abondement employeur PEE/PERCO en priorité si disponible",
         "La réponse nuance : pas toujours avantageux, dépend de la situation"
       ]
@@ -120,7 +120,7 @@
         "Le total patrimoine net taxable est calculé (930 000 €)",
         "Le skill conclut que le seuil d'assujettissement (1 300 000 €) n'est pas atteint",
         "Pas d'IFI dû, pas de déclaration 2042-IFI",
-        "Les données proviennent de data/ifi-bareme.json"
+        "Le seuil d'assujettissement IFI 1 300 000 € est correctement cité"
       ]
     },
     {

--- a/fiscaliste/foyer.example.json
+++ b/fiscaliste/foyer.example.json
@@ -1,0 +1,86 @@
+{
+  "_meta": {
+    "description": "Structure d'exemple pour un foyer fiscal. Copier ce fichier en foyer.json à la racine du projet et adapter.",
+    "annee_revenus": 2025,
+    "annee_declaration": 2026
+  },
+
+  "foyer": {
+    "situation": "marie",
+    "_situation_options": ["celibataire", "marie", "pacse", "divorce", "veuf"],
+    "annee_naissance_declarant1": 1985,
+    "annee_naissance_declarant2": 1987,
+    "nb_enfants_charge": 2,
+    "nb_enfants_alternee": 0,
+    "nb_enfants_invalides": 0,
+    "residence_fiscale": "FR",
+    "departement_residence": "75"
+  },
+
+  "revenus": {
+    "salaires_declarant1": 72000,
+    "salaires_declarant2": 48000,
+    "_commentaire_salaires": "Montants case 1AJ / 1BJ du bulletin de salaire, AVANT abattement forfaitaire 10% appliqué par la DGFIP",
+
+    "pensions_declarant1": 0,
+    "pensions_declarant2": 0,
+
+    "bnc_regime_normal": 0,
+    "_commentaire_bnc": "Case 5QC — BNC professionnels régime normal",
+    "micro_bnc_recettes": 0,
+
+    "dividendes_bruts": 5000,
+    "_commentaire_dividendes": "Case 2DC — dividendes avec droit abattement 40% si option barème",
+    "interets_rcm": 0,
+    "plus_values_mobilieres": 0,
+    "_commentaire_pv_mobi": "Case 3VG — plus-values de cession de titres",
+
+    "revenus_fonciers_micro": 0,
+    "revenus_fonciers_reels": 0,
+    "deficit_foncier_anterieur": 0,
+
+    "lmnp_reel_resultat": 0,
+    "_commentaire_lmnp": "Résultat après amortissements, positif seulement",
+
+    "crypto_plus_values": 0,
+    "revenus_chomage": 0,
+    "_commentaire_chomage": "Case 1AP — PAS D'ABATTEMENT 10% (différent de 1AJ)"
+  },
+
+  "deductions": {
+    "per_declarant1": 4000,
+    "per_declarant2": 2000,
+    "pension_alimentaire_enfant_majeur": 0,
+    "csg_deductible_n1": 0,
+    "_commentaire_csg": "CSG déductible uniquement si option barème en N-1, pas sous PFU"
+  },
+
+  "options_fiscales": {
+    "revenus_capital": "pfu",
+    "_options": ["pfu", "bareme"],
+    "_commentaire_option": "L'option barème est globale : elle s'applique à TOUS les revenus du capital de l'année"
+  },
+
+  "patrimoine_ifi": {
+    "assujetti": false,
+    "valeur_nette_taxable": 0,
+    "_commentaire_ifi": "IFI dû si patrimoine immobilier net > seuil d'assujettissement au 1er janvier (voir data/ifi-bareme.json)"
+  },
+
+  "equity_salarial": {
+    "rsu_gain_acquisition": 0,
+    "rsu_plus_value_cession": 0,
+    "bspce_gain_cession": 0,
+    "bspce_anciennete_societe_annees": 0,
+    "stock_options_levee": 0,
+    "pee_abondement_employeur": 0
+  },
+
+  "niches_fiscales": {
+    "dons_associations": 0,
+    "pinel_reduction": 0,
+    "fcpi_fip_versements": 0,
+    "emploi_a_domicile": 0,
+    "garde_enfant_exterieur": 0
+  }
+}

--- a/fiscaliste/references/cas-speciaux.md
+++ b/fiscaliste/references/cas-speciaux.md
@@ -1,0 +1,209 @@
+# Cas particuliers
+
+## Non-résidents fiscaux
+
+### Définition résidence fiscale
+
+Un contribuable est résident fiscal français si l'un de ces critères est rempli (article 4 B CGI) :
+- Foyer ou lieu de séjour principal en France
+- Exercice d'une activité professionnelle principale en France
+- Centre des intérêts économiques en France
+
+**La nationalité n'est pas un critère.**
+
+### Règles applicables aux non-résidents
+
+- Imposés uniquement sur les **revenus de source française** (article 164 A CGI)
+- Taux minimum : 20% sur la fraction ≤ 27 519 € et 30% au-delà (revenus 2025)
+- Pas de quotient familial au-delà de 2 parts
+- Pas de décote
+- Application des conventions fiscales bilatérales (crédit d'impôt, exonérations)
+
+**Ce skill ne couvre PAS la fiscalité des non-résidents en détail.** Pour les cas complexes, orienter vers un avocat fiscaliste spécialisé en fiscalité internationale.
+
+## Revenus exceptionnels : quotient
+
+### Mécanisme
+
+Lissage fiscal pour éviter qu'un revenu ponctuel ne fasse franchir artificiellement plusieurs tranches.
+
+**Formule** :
+```
+Impôt_supplémentaire = [IR(revenu_ordinaire + revenu_exceptionnel / coefficient) − IR(revenu_ordinaire)] × coefficient
+```
+
+**Coefficient par défaut : 4**. Peut être différent selon la nature du revenu.
+
+### Revenus éligibles
+
+- Prime exceptionnelle (non pérennisable)
+- Indemnité de départ volontaire ou licenciement (fraction imposable)
+- Gratification de fin d'activité
+- Vesting RSU massif (exceptionnellement élevé vs revenus habituels)
+- Régularisation d'arriérés de salaire
+- Plus-value de cession d'entreprise (cas spécifiques)
+
+### Conditions d'application
+
+- Revenu > **moyenne des revenus imposables des 3 années précédentes**
+- Caractère exceptionnel avéré (non récurrent)
+- Demande expresse du contribuable sur la déclaration
+
+### Nuance critique
+
+**Inutile si foyer déjà au TMI 45%** : le taux marginal ne change pas avec la division par 4.
+
+**Très utile si** :
+- TMI habituel 30% et revenu exceptionnel fait passer à 41%
+- TMI habituel 11% et revenu exceptionnel fait passer à 30% ou 41%
+
+### Exemple
+
+Foyer célibataire, RNI habituel 40 000 € (TMI 30%), vesting RSU 80 000 € imposé comme salaire.
+
+**Sans quotient** :
+- RNI total : 120 000 €
+- Impôt approximatif : ~32 000 €
+
+**Avec quotient (coefficient 4)** :
+- Revenu fractionné : 40 000 + 80 000/4 = 60 000 €
+- Impôt sur 60 000 € : ~12 000 €
+- Impôt sur 40 000 € : ~5 100 €
+- Supplément × 4 : (12 000 − 5 100) × 4 = 27 600 €
+- Impôt total : 5 100 + 27 600 = ~32 700 €
+
+Dans cet exemple, peu de gain car le revenu ordinaire est déjà en tranche 30%. L'intérêt est marginal.
+
+**Règle** : chiffrer systématiquement les deux scénarios avant de recommander le quotient.
+
+## CEHR (Contribution Exceptionnelle Hauts Revenus)
+
+Voir `data/bareme-ir-2025.json` → `cehr`.
+
+### Seuils (revenus 2025)
+
+| Situation | Tranche 3% | Tranche 4% |
+|-----------|-----------|-----------|
+| Célibataire | 250 000 € à 500 000 € | > 500 000 € |
+| Couple | 500 000 € à 1 000 000 € | > 1 000 000 € |
+
+**Base de calcul : RFR** (pas RNI). Le RFR inclut des éléments exonérés d'IR normal (certains revenus capital, abattements réintégrés).
+
+### À ne pas oublier
+
+- S'ajoute à l'IR net (ne se déduit pas)
+- Lissage possible sur la moyenne des 2 années précédentes (article 223 sexies CGI)
+
+## Revenus étrangers et conventions fiscales
+
+### Principes
+
+- France applique le principe de **mondialité** pour les résidents : imposition sur l'ensemble des revenus (y compris étrangers)
+- **Conventions fiscales bilatérales** peuvent prévoir :
+  - Exonération en France (méthode de l'exemption)
+  - Imposition en France avec crédit d'impôt pour l'impôt payé à l'étranger (méthode de l'imputation)
+
+### Méthodes courantes
+
+| Méthode | Effet |
+|---------|-------|
+| Exemption totale | Revenu non imposé en France |
+| Exemption avec taux effectif | Revenu inclus pour le calcul du taux, mais non imposé |
+| Imputation | Revenu imposé en France, crédit d'impôt = impôt payé à l'étranger (limité à l'impôt français correspondant) |
+
+### À vérifier
+
+- La convention fiscale **entre la France et le pays de source** du revenu
+- Formulaire 2047 pour déclarer les revenus étrangers (annexe à la 2042)
+- Crédits d'impôt étrangers : reports, limitations
+
+**Zone complexe** — renvoyer vers un avocat fiscaliste pour les cas significatifs (expatriation partielle, revenus locatifs étrangers, retraites étrangères).
+
+## Expatriation et retour en France
+
+### Exit tax
+
+Article 167 bis CGI — imposition immédiate des plus-values latentes sur titres détenus lors du départ à l'étranger, si :
+- Résidence fiscale française pendant au moins 6 ans sur les 10 dernières années
+- Détention de titres > seuils (plusieurs catégories de seuils)
+
+Sursis de paiement possible dans certains cas. Régime complexe.
+
+### Retour en France
+
+Régime d'**impatriation** (article 155 B CGI) : exonération partielle de l'impôt pour les impatriés sous conditions strictes. Durée 8 ans max.
+
+**Hors scope ce skill** — renvoyer vers un avocat fiscaliste spécialisé.
+
+## DOM-TOM
+
+Régimes spéciaux :
+- Réduction d'impôt de 30% à 40% dans les DOM (plafonnée)
+- Revenus de source DOM : régime spécifique
+- Investissement Girardin : mécanismes distincts
+
+**Hors scope ce skill** pour le détail. Signaler la spécificité et renvoyer vers la documentation locale / BOFiP dédié.
+
+## Allocations chômage et revenus de remplacement
+
+Déclarées case **1AP / 1BP** (pas 1AJ).
+
+**Points critiques** :
+- **Pas d'abattement 10%** (contrairement aux salaires)
+- CSG prélevée à taux réduit à la source
+- La fraction de CSG prélevée à taux réduit n'est pas déductible du revenu imposable
+
+**Erreur classique** : déclarer l'ARE en case 1AJ → bénéficie à tort de l'abattement 10% → redressement probable.
+
+## Situations matrimoniales particulières
+
+### Année du mariage / PACS
+
+- **Imposition commune** pour l'année entière (depuis 2011)
+- Ou imposition séparée sur option (cases dédiées)
+- À chiffrer : selon situation des conjoints, l'une peut être plus favorable
+
+### Année de séparation / divorce
+
+- **Imposition séparée** pour l'année entière depuis la séparation (principe)
+- Enfants à charge : attribution selon accord ou garde principale
+- Case T (parent isolé) possible pour celui qui assume seul les enfants
+
+### Année du décès d'un conjoint
+
+- Imposition commune jusqu'au décès (du 1er janvier à la date de décès)
+- Imposition individuelle du conjoint survivant pour la fin de l'année
+- Deux déclarations séparées à faire
+
+## Droit de reprise DGFIP
+
+Délai pendant lequel la DGFIP peut redresser :
+
+| Impôt | Délai standard |
+|-------|----------------|
+| IR | 3 ans (jusqu'au 31 décembre de la 3e année suivant celle de l'imposition) |
+| IFI | 6 ans (cas général) |
+| Tous impôts | **10 ans** en cas d'activité occulte ou fraude |
+| TVA | 3 ans |
+
+**Conservation des documents** : minimum 6 ans (conseil : 10 ans pour couvrir tous les cas).
+
+## Régularisation spontanée
+
+**Intérêt** : réduction des pénalités si le contribuable rectifie avant contrôle.
+
+- Intérêts de retard : 0,2%/mois
+- Pas de majoration si régularisation spontanée et bonne foi
+
+**Quand envisager** : oubli de déclaration (crypto, revenus étrangers, plus-values). Orienter vers un avocat fiscaliste pour les cas significatifs (régularisation structurée).
+
+## Références CGI / BOFiP
+
+- Résidence fiscale : art. 4 B CGI
+- Non-résidents : art. 164 A à 165 CGI
+- Revenus exceptionnels : art. 163-0 A CGI
+- CEHR : art. 223 sexies CGI
+- Exit tax : art. 167 bis CGI
+- Impatriation : art. 155 B CGI
+- Droit de reprise : LPF (Livre des Procédures Fiscales)
+- BOFiP : BOI-INT (conventions internationales), BOI-IR-LIQ

--- a/fiscaliste/references/crypto.md
+++ b/fiscaliste/references/crypto.md
@@ -1,0 +1,111 @@
+# Fiscalité des crypto-actifs (particuliers)
+
+Voir `data/plus-values-mobilieres-crypto.json` → `crypto_actifs`.
+
+## Régime des particuliers (occasionnel)
+
+Le régime des particuliers s'applique aux cessions **occasionnelles** d'actifs numériques. Si l'activité est habituelle/professionnelle, requalification en **BIC** (cotisations sociales TNS, régime plus lourd).
+
+**Indices d'activité habituelle** :
+- Volume de transactions élevé
+- Fréquence quasi quotidienne
+- Usage d'outils professionnels (bots, API, arbitrage automatisé)
+- Revenus crypto principaux du foyer
+
+## Fait générateur
+
+| Opération | Imposable ? |
+|-----------|-------------|
+| Achat crypto contre € / USD | Non |
+| Cession crypto contre € / USD | **Oui** |
+| Paiement en crypto (biens/services) | **Oui** (cession déguisée) |
+| Échange crypto-to-crypto (BTC → ETH) | **Non** (sursis, art. 150 VH bis) |
+| Staking / mining / airdrop | Selon contexte — souvent BNC ou BIC, pas PV mobilière |
+
+**Règle du sursis crypto-to-crypto** : les échanges entre crypto-actifs ne déclenchent pas l'imposition. Seul le passage en monnaie fiat (ou en biens/services) est taxable.
+
+## Méthode PAMC (Prix d'Acquisition Moyen Pondéré en Continu)
+
+**Formule officielle** :
+
+```
+plus_value_cession = prix_cession − (valeur_totale_portefeuille × montant_cession / valeur_portefeuille_avant_cession)
+```
+
+**Conséquences pratiques** :
+- Chaque cession puise dans le portefeuille global (pas en FIFO, pas en LIFO)
+- Nécessite de tracer l'historique complet depuis le premier achat
+- Si prix d'achat non documentés → risque de requalification en cession au prix 0 (PV max)
+
+**Outils recommandés** : Koinly, CoinTracking, Waltio, Cryptio. À vérifier que le logiciel applique bien la PAMC française.
+
+## Taux d'imposition
+
+### Régime par défaut : PFU 30%
+
+- 12,8% IR + 17,2% PS
+- Application sur la plus-value nette annuelle (après compensation des moins-values de l'année)
+
+### Option barème (depuis revenus 2023)
+
+Possible depuis la LFI 2022 (applicable revenus 2023). **Avantageuse si TMI ≤ 11%.**
+
+**Rappel** : l'option barème est **globale** — s'applique à tous les revenus du capital de l'année (y compris dividendes, intérêts, PV mobilières). Arbitrage à faire au niveau global.
+
+## Exonération du petit portefeuille
+
+**Seuil annuel : 305 €** de cessions cumulées.
+
+- Cessions ≤ 305 € par an → **exonération totale**
+- Cessions > 305 € par an → **imposition intégrale** (pas seulement la fraction au-delà)
+
+**Piège** : le seuil s'applique sur le **montant brut des cessions** de l'année, pas sur la plus-value. Vendre 500 € de crypto avec une PV de 10 € déclenche l'imposition sur les 10 € de PV.
+
+## Compensation des moins-values
+
+Les moins-values de l'année sont **compensables** avec les plus-values de l'année (crypto uniquement, pas compensables avec PV mobilières classiques).
+
+**Pas de report** des moins-values crypto sur les années suivantes (règle spécifique).
+
+## Formulaire 2086
+
+Déclaration obligatoire détaillant **chaque cession** :
+- Date de la cession
+- Valeur du portefeuille avant cession
+- Prix total d'acquisition du portefeuille
+- Prix de la cession
+- Plus-value ou moins-value calculée
+
+**Report sur 2042 C** :
+- Case 3AN : plus-value nette annuelle (gain)
+- Case 3BN : moins-value nette annuelle (perte)
+
+## Staking, mining, airdrops
+
+**Régime distinct des PV** — imposition selon la nature :
+
+| Activité | Régime probable |
+|----------|----------------|
+| Staking occasionnel | BNC non professionnel ou PV mobilière selon cas |
+| Mining | BIC |
+| Staking/lending professionnel | BIC |
+| Airdrop reçu passivement | Non imposable à la réception, PV au moment de la cession |
+| Rewards actifs (tâches à accomplir) | BNC ou salaire |
+
+**Zone grise** : la doctrine DGFIP évolue. Vérifier les dernières positions BOFiP.
+
+## Documentation à conserver
+
+Pour 6 ans minimum (délai de reprise) :
+- Historique complet des transactions (exports exchanges)
+- Preuves des dates et prix d'acquisition
+- Détail des échanges crypto-to-crypto (même non imposables)
+- Transferts entre wallets (pour prouver la continuité du portefeuille)
+
+## Références CGI / BOFiP
+
+- Régime particulier crypto : art. 150 VH bis CGI
+- Activité habituelle (BIC) : art. 34 CGI
+- Méthode PAMC : art. 150 VH bis-II CGI
+- Sursis échange crypto-crypto : art. 150 VH bis-I-2 CGI
+- BOFiP : BOI-RPPM-PVBMC-30

--- a/fiscaliste/references/declaration-workflow.md
+++ b/fiscaliste/references/declaration-workflow.md
@@ -1,0 +1,296 @@
+# Workflow de Déclaration des Revenus (2042)
+
+Guide d'exécution complet pour la déclaration annuelle des revenus d'un particulier français (revenus 2025, déclaration 2026).
+
+Ce workflow couvre les 10 étapes de la déclaration, de la collecte des documents à la vérification de l'avis d'imposition, en passant par le choix des options fiscales et la sélection des annexes pertinentes.
+
+---
+
+## Vue d'ensemble
+
+```
+Phase 1 : Préparation
+  1. Collecte des justificatifs
+  2. Consolidation du contexte foyer (foyer.json)
+  3. Identification des catégories de revenus
+
+Phase 2 : Choix stratégiques
+  4. PFU vs barème sur revenus du capital
+  5. Régime foncier (micro vs réel) / LMNP (micro-BIC vs réel)
+  6. Mobilisation du PER / reports d'épargne retraite
+
+Phase 3 : Saisie et annexes
+  7. Déclaration principale 2042
+  8. Annexes (2044, 2074, 2086, 2047, 2042-IFI, 2042-RICI)
+
+Phase 4 : Vérification et suivi
+  9. Simulation avant dépôt
+  10. Vérification de l'avis d'imposition et solde PAS
+```
+
+---
+
+## Phase 1 : Préparation
+
+### Étape 1 : Collecte des justificatifs
+
+**Objectif** : rassembler TOUS les documents permettant de remplir la déclaration.
+
+**Documents par source** :
+
+| Source | Document | Usage |
+|--------|----------|-------|
+| Employeur | Bulletin de décembre + attestation fiscale | Salaires imposables (1AJ), gain RSU (1TT) |
+| Pôle emploi | Attestation fiscale annuelle | ARE (1AP) — attention pas 1AJ |
+| Banque / courtier | IFU (Imprimé Fiscal Unique) | Intérêts, dividendes, PV mobilières |
+| Assurance-vie | Relevé annuel | Rachats, produits imposables |
+| Notaire | Acte de vente + formulaire 2048-IMM | PV immobilière |
+| Gestionnaire locatif | Récapitulatif loyers + charges | Revenus fonciers / LMNP |
+| Exchange crypto | Historique transactions | PV crypto (méthode PAMC) |
+| Organisme PER | Attestation de versement | Déduction PER |
+| Association / syndicat | Reçu fiscal | Réduction 66 % ou 75 % |
+| Employeur CESU / crèche | Attestation URSSAF / relevé | Crédit d'impôt 50 % |
+
+**Contrôle** : vérifier que tous les revenus pré-remplis sur impots.gouv.fr correspondent aux justificatifs reçus. Les oublis viennent souvent de comptes étrangers, de revenus exceptionnels (RSU, primes) ou de ventes ponctuelles.
+
+### Étape 2 : Consolidation du contexte foyer
+
+**Objectif** : construire ou mettre à jour `foyer.json` à la racine du projet.
+
+Voir [foyer.example.json](../foyer.example.json) pour la structure. Champs critiques :
+
+- **situation** : célibataire / marié / pacsé / divorcé / veuf
+- **nb_enfants_charge** : enfants à charge exclusive
+- **nb_enfants_alternee** : enfants en garde alternée (comptent pour 0,25 part chacun)
+- **nb_enfants_invalides** : demi-part supplémentaire
+- **annee_naissance_declarants** : pour le calcul de la demi-part personnes âgées (> 65 ans au 1er janvier)
+
+**Points d'attention** :
+
+- Année du mariage / PACS → imposition commune ou séparée (option)
+- Année de séparation → imposition séparée pour l'année entière depuis 2011
+- Parent isolé (case T) → demi-part supplémentaire si assume seul les enfants
+
+### Étape 3 : Identification des catégories de revenus
+
+**Objectif** : catégoriser chaque revenu pour savoir dans quelle case le déclarer.
+
+| Catégorie | Case 2042 | Annexe éventuelle |
+|-----------|-----------|-------------------|
+| Salaires | 1AJ / 1BJ | — |
+| Gain acquisition RSU | 1TT / 1UT | — |
+| Pensions | 1AS / 1BS | — |
+| Allocations chômage | 1AP / 1BP | — |
+| Indemnités maladie | 1AM / 1BM | — |
+| BNC régime normal | 5QC / 5RC | 2035 |
+| Micro-BNC | 5HQ / 5IQ | — |
+| Revenus fonciers réels | 4BA | **2044** |
+| Micro-foncier (nu) | 4BE | — |
+| LMNP micro-BIC longue durée | 5ND / 5OD | — |
+| LMNP réel | 5NA / 5OA | **2031 + 2033-A à D** |
+| Dividendes (PFU ou barème) | 2DC | — |
+| Intérêts / produits de placement | 2TR | — |
+| Plus-values mobilières | 3VG | **2074** (si détail) |
+| Plus-values crypto | 3AN / 3BN | **2086** |
+| Plus-value immobilière | 3VZ | **2048-IMM** (notaire) |
+| Revenus étrangers | — | **2047** |
+| Patrimoine immobilier net > 1,3 M€ | — | **2042-IFI** |
+| Dons, emploi à domicile, garde d'enfant | — | **2042-RICI** |
+
+**Piège** : déclarer l'ARE en 1AJ bénéficie à tort de l'abattement 10 % → redressement probable.
+
+---
+
+## Phase 2 : Choix stratégiques
+
+### Étape 4 : PFU vs barème sur revenus du capital
+
+**Objectif** : décider du régime d'imposition des revenus du capital (option **globale** et **irrévocable** pour l'année).
+
+**Méthode** :
+
+1. Lister tous les revenus du capital de l'année (intérêts, dividendes, PV mobilières, rachats AV < 8 ans, gains PEA avant 5 ans).
+2. Calculer les deux scénarios :
+   - **PFU 30 %** (12,8 % IR + 17,2 % PS) sur l'ensemble, sans abattement.
+   - **Barème** : abattement 40 % sur dividendes, PS 17,2 %, barème progressif au TMI du foyer, puis CSG déductible 6,8 % imputable sur le RNI de N+1.
+3. Retenir l'option la plus favorable.
+
+**Règle d'orientation rapide** :
+
+| TMI du foyer | Option probable |
+|--------------|-----------------|
+| 0 % ou 11 % | Barème quasi-toujours meilleur (tranche basse + abattement dividendes + CSG déductible) |
+| 30 % | À chiffrer — proche parité |
+| 41 % ou 45 % | PFU quasi-toujours meilleur |
+
+**Case à cocher** : 2OP (option pour le barème).
+
+### Étape 5 : Régime foncier et LMNP
+
+**Objectif** : choisir le régime le plus favorable sur les revenus immobiliers.
+
+**Location nue** :
+
+| Recettes | Options disponibles |
+|----------|---------------------|
+| ≤ 15 000 € | Micro-foncier (abattement 30 %) OU réel sur option |
+| > 15 000 € | Régime réel obligatoire — annexe 2044 |
+
+Le réel est avantageux dès que charges réelles > 30 % des loyers (crédit immobilier, travaux, assurance PNO, taxe foncière).
+
+**Déficit foncier** : imputable sur le revenu global dans la limite de 10 700 € / an, reportable 10 ans sur revenus fonciers uniquement.
+
+**Location meublée (LMNP)** :
+
+| Recettes annuelles | Régime | Abattement |
+|--------------------|--------|------------|
+| ≤ 77 700 € (longue durée ou meublé classé) | Micro-BIC | 50 % |
+| ≤ 15 000 € (meublé tourisme non classé) | Micro-BIC | 30 % |
+| > seuils OU sur option | Réel — annexe 2031 | Amortissements + charges réelles |
+
+Au **réel**, l'amortissement du bien (hors terrain, sur ~25-30 ans) rend souvent le résultat nul ou déficitaire. Le déficit LMNP est **non imputable sur le revenu global** (reportable 10 ans sur BIC non pro uniquement).
+
+**Bascule LMP** : si recettes > 23 000 € ET > 50 % des autres revenus pro du foyer → statut LMP (régime différent, exonération IFI possible, cotisations sociales SSI).
+
+### Étape 6 : Mobilisation du PER
+
+**Objectif** : décider d'un éventuel versement PER avant le 31 décembre pour réduire l'IR de l'année.
+
+**Ordre de priorité** :
+
+1. **Saturer l'abondement employeur PEE / PERCO** en priorité absolue (l'abondement est un match gratuit, rendement immédiat 50 % à 300 %).
+2. **Ensuite** envisager un versement PER individuel si :
+   - TMI actuel ≥ 30 % (économie immédiate significative)
+   - TMI estimé à la retraite < TMI actuel (gain net en report d'imposition)
+   - Plafond disponible non saturé (vérifier sur l'avis d'imposition N-1, rubrique "Plafond pour l'épargne retraite")
+
+**Calcul du plafond mobilisable** :
+
+- Plafond N = 10 % des revenus pro N-1 (salaires après abattement 10 %), dans les bornes 4 710 € et 37 680 € (revenus 2025).
+- + plafonds non utilisés N-3, N-2, N-1 (report 3 ans, ordre FIFO).
+- + plafond du conjoint si mutualisation cochée (imposition commune).
+
+**Saisie** : cases 6NS (déclarant 1) / 6NT (déclarant 2).
+
+---
+
+## Phase 3 : Saisie et annexes
+
+### Étape 7 : Déclaration principale 2042
+
+**Objectif** : saisir toutes les catégories de revenus et les options.
+
+**Pages principales** :
+
+- Page 1 : état civil, situation famille, enfants à charge
+- Page 2 : traitements, salaires, pensions, chômage (cadres 1)
+- Page 3 : revenus des capitaux mobiliers (cadres 2), plus-values (cadres 3)
+- Page 4 : revenus fonciers (cadres 4), BIC / BNC / BA (cadres 5)
+- Page 5 : charges déductibles (PER, pensions alimentaires, CSG déductible)
+- Page 6 : réductions et crédits d'impôt
+
+**Points d'attention systématiques** :
+
+- Cocher la case 2OP si option barème sur revenus du capital
+- Cocher la case "parent isolé" (T) si applicable
+- Vérifier les enfants en garde alternée (case H)
+- Reporter les PV mobilières depuis l'IFU (attention à la cohérence avec les 2074)
+
+### Étape 8 : Annexes à joindre
+
+**Tableau de décision** :
+
+| Situation | Annexe |
+|-----------|--------|
+| Location nue au réel | **2044** |
+| LMNP au réel | **2031 + 2033-A à 2033-D** |
+| Plus-values mobilières détaillées (plusieurs lignes, reports moins-values) | **2074** |
+| Cessions crypto > 305 € | **2086** (obligatoire même si PV nulle) |
+| Revenus étrangers | **2047** |
+| Patrimoine immobilier net > 1,3 M€ au 1er janvier | **2042-IFI + 2042-IFI-K** |
+| Réductions / crédits (dons, emploi à domicile, garde enfant, Pinel, FCPI…) | **2042-RICI** |
+| Plus-value immobilière (hors RP) | **2048-IMM** (en principe pris en charge par le notaire au moment de la vente) |
+| Frais réels salariés (option vs abattement 10 %) | Détail à joindre (tableau) |
+
+**Règle de prudence** : en cas de doute sur une annexe, en parler avec un expert-comptable ou un avocat fiscaliste. Oublier une annexe obligatoire peut déclencher un contrôle.
+
+---
+
+## Phase 4 : Vérification et suivi
+
+### Étape 9 : Simulation avant dépôt
+
+**Objectif** : vérifier l'impôt calculé avant validation définitive.
+
+**Outils** :
+
+- Simulateur officiel : impots.gouv.fr (onglet "Simulateur")
+- Avis d'imposition N-1 à titre de comparaison
+- Checklist des points à vérifier (voir ci-dessous)
+
+**Checklist pré-validation** :
+
+- [ ] Nombre de parts de QF cohérent avec la composition du foyer
+- [ ] Plafonnement QF appliqué (si enfants) — gain réel ≤ N × 1 807 €
+- [ ] Décote testée (si impôt brut faible)
+- [ ] Abattement 10 % salaires appliqué (vérifier plancher 509 € / plafond 14 555 €)
+- [ ] Aucune confusion 1AJ / 1AP (salaires vs chômage)
+- [ ] Option PFU / barème choisie explicitement (case 2OP)
+- [ ] PER déduit dans la limite du plafond disponible
+- [ ] Réductions d'impôt ≤ plafond global 10 000 €
+- [ ] CEHR calculée si RFR > seuils (250 / 500 k€ célib, 500 / 1 000 k€ couple)
+- [ ] Toutes les annexes pertinentes sont sélectionnées
+
+### Étape 10 : Vérification de l'avis d'imposition et solde PAS
+
+**Objectif** : contrôler que l'avis reçu (juillet-août) correspond à la simulation et calculer le solde PAS.
+
+**Points à contrôler** :
+
+- Impôt net cohérent avec la simulation pré-dépôt
+- Plafond PER pour l'année suivante (rubrique "Épargne retraite")
+- Revenu fiscal de référence (RFR) — base de nombreux dispositifs sociaux
+- Taux de PAS mis à jour automatiquement
+- Solde PAS à payer ou à rembourser (différence IR dû − PAS prélevé N)
+
+**Actions post-avis** :
+
+- Si solde à payer > 300 € : étalement automatique sur 4 mois (septembre-décembre)
+- Si solde à payer > 50 % de l'IR N-1 : acomptes recalculés sur N+1
+- En cas de désaccord : réclamation sur impots.gouv.fr dans les 3 ans (délai de reprise DGFIP identique)
+
+---
+
+## Calendrier type (revenus 2025 → déclaration 2026)
+
+| Date | Action |
+|------|--------|
+| Décembre 2025 | Dernier versement PER de l'année (effet sur IR 2025) |
+| Janvier-février 2026 | Collecte des IFU, attestations, relevés |
+| Avril 2026 | Ouverture de la déclaration en ligne |
+| Mai-juin 2026 | Date limite selon département |
+| Juillet-août 2026 | Réception de l'avis d'imposition |
+| Septembre 2026 | Solde PAS prélevé si dû |
+| Décembre 2026 | Dernier versement PER pour IR 2026 |
+
+## Pièges fréquents
+
+1. **Oublier un compte étranger** — obligation de déclarer l'ouverture (formulaire 3916) sous peine d'amende 1 500 € par compte.
+2. **Ne pas cocher 2OP** alors que le barème serait favorable au TMI 11 %.
+3. **ARE en 1AJ** — bénéficie à tort de l'abattement 10 %.
+4. **Oublier le quotient** pour un vesting RSU massif.
+5. **Sous-déclarer les cessions crypto** > 305 € — imposition totale sur TOUT.
+6. **Déduire un PER > plafond** — fraction non déductible.
+7. **Annexe 2086 oubliée** dès 1 € de cession crypto > 305 €.
+8. **Plafonnement global des niches (10 000 €)** — excédent perdu.
+
+## Références CGI / BOFiP
+
+- Obligation déclarative : art. 170 CGI
+- Option PFU / barème : art. 200 A CGI
+- Déclaration comptes étrangers : art. 1649 A CGI
+- Revenus fonciers : art. 14 à 33 quinquies CGI
+- BIC LMNP : art. 35 CGI
+- Plus-values mobilières : art. 150-0 A CGI
+- Crypto : art. 150 VH bis CGI
+- BOFiP général : BOI-IR

--- a/fiscaliste/references/deductions-reductions-credits.md
+++ b/fiscaliste/references/deductions-reductions-credits.md
@@ -1,0 +1,172 @@
+# Déductions, réductions et crédits d'impôt
+
+## Distinction fondamentale
+
+Voir `data/niches-fiscales.json` → `distinction_mecanismes`.
+
+| Mécanisme | S'applique sur | Remboursable si excédent ? | Ordre dans le calcul |
+|-----------|---------------|---------------------------|----------------------|
+| **Déduction** | Revenu imposable (avant calcul) | Non applicable | Étape 3 (RNI) |
+| **Réduction** | Impôt calculé | Non — plancher 0 | Étape 9 (après décote) |
+| **Crédit** | Impôt calculé | Oui — remboursé si > impôt dû | Étape 10 (après réductions) |
+
+**Conséquence pratique** : une déduction de 1 000 € à TMI 30% économise 300 €. Une réduction/crédit de 1 000 € économise 1 000 €. Les dispositifs ne sont donc pas équivalents à montant nominal identique.
+
+## Déductions (agissent sur le RNI)
+
+### PER (Plan d'Épargne Retraite)
+
+Voir `references/per.md`.
+
+- Déduction dans la limite du plafond (10% revenus pro, plancher 4 710 €, plafond 37 680 €)
+- Économie immédiate = versement × TMI
+
+### Pension alimentaire
+
+- Versée à un enfant majeur (case 6GI / 6GJ) : plafond annuel à vérifier
+- Versée à un ascendant dans le besoin : plafond distinct
+- **Condition clé** : preuve du besoin du bénéficiaire et du versement effectif
+- Déduction plafonnée
+
+### CSG déductible
+
+- 6,8% de la CSG prélevée sur les revenus du capital
+- **Uniquement si option barème progressif** sur les revenus du capital N-1
+- Imputée sur le RNI de N+1
+- **Zéro sous PFU**
+
+### Autres déductions notables
+
+- Frais réels professionnels (option vs abattement 10% salaires)
+- Charges foncières (régime réel) — voir `references/revenus-fonciers-lmnp.md`
+
+## Réductions d'impôt (agissent sur l'impôt, plancher 0)
+
+### Dispositifs dans le plafond global 10 000 €
+
+Voir `data/niches-fiscales.json` → `dispositifs_dans_plafond`.
+
+| Dispositif | Taux / mécanisme | Particularité |
+|-----------|------------------|---------------|
+| **Pinel** | Réduction étalée sur 6/9/12 ans | En extinction — dernier millésime 2024 |
+| **Denormandie** | Similaire Pinel, ancien avec travaux | Ciblé centres-villes dégradés |
+| **Loc'Avantages** | Selon conventionnement et loyer | Alternative au Pinel |
+| **FCPI / FIP** | 18% à 25% des versements | Plafond versements distinct |
+| **Malraux** | 22% ou 30% des travaux | Hors plafond dans certains cas |
+| **Monuments historiques** | Déduction travaux sans plafond | Conditions strictes (ouverture public) |
+| **Investissement forestier** | 18% des versements | Engagement 8 ans minimum |
+| **Corse / outre-mer** (certaines formes) | Variable | Vérifier plafonds spécifiques |
+
+### Dispositifs hors plafond global
+
+Voir `data/niches-fiscales.json` → `dispositifs_hors_plafond`.
+
+| Dispositif | Taux / mécanisme |
+|-----------|------------------|
+| **Dons associations** | 66% ou 75% (aide aux personnes en difficulté) |
+| **Cotisations syndicales** | 66% |
+| **Girardin industriel outre-mer** | Variable, sous conditions |
+| **Investissement outre-mer** (catégories spécifiques) | Variable |
+
+### Dons aux associations
+
+**Taux standard : 66%** de réduction, dans la limite de 20% du revenu imposable.
+
+**Taux majoré : 75%** pour les dons à des associations d'aide aux personnes en difficulté (Restos du Cœur, Secours Populaire, etc.), dans la limite de **1 000 €** par an. Au-delà : taux 66%.
+
+**Report** : les dons dépassant le plafond de 20% sont reportables sur les 5 années suivantes.
+
+## Crédits d'impôt (remboursables)
+
+### Emploi à domicile
+
+- **Taux : 50%** des dépenses éligibles
+- **Plafond général : 12 000 €** par an (donc crédit max 6 000 €)
+- **Majoration** : +1 500 € par enfant à charge ou personne de + 65 ans dans le foyer (plafond max 15 000 €)
+- **Éligible** : ménage, garde d'enfant à domicile, soutien scolaire, petit bricolage, jardinage, etc.
+- **Entreprise agréée ou emploi direct** avec déclaration URSSAF
+
+**Avance immédiate (depuis 2022)** : possible via CESU+ — l'URSSAF avance le crédit directement, pas d'attente de remboursement.
+
+### Garde d'enfant hors domicile
+
+- **Taux : 50%** des dépenses
+- **Plafond : 3 500 € par enfant** (donc crédit max 1 750 € par enfant)
+- **Âge limite** : enfant de moins de 6 ans au 1er janvier
+- **Éligibles** : crèche, assistante maternelle agréée, garde partagée
+
+### Cotisations syndicales
+
+- **Taux : 66%**
+- **Plafond** : 1% du salaire brut
+- Pour salariés déclarant à l'IR (pas pour les non-imposables)
+
+## Plafonnement global des niches fiscales
+
+Voir `data/niches-fiscales.json` → `plafonnement_global`.
+
+**Plafond : 10 000 €** par an (18 000 € pour investissements outre-mer spécifiques).
+
+**Mécanique** :
+1. Calculer toutes les réductions et crédits éligibles
+2. Distinguer ceux **dans le plafond** vs **hors plafond**
+3. Sommer les "dans le plafond"
+4. Si total > 10 000 € → l'excédent est **perdu** (pas reportable)
+
+**Pièges fréquents** :
+- Cumuler Pinel + FCPI + Girardin sans vérifier le plafond → partie perdue
+- Confondre "dans plafond" et "hors plafond" (les dons et l'emploi à domicile sont hors plafond)
+
+## Ordre d'application (après impôt brut)
+
+```
+Impôt brut après QF et décote
+  ↓ − réductions d'impôt (plancher 0)
+Impôt après réductions
+  ↓ − crédits d'impôt (peut être négatif = remboursement)
+Impôt net final
+```
+
+**Pourquoi distinguer l'ordre** : si l'impôt est déjà faible, une réduction est "perdue" (plancher 0) alors qu'un crédit reste remboursable.
+
+## Stratégies d'optimisation
+
+### 1. Vérifier le plafond global avant de cumuler
+
+Tableau rapide :
+- Pinel + FCPI : à additionner → vérifier ≤ 10 000 €
+- Malraux : peut dépasser le plafond selon les cas
+
+### 2. Privilégier les crédits si non imposable
+
+Un crédit d'impôt (emploi à domicile, garde d'enfant) est **remboursé** même si l'impôt est à 0. Une réduction est perdue dans ce cas.
+
+### 3. Étaler les dons
+
+Dons importants : étaler sur plusieurs années pour rester dans le plafond 20% du revenu imposable et éviter la perte.
+
+### 4. Combiner déduction + crédit
+
+Un même foyer peut :
+- Déduire du PER (réduction RNI)
+- Puis bénéficier de crédits d'impôt sur les dépenses restantes
+
+Les deux jouent sur des couches différentes du calcul.
+
+## Pièges fréquents
+
+1. **Confondre réduction et crédit** → surévaluer l'économie si foyer non imposable
+2. **Oublier le plafond 20% sur les dons** → excédent reporté mais souvent oublié en N+1
+3. **Plafond global mal évalué** → perte silencieuse
+4. **Déduction PER vs réduction FCPI** : ne pas confondre les mécanismes
+5. **Emploi à domicile non déclaré CESU** → pas d'éligibilité au crédit
+
+## Références CGI / BOFiP
+
+- Plafonnement global : art. 200-0 A CGI
+- Dons : art. 200 CGI
+- Emploi à domicile : art. 199 sexdecies CGI
+- Garde d'enfant : art. 200 quater B CGI
+- Pinel : art. 199 novovicies CGI
+- FCPI : art. 199 terdecies-0 A CGI
+- BOFiP : BOI-IR-RICI

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -1,0 +1,162 @@
+# Equity salarial (RSU, BSPCE, stock-options, PEE/PERCO)
+
+Voir `data/equity-salarial.json` pour les taux et seuils.
+
+## RSU (Restricted Stock Units)
+
+### Deux événements fiscaux distincts
+
+**1. Gain d'acquisition (au vesting)**
+- Valeur de l'action à la date d'acquisition
+- **Imposition : traitements et salaires** (case 1TT ou 1UT)
+- Au barème progressif de l'IR
+- Cotisations sociales : CSG/CRDS 9,7% + contribution salariale 10% (sur plans qualifiants, dans certains plafonds)
+
+**2. Plus-value de cession**
+- Valeur de cession − valeur au vesting
+- **Imposition : PV mobilière** (PFU 30% ou barème)
+- Uniquement si cession après vesting
+
+### Plans qualifiants (loi Macron)
+
+Régime de faveur pour la fraction ≤ plafonds (variables selon les plans) :
+- Imposition comme PV mobilière au PFU (pas comme salaire)
+- Abattement 50% possible sur une fraction
+
+Au-delà des plafonds : régime de droit commun (salaire).
+
+### Piège classique
+
+**Traiter le gain RSU comme une PV mobilière classique** → erreur majeure. Le gain au vesting est d'abord :
+1. Salaire (barème)
+2. Soumis à CSG 9,7%
+3. Soumis à contribution salariale 10% (plans qualifiants)
+
+Seule la plus-value ultérieure (valeur vesting → cession) est PV mobilière.
+
+### Stratégie : quotient pour revenus exceptionnels
+
+Un vesting massif (ex: 150 000 € en une seule année) fait franchir plusieurs tranches. Le **quotient pour revenus exceptionnels** (coefficient 4) peut lisser l'imposition.
+
+Voir `references/cas-speciaux.md` → revenus exceptionnels.
+
+**Nuance** : inutile si le foyer est déjà au TMI 45% — le taux marginal ne change pas avec la division.
+
+## Stock-options
+
+### Rabais excédentaire
+
+Différence entre prix du marché à l'attribution et prix d'exercice, au-delà de 5%.
+→ **Imposition comme salaire à l'acquisition**.
+
+### Gain de levée
+
+Selon date d'attribution :
+
+| Plan | Régime |
+|------|--------|
+| Avant 2012 | Barème de faveur (selon durée détention) |
+| 2012-2016 | Salaire (barème IR + cotisations sociales spécifiques) |
+| Après 2017 | Salaire (barème) + contribution salariale 10% sur plans qualifiants |
+
+Toujours consulter le plan pour déterminer le régime applicable.
+
+## BSPCE (Bons de Souscription de Parts de Créateur d'Entreprise)
+
+**Différence clé vs RSU** : pas de gain d'acquisition imposable comme salaire. Le gain n'est réalisé et imposé **qu'à la cession des actions**.
+
+### Imposition du gain de cession
+
+Voir `data/equity-salarial.json` → `bspce.gain_cession`.
+
+| Ancienneté dans la société à la date de cession | Taux global |
+|--------------------------------------------------|-------------|
+| **≥ 3 ans** | 30% (12,8% IR + 17,2% PS) |
+| **< 3 ans** | 50% (30% IR + 20% PS) |
+
+La pénalité pour départ précoce (< 3 ans) est forte. À intégrer dans les décisions de départ.
+
+### Conditions d'éligibilité de la société
+
+À vérifier avant attribution :
+- SA ou SAS française
+- Immatriculée depuis moins de 15 ans
+- Non cotée OU cotée sur compartiment dédié aux PME
+- Soumise à l'IS
+- Capital détenu à 25% minimum par des personnes physiques
+- Non issue d'une restructuration (fusion, scission, reprise d'activité)
+
+**Si conditions non remplies** : requalification en salaires → barème IR + cotisations sociales → traitement beaucoup plus défavorable.
+
+### Vérification préalable recommandée
+
+Demander à la société :
+- Date d'immatriculation au RCS
+- Capital social et répartition (tableau des associés)
+- Régime fiscal (IS obligatoire)
+- Historique des restructurations éventuelles
+
+## Épargne salariale (PEE / PERCO / PERO)
+
+### PEE (Plan d'Épargne Entreprise)
+
+Enveloppe collective distincte du PER individuel.
+
+- **Abondement employeur** : exonéré IR et PS dans les plafonds — **AVANTAGE MAJEUR**
+- **Plafond abondement** : ~3 709 € par bénéficiaire (8% PASS — vérifier annuellement)
+- **Blocage** : 5 ans sauf cas de déblocage anticipé (mariage, naissance 3e enfant, achat RP, divorce avec enfant, fin contrat travail, surendettement, invalidité, décès, violences conjugales)
+- **Sortie après 5 ans** : exonération IR, seuls PS 17,2% sur les gains
+- **Dividendes réinvestis** : exonérés IR tant qu'ils restent dans l'enveloppe
+
+### PERCO / PERO (PER d'entreprise)
+
+- **Sortie à la retraite** : rente ou capital
+- **Fiscalité sortie** : même que PER individuel (versements à barème, gains au PFU)
+- **Abondement employeur** : exonéré dans plafonds (~7 418 €, distinct du plafond PEE)
+
+### Arbitrage PEE/PERCO vs PER individuel
+
+| Enveloppe | Avantage unique | Quand privilégier |
+|-----------|----------------|-------------------|
+| PEE | Abondement employeur (levier +30% à +300%) | D'abord, toujours — tant qu'il y a abondement |
+| PERCO / PERO | Abondement employeur sur épargne retraite | En second après PEE max |
+| PER individuel | Déduction RNI (pas de plafond d'abondement) | En complément, après saturation PEE/PERCO |
+
+**Règle d'or** : ne jamais abonder un PER individuel avant d'avoir saturé l'abondement employeur PEE + PERCO. L'abondement est de l'argent gratuit.
+
+## Quotient pour revenus exceptionnels
+
+Vesting massif, cession d'entreprise, indemnité de départ → à activer.
+
+**Mécanisme** :
+1. Revenu exceptionnel ÷ coefficient (généralement 4)
+2. Ajouter au revenu ordinaire
+3. Calculer l'impôt supplémentaire
+4. × coefficient
+
+**À mentionner systématiquement** pour :
+- Vesting RSU > 1,5 × salaire annuel
+- Cession de parts de société
+- Indemnité de départ importante
+- Prime exceptionnelle massive
+
+**Inutile si** : foyer déjà à TMI 45% (taux marginal identique quelle que soit la division).
+
+## Formulaires
+
+| Revenu | Formulaire / case |
+|--------|-------------------|
+| Gain acquisition RSU (salaire) | 2042 case 1TT / 1UT |
+| Plus-value cession RSU | 2042 C case 3VG (PFU) ou 2074 (détail) |
+| Gain cession BSPCE | 2042 C case 3VG ou 3WB selon ancienneté |
+| Abondement PEE (information) | Déclaration employeur — exonéré |
+| Stock-options | Variable selon plan — consulter le plan |
+
+## Références CGI / BOFiP
+
+- RSU : art. 80 quaterdecies CGI
+- Stock-options : art. 80 bis CGI
+- BSPCE : art. 163 bis G CGI
+- PEE : art. L. 3332-1 et s. Code du travail
+- PER : art. 163 quatervicies CGI
+- BOFiP : BOI-RSA-ES (actionnariat salarié)

--- a/fiscaliste/references/ifi.md
+++ b/fiscaliste/references/ifi.md
@@ -1,0 +1,143 @@
+# IFI (Impôt sur la Fortune Immobilière)
+
+Voir `data/ifi-bareme.json` pour les tranches et paramètres.
+
+## Principe
+
+Impôt annuel sur le patrimoine **immobilier net** du foyer fiscal au **1er janvier**.
+
+**Condition d'assujettissement** : patrimoine immobilier net > 1 300 000 €.
+
+**Particularité** : une fois le seuil franchi, le barème s'applique à partir de **800 000 €** (pas à partir de 1 300 000 €). Mécanisme de décote entre 1 300 000 € et 1 400 000 € pour lisser l'entrée.
+
+## Assiette taxable
+
+### Actif immobilier (à inclure)
+
+- Biens immobiliers détenus directement (résidences, locatifs, terrains)
+- Parts de sociétés civiles (SCI, SCPI) à hauteur de la fraction immobilière
+- Parts de SCPI en direct ou via assurance-vie (fraction immobilière)
+- Immeubles affectés à l'activité professionnelle **du foyer** s'ils ne constituent pas l'outil de travail
+- Droits démembrés (usufruit ou pleine propriété, selon le cas)
+
+### Exonérations principales
+
+| Bien | Régime |
+|------|--------|
+| Résidence principale | **Abattement 30%** sur la valeur vénale |
+| Biens professionnels | Exonération totale si outil de travail (conditions strictes) |
+| Bois, forêts, parts GFA | Exonération partielle (25% imposable) sous engagement 30 ans |
+| LMP | Exonéré comme bien professionnel sous conditions de recettes et de revenus |
+| Location longue durée bail rural | Exonération partielle sous conditions |
+
+**Conditions "biens professionnels"** (article 885 O bis CGI) :
+- Fonction de direction effective
+- Rémunération > 50% des revenus professionnels du foyer
+- Détention > seuil minimum de participation
+
+## Passif déductible
+
+### Dettes déductibles
+
+- Emprunts immobiliers (capital restant dû au 1er janvier)
+- Dettes liées à travaux sur immeubles taxables
+- Impôts afférents à l'immobilier : taxe foncière, IFI N-1, droits de succession/donation
+
+### Dettes NON déductibles
+
+- Dettes personnelles non liées à l'immobilier
+- Emprunts in fine → **amortissement fictif** appliqué (déduction limitée selon un calendrier théorique)
+- Emprunts familiaux sans formalisme (acte non enregistré, pas d'intérêt réel) — article 885 T bis CGI
+
+### Plafonnement du passif
+
+Si le passif total dépasse 60% de la valeur des biens ET > 5 M€, la fraction au-delà n'est déductible qu'à hauteur de 50%.
+
+## Calcul du barème
+
+Voir `data/ifi-bareme.json` → `tranches`.
+
+| Tranche patrimoine net | Taux |
+|------------------------|------|
+| 0 à 800 000 € | 0% |
+| 800 000 à 1 300 000 € | 0,5% |
+| 1 300 000 à 2 570 000 € | 0,7% |
+| 2 570 000 à 5 000 000 € | 1,0% |
+| 5 000 000 à 10 000 000 € | 1,25% |
+| > 10 000 000 € | 1,5% |
+
+### Décote d'entrée
+
+Entre 1 300 000 € et 1 400 000 € : formule `17 500 − 1,25% × valeur_patrimoine_net`.
+
+Évite un effet de seuil brutal à 1 300 000 €.
+
+## Plafonnement global IR + IFI + PS
+
+**Règle des 75%** : le total IR + IFI + PS ne peut pas dépasser 75% des revenus de l'année N-1.
+
+Si dépassement → l'IFI est **réduit de l'excédent**.
+
+**Stratégie** : optimiser les revenus pris en compte (certains revenus exonérés ne comptent pas) pour maximiser le plafonnement.
+
+## Évaluation des biens
+
+### Résidence principale
+
+Valeur vénale au 1er janvier, **moins abattement 30%**.
+
+### Biens locatifs
+
+Valeur vénale — possible décote pour location en cours (bail en place réduit la valeur marchande d'environ 10-20%).
+
+### Parts de SCI / SCPI
+
+Valeur des parts × fraction immobilière. Possible décote pour illiquidité.
+
+### Biens démembrés
+
+- **Usufruit** : valeur pleine propriété × quote-part de l'usufruit selon barème fiscal (article 669 CGI)
+- **Nue-propriété** : pas d'IFI (sauf cas spécifiques : donation avec réserve d'usufruit, nue-propriété issue de démembrement fiscal → règles particulières)
+
+**Exception art. 885 G CGI** : dans certains cas (démembrement volontaire ultérieur), l'usufruitier et le nu-propriétaire sont chacun imposables à hauteur de leur quote-part.
+
+## Déclaration
+
+- Déclaration 2042-IFI jointe à la 2042
+- Annexes : 2042-IFI-K (évaluation des biens)
+- Date limite : même que la déclaration IR
+
+### Documents à préparer
+
+- Évaluation de chaque bien (expertise, estimation, comparables DVF)
+- Relevés bancaires emprunts au 1er janvier
+- Attestations SCPI / SCI
+- Tableau d'amortissement des emprunts in fine
+
+## Pièges fréquents
+
+1. **Oublier l'abattement 30% RP** — perte directe
+2. **Inclure un LMP en patrimoine taxable** — alors qu'il peut être exonéré comme bien professionnel
+3. **Emprunt in fine sans amortissement fictif** — redressement probable
+4. **Évaluer la RP au prix d'achat** au lieu de la valeur vénale actuelle — source de sous-déclaration
+5. **Omettre les SCPI en assurance-vie** — fraction immobilière imposable
+6. **Oublier le plafonnement 75%** — l'IFI peut être réduit si revenus faibles par rapport au patrimoine
+
+## Sanctions
+
+- Défaut ou retard de déclaration : intérêts de retard 0,2%/mois + majoration 10% à 40% selon gravité
+- Sous-évaluation > 10% : redressement + majoration 10%
+- Manquement délibéré : majoration 40%
+- Manœuvres frauduleuses : majoration 80%
+
+**Délai de reprise** : 6 ans pour l'IFI (contre 3 ans pour l'IR dans certains cas).
+
+## Références CGI / BOFiP
+
+- Champ IFI : art. 964 à 983 CGI
+- Résidence principale : art. 973-I CGI
+- Biens professionnels : art. 975 CGI
+- Passif déductible : art. 974 CGI
+- Plafonnement : art. 979 CGI
+- Barème : art. 977 CGI
+- BOFiP : BOI-PAT-IFI

--- a/fiscaliste/references/ir-mecanisme.md
+++ b/fiscaliste/references/ir-mecanisme.md
@@ -1,0 +1,135 @@
+# Mécanisme de l'Impôt sur le Revenu (IR)
+
+## Séquence de calcul (à dérouler intégralement)
+
+L'IR ne s'applique pas directement au revenu global. Il suit une séquence stricte :
+
+```
+1. Revenus bruts par catégorie
+   ↓ abattements spécifiques (10% salaires, 10% pensions, 40% dividendes si barème…)
+2. Revenus nets catégoriels
+   ↓ somme
+3. Revenu brut global
+   ↓ déductions (PER, pension alimentaire, CSG déductible N-1)
+4. Revenu Net Imposable (RNI)
+   ↓ ÷ nombre de parts
+5. Quotient
+   ↓ application du barème progressif
+6. Impôt par part
+   ↓ × nombre de parts
+7. Impôt brut
+   ↓ plafonnement du gain QF
+8. Impôt après QF
+   ↓ décote (si impôt brut < seuil)
+9. Impôt après décote
+   ↓ − réductions d'impôt
+10. Impôt après réductions
+    ↓ − crédits d'impôt (+ remboursement si excédent)
+11. Impôt net
+
++ Prélèvements sociaux (séparés, sur revenus du capital)
++ CEHR (si RFR > seuils)
+= Charge fiscale totale
+```
+
+**Ne jamais sauter d'étape.** Chaque intermédiaire doit être chiffré.
+
+## Point critique : terminologie des salaires
+
+La confusion la plus fréquente concerne le "salaire net imposable".
+
+| Terme | Où on le trouve | Valeur |
+|-------|----------------|--------|
+| Salaire brut | Bulletin de salaire — haut de fiche | Avant cotisations |
+| Salaire net | Bulletin de salaire — versé sur le compte | Après cotisations, mais AVANT CSG non déductible |
+| **Salaire net imposable (1AJ)** | **Bulletin de salaire — ligne dédiée** | **Base déclarée en 1AJ** |
+| RNI (après abattement) | Avis d'imposition | 1AJ × 0,9 (plage standard) |
+
+**Règle** : passer la valeur **1AJ** dans `irpp_calculer_ir` ou dans les simulations. Si l'utilisateur donne la "valeur nette après abattement" ou "le RNI", remonter : `1AJ ≈ RNI ÷ 0,9`.
+
+**En cas de doute, demander** : "Le chiffre que vous me donnez est-il celui du bulletin de salaire (case 1AJ) ou de l'avis d'imposition (RNI) ?"
+
+## Abattements par catégorie de revenu
+
+| Revenu | Case 2042 | Abattement | Source |
+|--------|-----------|-----------|--------|
+| Salaires | 1AJ/1BJ | 10% (min 509 €, max 14 555 €) ou frais réels | data/bareme-ir-2025.json |
+| Pensions / retraites | 1AS/1BS | 10% (min 450 €, max 4 446 €) par foyer | data/bareme-ir-2025.json |
+| Allocations chômage (ARE) | 1AP/1BP | **Aucun abattement** | — |
+| Dividendes (option barème) | 2DC | 40% | data/pfu-prelevements-sociaux.json |
+| Dividendes (PFU) | 2DC | Aucun abattement | — |
+| BNC régime normal | 5QC | Aucun abattement | — |
+| Micro-BNC | 5TE | 34% (plafond 77 700 €) | — |
+
+**Piège classique** : confondre 1AJ (salaires) et 1AP (chômage). L'abattement 10% s'applique uniquement sur 1AJ.
+
+## Application du barème progressif
+
+Utiliser `data/bareme-ir-2025.json` — champ `bareme_ir.tranches`.
+
+**Méthode par part** :
+1. Diviser le RNI par le nombre de parts → quotient
+2. Appliquer le barème progressif tranche par tranche sur le quotient
+3. Multiplier le résultat par le nombre de parts → impôt brut
+
+**Exemple (revenus 2025, célibataire, RNI = 40 000 €, 1 part)** :
+- Quotient = 40 000 €
+- Tranche 0-11 600 € : 0 €
+- Tranche 11 600-29 579 € : (29 579 - 11 600) × 11% = 17 979 × 11% = 1 977,69 €
+- Tranche 29 579-40 000 € : (40 000 - 29 579) × 30% = 10 421 × 30% = 3 126,30 €
+- Impôt brut = 1 977,69 + 3 126,30 = **5 103,99 €**
+
+## Décote
+
+Mécanisme de lissage pour les contribuables à faible impôt. Utiliser `data/bareme-ir-2025.json` — champ `decote`.
+
+**Formules (revenus 2025)** :
+- Célibataire : si impôt_brut < 1 982 € → décote = 897 − 0,4525 × impôt_brut
+- Couple : si impôt_brut < 3 277 € → décote = 1 483 − 0,4525 × impôt_brut
+
+**La décote ne peut pas rendre l'impôt négatif** (plancher à 0).
+
+Elle crée une zone de taux marginal effectif élevé : quand le revenu augmente, la décote baisse, donc le taux effectif marginal est supérieur au taux du barème.
+
+## CEHR (Contribution Exceptionnelle Hauts Revenus)
+
+S'applique sur le **RFR** (revenu fiscal de référence), pas le RNI. S'ajoute à l'IR net.
+
+Voir `data/bareme-ir-2025.json` — champ `cehr`.
+
+Ne jamais oublier dans les simulations hauts revenus : 3% à 4% sur la fraction au-delà des seuils.
+
+## Revenus exceptionnels : quotient
+
+Distinct du quotient familial. Permet de lisser fiscalement un revenu ponctuel exceptionnel (vesting RSU, prime exceptionnelle, indemnité de départ).
+
+**Mécanisme** :
+1. Diviser le revenu exceptionnel par un coefficient (généralement 4)
+2. Ajouter au revenu ordinaire
+3. Calculer l'impôt supplémentaire
+4. Multiplier ce supplément par le coefficient
+
+**Nuance clé** : si le foyer est déjà au TMI maximum (45%), le mécanisme ne procure aucun avantage. Le bénéfice existe uniquement si le revenu exceptionnel ferait franchir une ou plusieurs tranches.
+
+À mentionner systématiquement en cas de vesting RSU important, cession d'entreprise, indemnité de départ.
+
+## Prélèvement à la source (PAS)
+
+Mécanisme de collecte en temps réel — pas d'imposition supplémentaire.
+
+**Points souvent mal compris** :
+- **Taux personnalisé** : calculé par la DGFIP sur N-2 puis N-1. Peut être individualisé au sein du couple.
+- **Taux neutre** : appliqué par défaut si le salarié ne communique pas son taux (équivalent célibataire sans enfant). Peut entraîner sur/sous-prélèvement.
+- **Acomptes** : pour les revenus hors salaires (fonciers, BNC, dividendes), prélevés directement (mensuels ou trimestriels).
+- **Régularisation** : en N+1 lors de la déclaration. Si les revenus changent fortement (vesting, chômage, départ retraite), actualiser le taux en cours d'année sur impots.gouv.fr.
+- **Impact cash-flow** : un vesting RSU en fin d'année peut déclencher un solde à payer significatif en N+1.
+
+## Références CGI / BOFiP
+
+- Barème IR : art. 197 CGI
+- Quotient familial : art. 194-195 CGI
+- Décote : art. 197-4° CGI
+- Abattement 10% salaires : art. 83-3° CGI
+- CEHR : art. 223 sexies CGI
+- Revenus exceptionnels : art. 163-0 A CGI
+- PAS : art. 204 A à 204 N CGI

--- a/fiscaliste/references/pea-assurance-vie.md
+++ b/fiscaliste/references/pea-assurance-vie.md
@@ -1,0 +1,179 @@
+# PEA et Assurance-Vie (fiscalité des rachats)
+
+Voir `data/pea-assurance-vie.json` pour les taux et seuils.
+
+> **Note** : la fiscalité de la transmission de l'assurance-vie (au décès) est couverte par le skill `notaire`. Ce document ne couvre que la fiscalité des rachats de vivant.
+
+## PEA (Plan d'Épargne en Actions)
+
+### Plafonds de versement
+
+| Plan | Plafond |
+|------|---------|
+| PEA classique | 150 000 € |
+| PEA-PME | Variable (à vérifier) — plafond combiné avec PEA ≤ 225 000 € |
+| PEA jeune (enfant majeur rattaché) | 20 000 € |
+
+Les plafonds concernent les **versements**, pas la valeur du plan. Un plan peut dépasser 150 000 € de valorisation grâce aux gains.
+
+### Fiscalité selon ancienneté du plan
+
+#### Avant 5 ans
+
+- **Tout retrait entraîne la clôture** du plan
+- Imposition des gains au **PFU 30%** (ou barème sur option globale)
+
+**Exceptions** (clôture sans pénalité) :
+- Licenciement, invalidité, mise à la retraite
+- Création/reprise d'entreprise (réinvestissement dans les 3 mois)
+
+#### Après 5 ans
+
+- **Retraits libres** sans clôture du plan
+- **EXONÉRATION TOTALE d'IR** sur les gains
+- **Prélèvements sociaux 17,2%** dus sur les gains à chaque retrait
+
+### Taux historiques PS
+
+Les gains acquis avant certaines dates peuvent bénéficier de taux PS historiques plus faibles (par couches, selon l'historique des taux). Point technique rarement exploité manuellement — le PEA applique automatiquement la règle.
+
+### Composition éligible
+
+- Actions européennes (UE + EEE)
+- OPCVM investis à 75% minimum en actions européennes
+- Certaines ETF européens (vérifier l'éligibilité)
+
+**Non éligibles** : actions américaines, asiatiques, obligations, or, crypto.
+
+### Arbitrage PEA vs assurance-vie
+
+| Critère | PEA | AV |
+|---------|-----|-----|
+| Exonération IR | **Oui** après 5 ans | Non (abattement seulement) |
+| PS sur gains | 17,2% à chaque retrait | 17,2% PFU ou barème |
+| Composition | Actions EUR uniquement | Libre (actions, obligations, fonds €) |
+| Retrait avant échéance | Clôture avant 5 ans | Libre à tout moment |
+| Transmission | Dans succession classique | Régime spécifique (voir notaire) |
+| Plafond | 150 000 € | Aucun |
+
+**Stratégie de cumul** :
+- PEA pour la performance actions européennes (fiscalité imbattable après 5 ans)
+- AV pour la diversification (fonds €, UC mondiales) et la transmission
+
+## Assurance-Vie : fiscalité des rachats
+
+### Principe de proportionnalité
+
+**Un rachat partiel NE retire PAS que du capital non imposable.** Il retire une fraction **proportionnelle** de gains et de capital.
+
+**Formule** :
+```
+quote_part_gains_imposable = (gains_totaux / valeur_totale_contrat) × montant_racheté
+```
+
+**Exemple** :
+- Contrat : versements 80 000 € + gains 20 000 € = valeur totale 100 000 €
+- Rachat de 10 000 €
+- Quote-part gains imposable = (20 000 / 100 000) × 10 000 = **2 000 €**
+- 8 000 € sont du capital (non imposable), 2 000 € sont du gain (imposable)
+
+**Piège classique** : croire qu'un rachat de 10 000 € sur un contrat avec 20 000 € de gains retire d'abord du capital (0 imposable). Non.
+
+### Abattement annuel après 8 ans
+
+Voir `data/pea-assurance-vie.json` → `assurance_vie_rachats.abattement_annuel_apres_8_ans`.
+
+| Situation | Abattement annuel |
+|-----------|-------------------|
+| Célibataire, veuf, divorcé | 4 600 € |
+| Couple (imposition commune) | 9 200 € |
+
+**Condition** : 8 ans d'ancienneté du **contrat** (pas des versements).
+
+**Mécanique** : l'abattement s'applique sur la quote-part de gains imposable, pas sur le montant racheté.
+
+**Renouvelable** : chaque année civile (pas glissant sur 12 mois).
+
+### Taux d'imposition selon date des versements
+
+#### Versements avant le 27 septembre 2017
+
+Taux dégressif selon ancienneté du contrat. Prélèvement libératoire (PFL) optionnel :
+
+| Ancienneté du contrat | PFL | Barème (option) |
+|-----------------------|-----|-----------------|
+| < 4 ans | 35% | Barème |
+| 4-8 ans | 15% | Barème |
+| > 8 ans | 7,5% (après abattement) | Barème (après abattement) |
+
+#### Versements après le 27 septembre 2017
+
+**Règle** : PFU 30% sur les gains, avec modulation selon encours et ancienneté.
+
+| Situation | Taux |
+|-----------|------|
+| Contrat < 8 ans | PFU 30% (12,8% IR + 17,2% PS) |
+| Contrat ≥ 8 ans, encours < 150 000 € | PFU 24,7% (7,5% IR + 17,2% PS) après abattement |
+| Contrat ≥ 8 ans, encours ≥ 150 000 € | PFU 30% sur la fraction au-delà de 150 000 € de **versements nets** |
+
+**Seuil 150 000 €** : s'apprécie sur l'ensemble des contrats AV du foyer, au moment du rachat.
+
+### Option barème
+
+**Avantageuse si TMI ≤ 11%** — le barème peut être meilleur que le PFU après 8 ans (car abattement annuel + taux IR faible).
+
+Option **globale** et irrévocable pour l'année.
+
+### Contrats très anciens (avant 1983)
+
+Régime de faveur pour les contrats souscrits **avant le 1er janvier 1983** : exonération totale d'IR sur les gains.
+
+Extrêmement rare — à vérifier si le contrat est très ancien.
+
+## Stratégies courantes
+
+### 1. Rachats après 8 ans optimisés
+
+Fractionner les rachats pour rester dans l'abattement annuel (9 200 € couple).
+
+Exemple : besoin de 50 000 € sur 5 ans → 10 000 € par an optimise l'abattement (si gains ≤ abattement par rachat).
+
+### 2. Arbitrage UC vs fonds €
+
+- Fonds € : rendement faible mais sécurité + PS au fil de l'eau (CSG/CRDS en année N sur les intérêts crédités)
+- UC : rendement potentiel + PS uniquement au rachat (pas au fil de l'eau)
+
+### 3. Ouvrir un contrat tôt pour prendre date
+
+L'ancienneté compte. Un contrat ouvert avec 100 € prend date → 8 ans plus tard, l'abattement est disponible.
+
+## Déclaration
+
+### Rachats PEA
+
+- Pas de déclaration spécifique tant que le plan n'est pas clôturé
+- À la clôture : 2042 case 3VT (gains PEA imposables)
+- PS prélevés par l'établissement
+
+### Rachats AV
+
+- 2042 case 2CG (gains imposables au PFU)
+- 2042 case 2BH (gains imposables au barème si option)
+- Attestation annuelle de l'assureur requise
+
+## Pièges fréquents
+
+1. **Oublier la proportionnalité** → surévaluer ce qu'on peut retirer "sans impôt"
+2. **8 ans du versement** au lieu du contrat → mauvais calcul
+3. **Seuil 150 000 € en global** (tous contrats AV du foyer), pas par contrat
+4. **Option barème irrévocable** pour l'année
+5. **Retrait PEA avant 5 ans** pour un petit besoin → clôture automatique
+6. **PEA composé d'actions non éligibles** → régularisation DGFIP possible
+
+## Références CGI / BOFiP
+
+- PEA : art. 163 quinquies D CGI, art. L. 221-30 Code monétaire et financier
+- Assurance-vie fiscalité rachats : art. 125-0 A CGI
+- Abattement annuel AV : art. 125-0 A-I-2° CGI
+- Seuil 150 000 € : art. 125-0 A-I-2° bis CGI
+- BOFiP : BOI-RPPM-RCM-40-50 (PEA) et BOI-RPPM-RCM-20-10-20-50 (AV)

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -1,0 +1,146 @@
+# PER (Plan d'Épargne Retraite) individuel
+
+Voir `data/per-plafonds.json` pour les plafonds et paramètres.
+
+## Mécanisme de déduction
+
+Le versement PER **réduit le RNI** de l'année de versement.
+
+```
+RNI avant PER
+  − versement PER (dans la limite du plafond)
+= RNI après PER
+  ÷ nombre de parts
+= Quotient → barème → impôt brut réduit
+```
+
+**Économie d'impôt immédiate** = versement × TMI.
+
+Exemple : versement 5 000 €, TMI 30% → économie IR = 1 500 €.
+
+## Plafond de déduction
+
+### Formule
+
+**Plafond = 10% des revenus professionnels nets** de l'année N-1 (salaires après abattement 10%, BNC, BIC — pas les revenus du capital).
+
+### Bornes (revenus 2025)
+
+| Borne | Valeur | Base |
+|-------|--------|------|
+| Plancher | 4 710 € | 10% × PASS 2025 |
+| Plafond absolu | 37 680 € | 10% × 8 × PASS 2025 |
+
+**Plancher garanti** même sans revenus professionnels → toujours au moins 4 710 € déductibles.
+
+### Report des plafonds non utilisés
+
+Les plafonds non utilisés des **3 années précédentes** sont mobilisables. Ordre : plafond de l'année en cours d'abord, puis plafonds N-3, N-2, N-1 (ordre FIFO — le plus ancien en premier).
+
+**Exemple** :
+- Plafond N : 5 000 €, utilisé 3 000 € → reste 2 000 € reportables sur N+1 à N+3
+- Au-delà de N+3, le plafond non utilisé est **perdu**
+
+### Mutualisation couple
+
+Les époux/pacsés soumis à imposition commune peuvent **mutualiser leurs plafonds** (case à cocher sur 2042). Un conjoint sans revenu pro peut bénéficier du plafond inemployé de l'autre.
+
+## Arbitrage : le PER est-il vraiment utile ?
+
+**Le PER est un REPORT d'imposition, pas une exonération.**
+
+À la sortie, les versements sont imposés comme revenu (barème). Les gains sont imposés au PFU.
+
+### Gagnant / perdant
+
+| Situation | Résultat |
+|-----------|----------|
+| TMI entrée > TMI sortie | **Gain net** — économie à l'entrée > imposition sortie |
+| TMI entrée = TMI sortie | **Neutre fiscalement** — seul l'effet capitalisation sur l'économie initiale joue |
+| TMI entrée < TMI sortie | **Perte nette** — rare mais possible (carrière ascendante, sortie capital massif) |
+
+### Cas typiques favorables
+
+- **Actif TMI 30-41% avec retraite estimée TMI 11-30%** : gain net substantiel
+- **Année de revenus exceptionnels** : versement pour écraser l'IR de l'année, sortie étalée plus tard
+- **Quotient pour revenus exceptionnels + PER** : combinaison puissante pour un vesting RSU important
+
+### Cas défavorables ou neutres
+
+- **TMI 11% stable** : intérêt marginal — seul l'effet capitalisation compte
+- **TMI 45% stable (hauts revenus à la retraite)** : pas d'avantage, imposition identique entrée/sortie
+- **Horizon court (< 10 ans avant retraite)** : peu d'effet de capitalisation
+
+## Sortie du PER
+
+### Sortie à la retraite
+
+**Deux options au choix** :
+
+1. **Sortie en rente viagère**
+   - Imposition comme pension (barème + abattement 10% plafonné)
+   - Prélèvements sociaux 9,1%
+   - Protection en cas de longévité
+
+2. **Sortie en capital**
+   - **Versements déduits à l'entrée** : imposés au barème progressif (part capital)
+   - **Gains** : imposés séparément au PFU 30%
+   - Possibilité de fractionner la sortie sur plusieurs années (à demander à l'assureur)
+
+**Piège sortie capital** : ne pas confondre le régime du capital (barème, écrase la tranche) et celui des gains (PFU fixe). Bien distinguer.
+
+### Versements non déduits (cas rare)
+
+Si l'on a choisi de ne pas déduire les versements (case à cocher à la souscription) :
+- Sortie partiellement exonérée
+- Seuls les gains sont imposés (PFU)
+- Utile si on anticipe un TMI sortie > TMI entrée — rare
+
+### Sortie anticipée autorisée
+
+Cas de déblocage avant la retraite (sans pénalité fiscale sur le capital) :
+- Achat de la résidence principale
+- Décès du conjoint / partenaire PACS
+- Invalidité
+- Surendettement
+- Fin des droits au chômage
+- Cessation d'activité non salariée après jugement de liquidation
+
+Hors ces cas : déblocage impossible (capital bloqué jusqu'à la retraite).
+
+## Mécanique pratique
+
+### Variable V_BTPERPTOTV / V_BTPERPTOTC
+
+Le moteur de calcul DGFIP (Mlang / `irpp-mcp`) exige la variable `V_BTPERPTOTV` (ou V_BTPERPTOTC pour le conjoint) qui représente le **plafond disponible**.
+
+**Sans cette variable, le moteur annule la déduction** — c'est un piège connu.
+
+Le serveur `irpp-mcp` calcule le plafond automatiquement depuis les revenus de l'année courante (cas simplifié : pas de report des années précédentes).
+
+### Déclaration
+
+- Versements : case 6NS (déclarant 1) / 6NT (déclarant 2) sur la 2042
+- Plafond calculé automatiquement par la DGFIP (figure sur l'avis d'imposition N-1, rubrique "Plafond pour l'épargne retraite")
+
+## Différence PER individuel vs PERCO / PERO
+
+Voir `references/equity-salarial.md` pour le détail.
+
+**Règle d'or** : toujours saturer l'abondement employeur (PEE + PERCO) AVANT d'abonder un PER individuel. L'abondement est de l'argent gratuit.
+
+## Pièges fréquents
+
+1. **Oublier le plafond** : versement > plafond → fraction non déductible (mais remboursable sans frais ou reportable selon le contrat)
+2. **Sortie en capital sur un TMI 45%** : imposition quasi équivalente à un revenu normal — intérêt limité
+3. **Mutualisation couple oubliée** : conjoint sans revenu laisse 4 710 € de plafond inemployé
+4. **Assurer le plafond N-1 sur l'avis** : ne pas se fier aux calculs manuels, utiliser le plafond officiel DGFIP
+5. **PER individuel avant PEE/PERCO** : manque l'abondement employeur
+
+## Références CGI / BOFiP
+
+- PER individuel : art. 163 quatervicies CGI
+- Plafond de déduction : art. 163 quatervicies-I-2 CGI
+- Sortie en capital : art. 158-5-b bis CGI
+- Mutualisation couple : art. 163 quatervicies-I-2° CGI
+- BOFiP : BOI-IR-BASE-20-50-20

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -108,15 +108,21 @@ Cas de déblocage avant la retraite (sans pénalité fiscale sur le capital) :
 
 Hors ces cas : déblocage impossible (capital bloqué jusqu'à la retraite).
 
+## Priorité absolue : abondement employeur avant PER individuel
+
+**Avant tout versement PER individuel, vérifier que l'abondement PEE / PERCO de l'employeur est saturé.**
+
+L'abondement est un complément versé par l'entreprise pour chaque euro versé par le salarié sur son PEE ou son PERCO — typiquement 50 à 300 % du versement salarié, dans une limite annuelle (8 % du PASS pour le PEE, 16 % du PASS pour le PERCO).
+
+| Dispositif | Avantage |
+|------------|----------|
+| **PEE + abondement** | Prime gratuite de l'employeur + exonération IR sur l'abondement + PFU 17,2 % à la sortie (pas 30 %) |
+| **PERCO + abondement** | Idem + blocage jusqu'à la retraite |
+| **PER individuel** | Uniquement économie d'impôt immédiate × TMI, pas de match employeur |
+
+**Règle** : un abondement employeur de 100 % représente un rendement immédiat de 100 %. Aucune défiscalisation PER n'égale ce rendement. Toujours saturer PEE/PERCO en premier si l'option existe.
+
 ## Mécanique pratique
-
-### Variable V_BTPERPTOTV / V_BTPERPTOTC
-
-Le moteur de calcul DGFIP (Mlang / `irpp-mcp`) exige la variable `V_BTPERPTOTV` (ou V_BTPERPTOTC pour le conjoint) qui représente le **plafond disponible**.
-
-**Sans cette variable, le moteur annule la déduction** — c'est un piège connu.
-
-Le serveur `irpp-mcp` calcule le plafond automatiquement depuis les revenus de l'année courante (cas simplifié : pas de report des années précédentes).
 
 ### Déclaration
 

--- a/fiscaliste/references/quotient-familial.md
+++ b/fiscaliste/references/quotient-familial.md
@@ -1,0 +1,123 @@
+# Quotient familial et plafonnement
+
+## Calcul des parts
+
+Le quotient familial réduit le revenu taxable en augmentant le nombre de parts.
+
+### Parts de base selon situation
+
+| Situation | Parts de base |
+|-----------|--------------|
+| Célibataire, divorcé, séparé | 1 |
+| Marié, pacsé (imposition commune) | 2 |
+| Veuf sans enfant | 1 |
+| Veuf avec enfant(s) | 2 (+ parts enfants) |
+
+### Majoration pour enfants à charge
+
+| Rang de l'enfant | Parts ajoutées |
+|------------------|----------------|
+| 1er enfant | +0,5 |
+| 2ème enfant | +0,5 |
+| 3ème enfant et suivants | +1 chacun |
+
+**Cas particuliers** :
+- Enfant en résidence alternée : moitié des valeurs ci-dessus (0,25 / 0,25 / 0,5)
+- Enfant invalide (carte CMI-invalidité) : +0,5 part supplémentaire
+- Parent isolé (case T, divorcé/veuf élevant seul des enfants) : +0,5 part sur le premier enfant
+
+### Exemples
+
+| Foyer | Parts |
+|-------|-------|
+| Célibataire sans enfant | 1 |
+| Célibataire, 1 enfant | 1,5 (ou 2 si parent isolé) |
+| Marié, 0 enfant | 2 |
+| Marié, 2 enfants | 3 (2 + 0,5 + 0,5) |
+| Marié, 3 enfants | 4 (2 + 0,5 + 0,5 + 1) |
+| Marié, 1 enfant + 1 en résidence alternée | 2,75 (2 + 0,5 + 0,25) |
+
+## Plafonnement du gain QF
+
+**Mécanisme critique souvent oublié.** Le gain d'impôt lié aux demi-parts supplémentaires (enfants) est plafonné.
+
+### Algorithme de vérification
+
+```
+impôt_avec_parts_pleines = calcul normal avec toutes les parts
+impôt_sans_enfants       = calcul avec parts de base seulement (1 ou 2)
+gain_réel = impôt_sans_enfants − impôt_avec_parts_pleines
+
+plafond_par_demi_part = 1 807 €  (revenus 2025, voir data/bareme-ir-2025.json)
+nb_demi_parts_supp = (nb_parts − parts_de_base) × 2
+gain_max = plafond_par_demi_part × nb_demi_parts_supp
+
+impôt_final = impôt_sans_enfants − min(gain_réel, gain_max)
+```
+
+### Conséquence pratique
+
+Au-delà d'un certain seuil de revenu, **l'avantage fiscal stagne** même si le revenu augmente. Les enfants cessent de réduire l'impôt proportionnellement.
+
+**Exemple (marié, 2 enfants, 2025)** :
+- Parts pleines : 3 parts
+- Demi-parts supplémentaires : (3 − 2) × 2 = 2 demi-parts
+- Gain maximum : 2 × 1 807 € = **3 614 €**
+
+Au-delà d'environ 90-100 k€ de RNI, le plafond devient actif et le gain QF stagne à 3 614 €.
+
+### Pièges fréquents
+
+1. **Oublier le plafonnement** : calculer l'IR avec 3 parts sans comparer au calcul à 2 parts + plafond.
+2. **Appliquer le plafonnement sur 1 part** : non, il s'applique sur les demi-parts **supplémentaires** à la situation de base.
+3. **Parent isolé** : la demi-part du parent isolé (case T) a son propre plafond, distinct.
+
+## Décote
+
+Mécanisme distinct du QF, appliqué **après** le plafonnement.
+
+### Formules (revenus 2025)
+
+Voir `data/bareme-ir-2025.json` → champ `decote`.
+
+- **Célibataire** : si impôt_brut < 1 982 € → décote = 897 − 0,4525 × impôt_brut
+- **Couple** : si impôt_brut < 3 277 € → décote = 1 483 − 0,4525 × impôt_brut
+
+### Ordre d'application
+
+```
+Impôt brut (après barème)
+  ↓ plafonnement QF
+Impôt après QF
+  ↓ décote (si applicable)
+Impôt après décote
+  ↓ réductions puis crédits
+Impôt net
+```
+
+### Particularité : taux marginal effectif élevé
+
+Dans la zone de décote, chaque euro supplémentaire de revenu :
+- Augmente l'impôt au taux du barème
+- Diminue la décote de 0,4525 × ce supplément
+
+Taux marginal effectif ≈ (taux_barème × 1,4525). Un foyer à la tranche 11% peut subir un taux marginal effectif proche de 16% dans la zone de décote.
+
+## Parent isolé (case T)
+
+Majoration de 0,5 part pour les contribuables vivant seuls et élevant des enfants.
+
+**Conditions** :
+- Célibataire, divorcé ou séparé au 1er janvier
+- Assume la charge exclusive ou principale d'au moins un enfant
+- N'est pas en concubinage
+
+**Plafonnement spécifique** : la demi-part "T" a son propre plafond (distinct du plafond par demi-part "enfant classique"). Vérifier sur impots.gouv.fr.
+
+## Références CGI / BOFiP
+
+- Parts : art. 194 à 195 CGI
+- Plafonnement QF : art. 197-2 CGI
+- Décote : art. 197-4° CGI
+- Parent isolé : art. 194-II CGI
+- BOFiP : BOI-IR-LIQ-10-20-20 et BOI-IR-LIQ-20-20-30

--- a/fiscaliste/references/revenus-capital.md
+++ b/fiscaliste/references/revenus-capital.md
@@ -1,0 +1,118 @@
+# Revenus du capital (RCM, dividendes, plus-values mobilières)
+
+## PFU vs barème : l'arbitrage fondamental
+
+Les revenus mobiliers (dividendes, intérêts, plus-values de titres) sont soumis au choix :
+
+| Régime | Taux | Caractéristiques |
+|--------|------|------------------|
+| **PFU (flat tax)** | 30% (12,8% IR + 17,2% PS) | Par défaut. Pas d'abattement. Pas de CSG déductible. |
+| **Barème progressif** | Selon TMI | Sur option **globale** (tous les revenus du capital de l'année). Abattement 40% sur dividendes. CSG déductible 6,8% en N+1. |
+
+Voir `data/pfu-prelevements-sociaux.json` pour les taux exacts.
+
+### Règles d'orientation rapide
+
+| TMI | Recommandation | Raison |
+|-----|---------------|--------|
+| 0% ou 11% | Barème | Tranche basse + abattement 40% dividendes + CSG déductible |
+| 30% | À chiffrer | Selon composition : dividendes (abattement 40%) vs intérêts/PV (pas d'abattement) |
+| 41% ou 45% | PFU | Flat tax 12,8% < TMI 41%/45% |
+
+**Règle absolue** : l'option barème est **globale et irrévocable pour l'année**. Elle engage TOUS les revenus du capital du foyer. Ne jamais recommander sans avoir vérifié la composition complète.
+
+### Exemple de calcul comparatif
+
+Foyer célibataire, TMI 30%, dividendes 10 000 € :
+
+**Sous PFU** :
+- IR : 10 000 × 12,8% = 1 280 €
+- PS : 10 000 × 17,2% = 1 720 €
+- Total : 3 000 €
+
+**Sous barème** :
+- Assiette IR : 10 000 × (1 − 0,40) = 6 000 €
+- IR : 6 000 × 30% = 1 800 €
+- PS : 10 000 × 17,2% = 1 720 €
+- CSG déductible N+1 : 10 000 × 6,8% × 30% (économie) = 204 € (N+1)
+- Total net : 3 520 − 204 = **3 316 €**
+
+→ Ici, PFU avantageux (3 000 € < 3 316 €) malgré l'abattement 40%.
+
+Mais si le même foyer a aussi **5 000 € de PV mobilière** sans abattement :
+- PFU : 5 000 × 30% = 1 500 €
+- Barème : 5 000 × 30% IR + 5 000 × 17,2% PS = 2 360 €
+- → PFU toujours plus favorable
+
+## Types de revenus du capital
+
+### Dividendes (case 2DC)
+
+- Par défaut : PFU 30%
+- Option barème : abattement 40% puis IR barème + PS 17,2%
+- **Dividendes étrangers** : peuvent avoir été soumis à une retenue à la source dans le pays d'origine — crédit d'impôt possible sous convention fiscale
+
+### Intérêts, RCM (case 2TR)
+
+- Obligations, crowdfunding immobilier (intérêts), livrets fiscalisés, comptes à terme
+- Soumis au PFU par défaut ou barème sur option
+- **Pas d'abattement** — contrairement aux dividendes
+- **Crowdfunding immobilier** : imposé comme RCM, pas comme revenus fonciers, même si sous-jacent immobilier
+- **Livrets réglementés** (Livret A, LDDS, LEP) : exonérés d'IR et de PS → à ne pas confondre
+
+### Plus-values mobilières (case 3VG)
+
+- Gain net de cession de titres (actions, parts sociales, OPC)
+- PFU par défaut ou barème sur option
+- Voir `data/plus-values-mobilieres-crypto.json` pour détails
+- **Abattements durée de détention** : uniquement pour titres acquis **avant 2018** ET option barème
+- **Abattement dirigeant retraite** : 500 000 € forfaitaires sous conditions strictes (cession de titres, départ en retraite)
+
+### Crypto-actifs
+
+Voir `references/crypto.md` — régime distinct (méthode PAMC, formulaire 2086).
+
+## Prélèvements sociaux : couche distincte de l'IR
+
+**À ne jamais confondre avec l'IR.** Les PS sont prélevés en plus sur la quasi-totalité des revenus du capital.
+
+- Taux global : 17,2% (ou 18,6% selon LFSS 2026 — vérifier)
+- Composition : CSG + CRDS + prélèvement de solidarité
+- **Sous PFU** : PS inclus dans le taux global de 30%
+- **Sous barème** : PS séparés de l'IR (mais CSG 6,8% déductible en N+1)
+
+**Exceptions de taux (17,2% au lieu du taux courant)** :
+- AV et contrats de capitalisation anciens
+- CEL/PEL ouverts avant le 31/12/2017
+- PEP
+
+### CSG déductible
+
+- Montant : 6,8% de la base
+- **Condition** : uniquement sous option barème progressif
+- **Zéro déductible sous PFU**
+- Imputée en N+1 sur le RNI → économie = CSG déductible × TMI N+1
+
+## Enveloppes fiscales spécifiques
+
+Voir `references/pea-assurance-vie.md` pour le détail du PEA et de l'AV (rachats).
+
+**PEA** : exonération IR après 5 ans, PS 17,2% restent dus.
+**AV** : abattement annuel après 8 ans, fiscalité selon date des versements.
+
+## Pièges fréquents
+
+1. **Confondre IR et PS** dans une simulation — conduit à sous-estimer la charge d'environ 17 points.
+2. **Oublier l'option barème globale** — choisir le barème pour les dividendes implique le barème aussi pour les intérêts et PV mobilières.
+3. **CSG déductible sous PFU** — elle n'existe pas.
+4. **Abattement 40% sous PFU** — n'existe que sous barème.
+5. **Retenue à la source étrangère** — créditer contre l'IR français (conventions fiscales) — à ne pas oublier.
+
+## Références CGI / BOFiP
+
+- PFU : art. 200 A CGI
+- Option barème : art. 200 A-2 CGI
+- Abattement dividendes 40% : art. 158-3° CGI
+- Plus-values mobilières : art. 150-0 A à 150-0 D CGI
+- Prélèvements sociaux : art. L. 136-1 et s. CSS
+- BOFiP : BOI-RPPM-RCM (dividendes/RCM) et BOI-RPPM-PVBMI (PV mobilières)

--- a/fiscaliste/references/revenus-fonciers-lmnp.md
+++ b/fiscaliste/references/revenus-fonciers-lmnp.md
@@ -1,0 +1,140 @@
+# Revenus fonciers, LMNP et SCI à l'IR
+
+## Distinction fondamentale
+
+| Type de location | Régime fiscal | Catégorie |
+|------------------|---------------|-----------|
+| Non meublée (location nue) | Revenus fonciers | Revenus fonciers (micro ou réel) |
+| Meublée non professionnelle | **BIC** | LMNP (micro-BIC ou réel) |
+| Meublée professionnelle | **BIC** | LMP (réel obligatoire) |
+| SCI à l'IR | Revenus fonciers | Transparence fiscale |
+| SCI à l'IS | IS | **Hors scope fiscaliste** — voir skill `comptable` |
+
+**Erreur classique** : déclarer une location meublée en revenus fonciers. Non — le meublé relève des BIC. Conséquences fiscales très différentes (amortissements possibles en réel).
+
+## Revenus fonciers (location nue)
+
+### Micro-foncier (régime simplifié)
+
+Voir `data/regimes-fonciers-lmnp.json` → `micro_foncier`.
+
+- **Condition** : revenus fonciers bruts ≤ 15 000 €
+- **Abattement** : 30% automatique
+- **Exclusions** : SCI, monuments historiques, Pinel, Borloo, Malraux, etc.
+- **Avantage** : simplicité. Pas de comptabilité.
+- **Inconvénient** : aucun déficit possible. Si vos charges réelles > 30%, vous payez trop d'impôt.
+
+### Régime réel
+
+Obligatoire au-delà de 15 000 € bruts ou sur option irrévocable pour 3 ans.
+
+**Charges déductibles** :
+- Intérêts d'emprunt (imputables uniquement sur les revenus fonciers)
+- Travaux d'entretien, réparation, amélioration (pas construction, pas agrandissement)
+- Taxe foncière (hors TEOM récupérable)
+- Primes d'assurance (PNO, GLI)
+- Frais de gestion (agence, syndic fraction non récupérable)
+- Provisions pour charges de copropriété
+
+**Piège travaux** : les travaux de construction, reconstruction, agrandissement **NE SONT PAS** déductibles des revenus fonciers — ils majorent seulement le prix d'acquisition pour la future plus-value.
+
+### Déficit foncier
+
+Voir `data/regimes-fonciers-lmnp.json` → `regime_reel_foncier.deficit_foncier`.
+
+**Mécanisme** :
+- Charges > recettes → déficit
+- **Imputable sur le revenu global dans la limite de 10 700 €** par an (ou 21 400 € pour travaux de rénovation énergétique globale — dispositif temporaire)
+- Au-delà : reportable sur les revenus fonciers des **10 années suivantes**
+- **Exception critique** : les intérêts d'emprunt **ne sont JAMAIS imputables sur le revenu global**, uniquement sur les revenus fonciers
+
+**Stratégie d'optimisation** :
+- Concentrer les travaux importants sur une année → déficit imputable sur revenu global
+- Attention à ne pas vendre le bien avant 3 ans après imputation (sinon reprise du déficit)
+
+## LMNP (Location Meublée Non Professionnelle)
+
+### Régime micro-BIC
+
+Voir `data/regimes-fonciers-lmnp.json` → `micro_bic_lmnp`.
+
+**Réforme loi Le Meur (nov. 2024), applicable revenus 2025** — la distinction clé est désormais **classé / non classé**, plus résidence principale.
+
+| Type de location | Seuil | Abattement |
+|------------------|-------|-----------|
+| LMNP longue durée | 77 700 € | 50% |
+| Meublé de tourisme classé | 77 700 € | 50% |
+| **Meublé de tourisme non classé** | **15 000 €** | **30%** |
+
+Au-delà des plafonds : régime réel obligatoire.
+
+### Régime réel LMNP
+
+**Principe** : résultat BIC = recettes − charges − **amortissements**.
+
+**Amortissements** :
+- Bien immobilier : 2-3%/an sur 25-40 ans (hors terrain, terrain non amortissable)
+- Mobilier : 10-20%/an sur 5-10 ans
+- Gros travaux : amortissables sur leur durée d'usage
+
+**Résultat fiscal** : souvent nul ou déficitaire grâce aux amortissements → pas d'IR sur les loyers pendant des années.
+
+**Déficit LMNP** : NON imputable sur le revenu global (contrairement au LMP). Reportable sur les BIC meublés des **10 années suivantes**.
+
+### Bascule LMP vs LMNP
+
+Voir `data/regimes-fonciers-lmnp.json` → `lmp_vs_lmnp`.
+
+**Conditions LMP (cumulatives)** :
+1. Recettes meublées > 23 000 €
+2. ET recettes meublées > 50% des autres revenus professionnels du foyer (salaires + BNC + BIC + rémunérations dirigeant)
+
+**Conséquences LMP** :
+- Déficits imputables sur le revenu global
+- Plus-values professionnelles (exonération possible après 5 ans sous conditions de recettes)
+- Cotisations sociales TNS sur le bénéfice (SSI) — charge significative
+- Biens exonérés d'IFI comme biens professionnels (sous conditions)
+
+**Attention bascule involontaire** : une baisse des revenus professionnels (chômage, retraite) peut faire basculer en LMP malgré des loyers inchangés. À surveiller.
+
+## SCI à l'IR
+
+Voir `data/regimes-fonciers-lmnp.json` → `sci_ir`.
+
+**Régime par défaut** : transparence fiscale.
+
+- Les revenus et charges remontent directement dans la déclaration de chaque associé au prorata des parts
+- Nature fiscale : revenus fonciers classiques (micro ou réel selon le total fonciers du foyer)
+- Cession des parts ou du bien : régime des plus-values immobilières des particuliers
+- L'amortissement **n'est PAS possible** (contrairement à la SCI à l'IS)
+
+**Quand choisir SCI IR** :
+- Transmission patrimoniale (démembrement, donation de parts)
+- Location nue (meublé en SCI = risque de requalification IS)
+- Détention longue (exonération PV immo à 22 ans IR / 30 ans PS)
+
+**Quand choisir SCI IS (hors scope)** :
+- Fort rendement locatif et réinvestissement
+- Possibilité d'amortir le bien
+- Piège : à la cession, PV calculée sur valeur nette comptable (après amortissements) → imposition forte
+
+→ Pour SCI à l'IS, voir skill `comptable`.
+
+## Formulaires
+
+| Régime | Formulaire |
+|--------|-----------|
+| Micro-foncier | 2042 case 4BE |
+| Régime réel foncier | 2044 (ou 2044 spéciale) |
+| Micro-BIC LMNP | 2042 C-PRO (cases 5ND, 5NG, etc.) |
+| Réel LMNP / LMP | 2031 + 2033 (liasse BIC) + 2042 C-PRO |
+| SCI IR | Déclaration 2072 (SCI) + report sur 2044 (associés) |
+
+## Références CGI / BOFiP
+
+- Revenus fonciers : art. 14 à 33 quater CGI
+- Déficit foncier : art. 156-I-3° CGI
+- LMNP : art. 35-I-5° bis CGI
+- LMP : art. 155-IV CGI
+- SCI : art. 8 CGI (transparence)
+- BOFiP : BOI-RFPI (fonciers) et BOI-BIC-CHAMP-40 (meublés)


### PR DESCRIPTION
## Résumé

Nouveau skill `fiscaliste` pour la fiscalité des particuliers français, miroir du `controleur-fiscal` existant (qui cherche les failles côté DGFIP).

### Scope

- **Couvert** : IR (barème, quotient familial, décote, PAS, CEHR), IFI, revenus du capital (PFU vs barème, PEA, assurance-vie rachats), revenus fonciers (micro/réel, LMNP, SCI IR), equity salarial (RSU, BSPCE, stock-options, PEE/PERCO), crypto (PAMC, formulaire 2086), PER, niches fiscales.
- **Hors scope** (redirections explicites) :
  - Succession / donation / démembrement → skill `notaire`
  - IS / SASU / arbitrage salaire-dividendes / SCI à l'IS → skill `comptable`

### Structure

```
fiscaliste/
├── SKILL.md                      (valeurs 2025 inlinées, pas de dépendance Read sur data/)
├── foyer.example.json
├── data/          (10 JSON — barèmes LFI 2026, seuils, taux)
├── references/    (12 MD dont declaration-workflow.md)
└── evals/evals.json (10 scénarios)
```

### Dépendance

**Aucune dépendance obligatoire.** Le skill fonctionne standalone (barèmes 2025 inlinés directement dans `SKILL.md`).

### Benchmark evals

| | With skill | Without | Delta |
|---|---|---|---|
| Mean pass rate | **93%** | 86% | **+7pts** |
| Avg per scénario | 94% | 80% | +14% |
| Coût | $0.76 | $1.63 | −53% |

Gains forts sur redirections (+67% chacune), rsu (+14%), lmnp (+16%). Neutre sur crypto, ifi, couple-enfants, pfu-dividendes.

## Test plan

- [x] Scope et redirections (succession → notaire, SASU → comptable) — SKILL.md:26-27 et 178-180
- [x] Barèmes LFI 2026 sur `data/bareme-ir-2025.json` — 11600/29579/84577/181917, QF 1807€, décote 1982/3277€
- [x] Cohérence PS 17,2% pour revenus 2025 (LFSS 2026 à 18,6% ne s'applique qu'à partir de 2026) — data et evals alignés
- [x] Déclaration workflow (inspiré `comptable/cloture-workflow.md`) — `references/declaration-workflow.md`, 10 étapes en 4 phases
- [x] Benchmark evals reproduit — 93%/86%

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
