### PR TITLE
docs: clarify GitHub skill installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,25 +57,11 @@ Lance ensuite le setup pour la gestion de toute ma paperasse
 
 L'agent va cloner le repo, installer les skills, et lancer le setup guidé qui vous posera quelques questions (nom de votre société, régime TVA, comptes bancaires) pour configurer votre environnement.
 
-#### Attention aux ressources partagées
+#### Installation manuelle
 
-Certains skills dépendent de fichiers partagés à la racine du repo via des liens symboliques. C'est notamment le cas de `comptable`, `controleur-fiscal` et `commissaire-aux-comptes`, qui référencent `../data`, `../company.example.json`, et pour `comptable` également `../scripts`, `../templates` et `../integrations`.
-
-Si votre agent ou votre installateur télécharge les dossiers de skills un par un via l'API GitHub, vérifiez qu'il préserve ou reconstruit ces liens. Sinon, les liens peuvent devenir de petits fichiers texte contenant seulement `../data`, `../scripts`, etc. Le skill semble alors installé, mais les workflows qui lisent les données, scripts, templates ou intégrations échouent ensuite.
-
-Pour une installation manuelle dans Codex, gardez les dossiers partagés au même niveau que les dossiers de skills :
-
-```bash
-mkdir -p ~/.codex/skills
-cp -R comptable controleur-fiscal commissaire-aux-comptes fiscaliste notaire syndic ~/.codex/skills/
-cp -R data scripts templates integrations company.example.json ~/.codex/skills/
-```
-
-Après installation, vérifiez que les chemins partagés sont bien des liens symboliques ou de vrais dossiers, pas des fichiers texte :
-
-```bash
-ls -l ~/.codex/skills/comptable/data ~/.codex/skills/comptable/scripts ~/.codex/skills/comptable/templates ~/.codex/skills/comptable/integrations
-```
+Si vous n'utilisez ni agentskill.sh ni un clone Git complet, attention aux liens symboliques vers les ressources partagées (`data`, `scripts`, `templates`, `integrations`).
+Certains installateurs qui téléchargent les dossiers un par un via l'API GitHub les transforment en petits fichiers texte.
+Voir [l'installation manuelle](docs/manual-install.md) pour les commandes Codex et les vérifications.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ Lance ensuite le setup pour la gestion de toute ma paperasse
 
 L'agent va cloner le repo, installer les skills, et lancer le setup guidé qui vous posera quelques questions (nom de votre société, régime TVA, comptes bancaires) pour configurer votre environnement.
 
+#### Attention aux ressources partagées
+
+Certains skills dépendent de fichiers partagés à la racine du repo via des liens symboliques. C'est notamment le cas de `comptable`, `controleur-fiscal` et `commissaire-aux-comptes`, qui référencent `../data`, `../company.example.json`, et pour `comptable` également `../scripts`, `../templates` et `../integrations`.
+
+Si votre agent ou votre installateur télécharge les dossiers de skills un par un via l'API GitHub, vérifiez qu'il préserve ou reconstruit ces liens. Sinon, les liens peuvent devenir de petits fichiers texte contenant seulement `../data`, `../scripts`, etc. Le skill semble alors installé, mais les workflows qui lisent les données, scripts, templates ou intégrations échouent ensuite.
+
+Pour une installation manuelle dans Codex, gardez les dossiers partagés au même niveau que les dossiers de skills :
+
+```bash
+mkdir -p ~/.codex/skills
+cp -R comptable controleur-fiscal commissaire-aux-comptes fiscaliste notaire syndic ~/.codex/skills/
+cp -R data scripts templates integrations company.example.json ~/.codex/skills/
+```
+
+Après installation, vérifiez que les chemins partagés sont bien des liens symboliques ou de vrais dossiers, pas des fichiers texte :
+
+```bash
+ls -l ~/.codex/skills/comptable/data ~/.codex/skills/comptable/scripts ~/.codex/skills/comptable/templates ~/.codex/skills/comptable/integrations
+```
+
 ---
 
 ## Les 6 skills

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -1,0 +1,43 @@
+# Installation manuelle
+
+Cette page concerne les installations manuelles de Paperasse, notamment quand un agent télécharge les dossiers depuis GitHub au lieu de cloner le repo complet.
+
+## Pourquoi cette vérification existe
+
+Paperasse partage certaines ressources entre plusieurs skills avec des liens symboliques. Par exemple :
+
+- `comptable/data` pointe vers `../data`
+- `comptable/scripts` pointe vers `../scripts`
+- `comptable/templates` pointe vers `../templates`
+- `comptable/integrations` pointe vers `../integrations`
+- `comptable/company.example.json` pointe vers `../company.example.json`
+- `controleur-fiscal/data` et `commissaire-aux-comptes/data` pointent vers `../data`
+- `controleur-fiscal/company.example.json` et `commissaire-aux-comptes/company.example.json` pointent vers `../company.example.json`
+
+Un clone Git complet préserve ces liens. En revanche, certains installateurs qui téléchargent les dossiers skill par skill via l'API GitHub peuvent transformer les liens en petits fichiers texte contenant seulement `../data`, `../scripts`, etc. Le skill semble alors installé, mais les workflows qui lisent les données, scripts, templates ou intégrations échouent.
+
+## Installation Codex
+
+Depuis la racine du repo Paperasse cloné :
+
+```bash
+mkdir -p ~/.codex/skills
+cp -R comptable controleur-fiscal commissaire-aux-comptes fiscaliste notaire syndic ~/.codex/skills/
+cp -R data scripts templates integrations company.example.json ~/.codex/skills/
+```
+
+Cette structure garde les dossiers partagés au même niveau que les dossiers de skills, ce qui permet aux liens relatifs comme `../data` de rester valides.
+
+## Vérification
+
+Après installation, vérifiez que les chemins partagés sont bien des liens symboliques ou de vrais dossiers, pas des fichiers texte :
+
+```bash
+ls -l ~/.codex/skills/comptable/data \
+  ~/.codex/skills/comptable/scripts \
+  ~/.codex/skills/comptable/templates \
+  ~/.codex/skills/comptable/integrations \
+  ~/.codex/skills/comptable/company.example.json
+```
+
+Si la sortie affiche des fichiers réguliers de quelques octets au lieu de liens symboliques ou de dossiers, l'installation est incomplète. Recréez alors les liens ou réinstallez depuis un clone Git complet.


### PR DESCRIPTION
## Summary

- document the shared resources used by Paperasse skills through symlinks
- warn agents and installers that downloading skill folders one by one can turn symlinks into plain text files
- add a Codex manual installation example that keeps shared folders at the same level as skill folders

## Validation

- documentation-only change
- checked the observed symlink layout in the repository