### PR TITLE
docs: add ECOSYSTEM.md for community forks registry

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,0 +1,51 @@
+# Ecosystem — Community Forks
+
+> **For maintainers of jurisdiction-specific forks:** add your fork to the table below via a PR.
+> One row per jurisdiction. Keep it factual: repo, scope, working language, output language, license, status.
+
+---
+
+## Why this file exists
+
+The paperasse architecture — `SKILL.md` + `references/` + `evals/` + `data/` + `templates/` — is jurisdiction-agnostic by design. The pattern travels well, but jurisdiction law is total: French PCG/BOFiP/URSSAF has zero overlap with Tunisian JORT/BCT/CNSS/RNE. Forks belong in separate repos, not as branches of this one.
+
+This file is the registry. Users looking for their jurisdiction start here.
+
+---
+
+## Community forks
+
+| Jurisdiction | Repo | Scope | Working language | Output language | License | Status |
+|---|---|---|---|---|---|---|
+| TN Tunisia | [`YassineAta/paperasse-tn`](https://github.com/YassineAta/paperasse-tn) | Freelancers / devs / small entrepreneurs -- IRPP, IS, CNSS (10 classes), BCT forex compliance, Diwana, RNE filing, SUARL/patente, NAT codes | English | English (explanations) / French (output docs) | MIT | v0.2.0 - active |
+
+---
+
+## Adding your fork
+
+Open a PR that adds **one row** to the table above. Checklist before opening:
+
+- [ ] Your fork is MIT-compatible (or clearly states a different license in the row).
+- [ ] Your `README.md` credits upstream `romainsimon/paperasse` with a link and mentions MIT attribution.
+- [ ] Your repo follows the `SKILL.md` + `references/` + `evals/` layout (skills may differ; structure should not).
+- [ ] Status is honest: `alpha`, `beta`, `active`, `archived`, or `maintenance`.
+
+That's it. No approval process -- just a PR. If your jurisdiction already has an entry that's gone stale, open a PR to update it.
+
+---
+
+## What forks should NOT do
+
+- **Reuse upstream skill slugs** (`comptable`, `notaire`, etc.) for jurisdiction-specific skills. Use your own slugs to avoid conflicts in skill loaders that index by slug.
+- **Claim compatibility with upstream** unless evals pass against the upstream harness. Forks diverge by design.
+- **Copy upstream references verbatim** for a different jurisdiction. French CGI articles don't apply to Tunisian IRPP. The references layer must be rebuilt from local primary sources.
+
+---
+
+## Cross-fork coordination
+
+If you're making a change that affects the **shared architecture** -- `SKILL.md` schema, eval harness API, `data/sources.json` format, `marketplace.json` structure -- open an issue on the upstream repo tagged `ecosystem` before merging. Fork maintainers watch upstream; this gives them a heads-up to adapt without breaking their pipelines silently.
+
+---
+
+*This file is maintained by the community. If a fork goes stale for more than 12 months with no commits, it will be moved to a "Stale forks" section -- not removed.*

--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ Des forks par juridiction maintenus par la communauté :
 
 - 🇹🇳 [**paperasse-tn**](https://github.com/YassineAta/paperasse-tn) (Tunisie) — skills pour la paperasse tunisienne (IRPP, BCT/forex, RNE/NAT, SUARL). Trois skills : `mo7aseb`, `bct-shield`, `3adel-ichhad`.
 
-Ces forks ne sont **pas maintenus par paperasse** : la fraîcheur des références fiscales et juridiques est de la responsabilité de leurs auteurs. Ouvrez une issue ici si vous voulez ajouter votre fork à cette liste.
+Ces forks ne sont **pas maintenus par paperasse** : la fraîcheur des références fiscales et juridiques est de la responsabilité de leurs auteurs.
+
+La liste complète et le template pour ajouter votre fork : [ECOSYSTEM.md](ECOSYSTEM.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Follows up on #20.

- Adds `ECOSYSTEM.md` at repo root — canonical registry for jurisdiction-specific forks, structured to scale as more ports are added.
- Updates `README.md`: replaces the "ouvrez une issue" call-to-action in the Forks communautaires section with a pointer to `ECOSYSTEM.md`.

### What ECOSYSTEM.md contains

- **Why this file exists** — rationale for separate repos per jurisdiction (law divergence is total).
- **Community forks table** — one row per fork: repo, scope, languages, license, status. `paperasse-tn` is the seed entry.
- **Checklist to add a fork** — 4 bullets (MIT-compat, upstream credit, layout, honest status). PR to add a row, no approval gate.
- **What forks should NOT do** — slug collisions, false compatibility claims, verbatim reference copies.
- **Cross-fork coordination** — upstream `ecosystem` issue tag for architecture changes.

## Test plan

- [ ] `ECOSYSTEM.md` renders correctly on GitHub (table, links, checkboxes).
- [ ] README link to `ECOSYSTEM.md` resolves.
- [ ] No other files changed.

---
*Generated with [Claude Code](https://claude.com/claude-code)*