### PR TITLE
fix(fiscaliste): LFSS 2026 PS differentiation + add CDHR (closes #29)

### DIFF
--- a/fiscaliste/SKILL.md
+++ b/fiscaliste/SKILL.md
@@ -99,11 +99,18 @@ Dernière MAJ: [date] — Vérifier les barèmes de la dernière loi de finances
 
 ### PFU et prélèvements sociaux
 
-- **PFU global : 30 %** (12,8 % IR + 17,2 % PS) pour les revenus 2025
-- **Prélèvements sociaux sur revenus du capital : 17,2 %** (revenus 2025)
+La LFSS 2026 (loi n° 2025-1403 du 30/12/2025, art. 12) a porté la CSG sur les revenus du capital de 9,2 % à 10,6 %, soit un total PS de 17,2 % à 18,6 %, **avec deux dates d'entrée en vigueur distinctes** selon la nature du revenu :
+
+| Catégorie | Base CSS | PS revenus 2025 (déclaration 2026) | PS revenus 2026+ | PFU effectif 2025 |
+|---|---|---|---|---|
+| **Revenus du patrimoine** : PV mobilières (CTO), crypto, LMNP | L. 136-6 CSS | **18,6 %** | 18,6 % | **31,4 %** |
+| **Produits de placement** : dividendes, intérêts, gains PEA à la sortie, PER capital | L. 136-7 CSS | 17,2 % | **18,6 % (à partir du 01/01/2026)** | 30 % |
+| **Cas inchangés** : AV, foncier nu, SCPI, PEL/CEL anciens, livrets réglementés | n/a | 17,2 % | 17,2 % | n/a |
+
+**Conséquence pratique** : pour la déclaration 2026 (revenus 2025), une PV mobilière sur compte-titres est imposée à **31,4 % au PFU** (12,8 % IR + 18,6 % PS), alors qu'un dividende encaissé en 2025 reste à **30 %** (12,8 % IR + 17,2 % PS). Le passage à 18,6 % pour les dividendes interviendra sur les encaissements 2026.
+
 - **CSG déductible : 6,8 %** — **uniquement si option barème** sur revenus du capital N-1
 - **Option barème globale** : concerne TOUS les revenus du capital de l'année
-- LFSS 2026 a porté le taux PS à 18,6 % à compter du 1er janvier 2026 — ne s'applique PAS aux revenus 2025 déclarés en 2026 (encaissement antérieur).
 
 ### PER (versements 2025)
 
@@ -123,17 +130,27 @@ Dernière MAJ: [date] — Vérifier les barèmes de la dernière loi de finances
 
 ### CEHR (Contribution Exceptionnelle Hauts Revenus)
 
-Base : RFR, pas RNI. S'ajoute à l'IR net.
+Base : RFR, pas RNI. S'ajoute à l'IR net. Art. 223 sexies CGI.
 
 | Situation | Tranche 3 % | Tranche 4 % |
 |-----------|-------------|-------------|
 | Célibataire | 250 000 € — 500 000 € | > 500 000 € |
 | Couple | 500 000 € — 1 000 000 € | > 1 000 000 € |
 
+### CDHR (Contribution Différentielle sur les Hauts Revenus)
+
+Mécanisme **distinct de la CEHR** : impose un **plancher d'imposition à 20 %** sur les foyers à hauts RFR. Art. 224 CGI, créé par l'art. 10 LFI 2025 (loi n° 2025-127 du 14/02/2025), **pérennisé par la LFI 2026** jusqu'au retour du déficit public sous 3 % du PIB.
+
+Seuils RFR : > 250 000 € (célibataire) / > 500 000 € (couple). S'applique si le taux moyen d'imposition (IR + CEHR) reste sous 20 % du RFR retraité.
+
+Calcul automatique par l'administration après dépôt de la 2042. Acompte de 95 % à verser entre le 1er et le 15 décembre via le service "Prélèvement à la source" sur impots.gouv.fr.
+
+Détail dans [references/cas-speciaux.md](references/cas-speciaux.md) section CDHR.
+
 ### Crypto (PAMC)
 
 - **Exonération totale** si cessions annuelles ≤ **305 €** (seuil en montant brut, pas en PV)
-- Au-delà : imposition PFU 30 % sur TOUTE la PV (pas seulement l'excédent)
+- Au-delà : imposition **PFU 31,4 %** (12,8 % IR + 18,6 % PS, LFSS 2026, PV mobilière = revenu du patrimoine) sur TOUTE la PV (pas seulement l'excédent), pour les cessions réalisées dès 2025
 - Formulaire 2086 obligatoire dès 1 € de cession > 305 €
 
 ### Assurance-vie — rachats après 8 ans
@@ -170,7 +187,7 @@ python fiscaliste/scripts/calc_ir.py --rni 45000 --parts 1
 python fiscaliste/scripts/calc_ir.py --rni 126000 --parts 3 --parts-base 2
 ```
 
-Le script applique : barème 2025, quotient familial avec plafonnement, décote, PS 17,2 % sur revenus du capital, CEHR. Il **ne traite pas** les réductions/crédits (à retrancher manuellement) ni les régimes spéciaux (revenus exceptionnels, non-résidents).
+Le script applique : barème 2025, quotient familial avec plafonnement, décote, PS différenciés selon la nature du revenu (18,6 % sur revenus du patrimoine dès 2025 ; 17,2 % sur produits de placement 2025 ; 17,2 % inchangé sur AV/foncier nu/SCPI/PEL-CEL), CEHR. Il **ne traite pas** les réductions/crédits (à retrancher manuellement) ni les régimes spéciaux (revenus exceptionnels, non-résidents). Pour la CDHR (plancher 20 % sur RFR > 250/500 k€), voir [references/cas-speciaux.md](references/cas-speciaux.md) — calculée automatiquement par l'administration.
 
 Pour la fraîcheur des données : `python fiscaliste/scripts/update_data.py`.
 
@@ -254,7 +271,7 @@ Ces points sont systématiquement vérifiés par les utilisateurs exigeants — 
 ### Pour des RSU
 
 - Gain d'acquisition = **SALAIRE** (case 1TT), abattement 10 % applicable sur le total salaires.
-- PV de cession ultérieure = **distincte**, imposée au PFU 30 % au moment de la revente.
+- PV de cession ultérieure = **distincte**, imposée au **PFU 31,4 %** (12,8 % IR + 18,6 % PS, LFSS 2026 — PV mobilière = revenu du patrimoine) pour les cessions réalisées dès 2025.
 - Toujours distinguer ces deux phases dans la réponse.
 - Mentionner la contribution salariale 10 % si plan qualifiant.
 - CSG 9,7 % sur le gain d'acquisition RSU.

--- a/fiscaliste/data/bareme-ir-2025.json
+++ b/fiscaliste/data/bareme-ir-2025.json
@@ -53,6 +53,7 @@
 
   "cehr": {
     "description": "Contribution Exceptionnelle sur les Hauts Revenus — basée sur le RFR, pas le RNI. S'ajoute à l'IR net.",
+    "base_legale": "art. 223 sexies CGI",
     "seuils_celibataire": [
       { "de": 250000, "a": 500000, "taux": 0.03 },
       { "au_dela": 500000, "taux": 0.04 }
@@ -62,5 +63,22 @@
       { "au_dela": 1000000, "taux": 0.04 }
     ],
     "note": "Valeurs de référence — vérifier en cas de LFI modifiant le dispositif."
+  },
+
+  "cdhr": {
+    "description": "Contribution Différentielle sur les Hauts Revenus — distincte de la CEHR. Impose un plancher d'imposition à 20 % sur les foyers à hauts RFR. Calcul automatique par l'administration après dépôt de la 2042.",
+    "base_legale": "art. 224 CGI, créé par l'art. 10 LFI 2025 (loi n° 2025-127 du 14/02/2025), pérennisé par la LFI 2026",
+    "plancher_imposition": 0.20,
+    "seuils_rfr": {
+      "celibataire_veuf_separe_divorce": 250000,
+      "couple_marie_pacse": 500000
+    },
+    "mecanisme": "La CDHR vient combler la différence si IR + CEHR < 20 % du RFR retraité. Distincte de la CEHR (les deux peuvent s'appliquer simultanément).",
+    "calendrier": {
+      "acompte": "95 % du montant estimé à verser entre le 1er et le 15 décembre de l'année des revenus, via le service 'Prélèvement à la source' sur impots.gouv.fr",
+      "solde": "calculé automatiquement par l'administration après dépôt de la 2042 au printemps suivant"
+    },
+    "perennisation": "Initialement transitoire (revenus 2024), pérennisée par la LFI 2026 jusqu'au retour du déficit public sous 3 % du PIB",
+    "source": "https://www.impots.gouv.fr/actualite/contribution-differentielle-sur-les-hauts-revenus-cdhr"
   }
 }

--- a/fiscaliste/data/pfu-prelevements-sociaux.json
+++ b/fiscaliste/data/pfu-prelevements-sociaux.json
@@ -4,23 +4,64 @@
     "declaration": 2026,
     "sources": [
       "https://bofip.impots.gouv.fr/",
-      "LFSS 2026 (portant le taux PS à 18.6% à compter du 1er janvier 2026, ne s'applique PAS aux revenus 2025)"
+      "LFSS 2026 (loi n° 2025-1403 du 30 décembre 2025), art. 12 — modifie l'art. L. 136-8 CSS, porte la CSG sur revenus du capital de 9,2 % à 10,6 % (PS total 17,2 % -> 18,6 %)",
+      "Art. L. 136-6 CSS (revenus du patrimoine) — hausse applicable aux revenus 2025",
+      "Art. L. 136-7 CSS (produits de placement) — hausse applicable aux revenus encaissés à partir du 01/01/2026"
     ]
   },
 
   "pfu": {
-    "description": "Prélèvement Forfaitaire Unique (flat tax) sur les revenus du capital 2025. Taux global comprenant IR + PS.",
-    "taux_global": 0.30,
-    "detail_ir": 0.128,
-    "detail_ps": 0.172,
-    "note_lfss_2026": "LFSS 2026 a relevé le taux global PS de 17.2% à 18.6% à compter du 1er janvier 2026. N'impacte que les revenus perçus à partir de 2026. Les revenus 2025 restent à 17.2%."
+    "description": "Prélèvement Forfaitaire Unique (flat tax) sur les revenus du capital 2025. Taux IR fixe (12,8 %) + PS variable selon la nature du revenu (LFSS 2026 art. 12).",
+    "taux_ir": 0.128,
+    "taux_global_par_categorie": {
+      "revenus_du_patrimoine": {
+        "taux_global": 0.314,
+        "detail_ps": 0.186,
+        "description": "PV mobilières (compte-titres), crypto, LMNP. Base CSS : L. 136-6. PS 18,6 % applicable aux revenus 2025 (déclaration 2026)."
+      },
+      "produits_de_placement_2025": {
+        "taux_global": 0.30,
+        "detail_ps": 0.172,
+        "description": "Dividendes, intérêts, gains PEA à la sortie, PER capital. Base CSS : L. 136-7. PS 17,2 % pour les revenus encaissés en 2025 ; passage à 18,6 % à compter du 01/01/2026."
+      },
+      "produits_de_placement_2026": {
+        "taux_global": 0.314,
+        "detail_ps": 0.186,
+        "description": "Mêmes revenus que produits_de_placement_2025, mais encaissés à partir du 01/01/2026."
+      }
+    }
   },
 
   "prelevements_sociaux": {
-    "description": "CSG + CRDS + prélèvement de solidarité sur les revenus du capital (revenus 2025)",
-    "taux_revenus_capital": 0.172,
+    "description": "CSG + CRDS + prélèvement de solidarité. Taux différencié depuis la LFSS 2026 (art. 12).",
+    "composition": {
+      "csg": "10,6 % (hausse) ou 9,2 % (taux historique, maintenu sur certains revenus)",
+      "crds": "0,5 %",
+      "prelevement_solidarite": "7,5 %"
+    },
+    "taux_revenus_du_patrimoine_2025": {
+      "valeur": 0.186,
+      "couvre": ["PV mobilières (CTO)", "crypto (PAMC)", "LMNP", "revenus locatifs reclassés"],
+      "base_legale": "art. L. 136-6 CSS modifié par LFSS 2026 art. 12 — applicable dès les revenus 2025"
+    },
+    "taux_produits_de_placement_2025": {
+      "valeur": 0.172,
+      "couvre": ["dividendes", "intérêts", "RCM", "gains PEA à la sortie", "PER capital"],
+      "base_legale": "art. L. 136-7 CSS — taux 17,2 % maintenu pour les encaissements 2025",
+      "note": "Passage à 18,6 % pour les encaissements à compter du 01/01/2026"
+    },
+    "taux_produits_de_placement_2026": {
+      "valeur": 0.186,
+      "couvre": ["mêmes revenus que produits_de_placement_2025, mais encaissés à partir du 01/01/2026"],
+      "base_legale": "art. L. 136-7 CSS modifié par LFSS 2026 art. 12"
+    },
+    "taux_inchanges_17_2": {
+      "valeur": 0.172,
+      "couvre": ["assurance-vie", "contrats de capitalisation", "foncier nu", "SCPI", "PEL/CEL anciens", "PEP"],
+      "note": "Cas exclus de la hausse LFSS 2026 — taux 17,2 % permanent"
+    },
     "dont_csg_deductible_si_bareme": 0.068,
-    "note_csg": "La CSG déductible (6.8%) ne s'applique QUE si option barème progressif. Zéro déductible sous PFU. Elle s'impute en N+1 sur le RNI.",
+    "note_csg_deductible": "La CSG déductible (6,8 %) ne s'applique QUE si option barème progressif. Zéro déductible sous PFU. Elle s'impute en N+1 sur le RNI.",
     "taux_plus_values_immo": 0.172
   },
 
@@ -33,7 +74,8 @@
   "arbitrage_pfu_vs_bareme": {
     "description": "Règle d'orientation rapide — à affiner selon composition des revenus",
     "tmi_faible_bareme_avantageux": "TMI 0% ou 11%, le barème est presque toujours meilleur (tranche basse + abattement 40% sur dividendes + CSG déductible)",
-    "tmi_eleve_pfu_avantageux": "TMI 30%+, le PFU à 30% (12.8% IR + 17.2% PS) est souvent meilleur pour intérêts et plus-values. Pour dividendes : arbitrage à faire (abattement 40% peut compenser)",
-    "rappel_option_globale": "L'option barème est globale et irrévocable pour l'année — engage TOUS les revenus du capital"
+    "tmi_eleve_pfu_avantageux": "TMI 30%+, le PFU est souvent meilleur pour intérêts et plus-values. Pour dividendes : arbitrage à faire (abattement 40% peut compenser, surtout en 2025 où PS = 17,2 %)",
+    "rappel_option_globale": "L'option barème est globale et irrévocable pour l'année — engage TOUS les revenus du capital",
+    "note_lfss_2026": "À partir des revenus 2026, le PFU monte à 31,4 % aussi sur dividendes/intérêts. Le calcul d'arbitrage doit en tenir compte pour les projections N+1."
   }
 }

--- a/fiscaliste/data/sources.json
+++ b/fiscaliste/data/sources.json
@@ -20,13 +20,13 @@
       "name": "PFU et prélèvements sociaux",
       "file": "pfu-prelevements-sociaux.json",
       "annee_revenus": 2025,
-      "source_officielle": "LFSS 2026 (PS 18,6% à compter 2026) — revenus 2025 restent à 17,2%",
-      "article_cgi": "art. 200 A CGI, art. L. 136-1 CSS",
+      "source_officielle": "LFSS 2026 (loi n° 2025-1403 du 30/12/2025, art. 12) — différenciation L. 136-6 (revenus du patrimoine, PS 18,6 % dès 2025) vs L. 136-7 (produits de placement, PS 17,2 % en 2025, 18,6 % à compter du 01/01/2026)",
+      "article_cgi": "art. 200 A CGI, art. L. 136-6 et L. 136-7 CSS",
       "bofip": "BOI-RPPM-RCM-30",
       "update_frequency": "annual",
-      "last_fetched": "2026-04-12",
+      "last_fetched": "2026-05-13",
       "next_check": "2026-12-30",
-      "check_instructions": "Vérifier CSG/CRDS/prélèvement solidarité. Attention au décalage LFSS N vs encaissement."
+      "check_instructions": "Vérifier CSG/CRDS/prélèvement solidarité. Attention à la différenciation revenus du patrimoine vs produits de placement (deux dates d'entrée en vigueur depuis LFSS 2026)."
     },
     {
       "id": "per-plafonds",

--- a/fiscaliste/references/cas-speciaux.md
+++ b/fiscaliste/references/cas-speciaux.md
@@ -78,7 +78,7 @@ Dans cet exemple, peu de gain car le revenu ordinaire est déjà en tranche 30%.
 
 ## CEHR (Contribution Exceptionnelle Hauts Revenus)
 
-Voir `data/bareme-ir-2025.json` → `cehr`.
+Voir `data/bareme-ir-2025.json` → `cehr`. Base légale : art. 223 sexies CGI.
 
 ### Seuils (revenus 2025)
 
@@ -93,6 +93,56 @@ Voir `data/bareme-ir-2025.json` → `cehr`.
 
 - S'ajoute à l'IR net (ne se déduit pas)
 - Lissage possible sur la moyenne des 2 années précédentes (article 223 sexies CGI)
+
+## CDHR (Contribution Différentielle sur les Hauts Revenus)
+
+Voir `data/bareme-ir-2025.json` → `cdhr`.
+
+Mécanisme **distinct de la CEHR** : impose un **plancher d'imposition à 20 %** sur les foyers à hauts RFR. À ne jamais confondre avec la CEHR (les deux peuvent s'appliquer simultanément sur un même foyer).
+
+### Base légale
+
+- Art. 224 CGI, créé par l'**art. 10 de la LFI 2025** (loi n° 2025-127 du 14/02/2025)
+- **Pérennisée par la LFI 2026** jusqu'au retour du déficit public sous 3 % du PIB (donc applicable aux revenus 2025+ jusqu'à condition de fin)
+
+### Seuils RFR
+
+| Situation | Seuil de déclenchement |
+|---|---|
+| Célibataire, veuf, séparé, divorcé | RFR > 250 000 € |
+| Couple marié ou pacsé (imposition commune) | RFR > 500 000 € |
+
+### Mécanisme
+
+La CDHR s'applique lorsque le **taux moyen d'imposition** (IR + CEHR, après réductions et crédits d'impôt) reste **inférieur à 20 % du RFR retraité**. Elle vient combler la différence pour atteindre ce plancher de 20 %.
+
+Calcul automatique par l'administration après dépôt de la 2042. Pas de case spécifique à remplir manuellement.
+
+### Distinction CEHR vs CDHR
+
+| Critère | CEHR (art. 223 sexies CGI) | CDHR (art. 224 CGI) |
+|---|---|---|
+| Nature | Surtaxe additionnelle | Plancher d'imposition |
+| Taux | 3 % à 4 % selon tranche RFR | 0 à 20 % selon écart au plancher |
+| Mode de calcul | Direct sur le RFR | Différentiel (complète si IR + CEHR < 20 % RFR) |
+| Application | Tous les foyers > seuils | Uniquement si IR effectif < 20 % du RFR |
+
+Les deux peuvent s'appliquer simultanément : la CEHR est toujours due au-delà des seuils, la CDHR ne se déclenche qu'en cas de fort poids des revenus PFU (faiblement imposés à 12,8 % IR).
+
+### Calendrier
+
+- **Acompte** : 95 % du montant estimé à verser entre le **1er et le 15 décembre** de l'année des revenus, via le service "Prélèvement à la source" sur impots.gouv.fr
+- **Solde** : calculé automatiquement par l'administration après dépôt de la 2042 au printemps suivant
+
+### Cas typiques touchés
+
+- Dirigeants à fort revenu PFU dividendes (TMI effectif IR ~12,8 % alors que RFR > 250 k€)
+- Business angels avec PV mobilières importantes
+- Cadres exécutifs à fort RSU/BSPCE l'année de vesting/cession
+
+### Source officielle
+
+[impots.gouv.fr — Contribution Différentielle sur les Hauts Revenus](https://www.impots.gouv.fr/actualite/contribution-differentielle-sur-les-hauts-revenus-cdhr)
 
 ## Revenus étrangers et conventions fiscales
 

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -16,7 +16,8 @@ Voir `data/equity-salarial.json` pour les taux et seuils.
 
 **2. Plus-value de cession**
 - Valeur de cession − valeur au vesting
-- **Imposition : PV mobilière** (PFU 30% ou barème)
+- **Imposition : PV mobilière** : PFU à **31,4 % pour les cessions réalisées dès 2025** (12,8 % IR + 18,6 % PS, LFSS 2026), ou barème sur option
+- Les PV mobilières sont des "revenus du patrimoine" (art. L. 136-6 CSS), donc soumises au taux PS 18,6 % dès les revenus 2025
 - Uniquement si cession après vesting
 
 ### Plans qualifiants (loi Macron)
@@ -69,10 +70,12 @@ Toujours consulter le plan pour déterminer le régime applicable.
 
 Voir `data/equity-salarial.json` → `bspce.gain_cession`.
 
-| Ancienneté dans la société à la date de cession | Taux global |
+| Ancienneté dans la société à la date de cession | Taux global pour cessions 2025 |
 |--------------------------------------------------|-------------|
-| **≥ 3 ans** | 30% (12,8% IR + 17,2% PS) |
-| **< 3 ans** | 50% (30% IR + 20% PS) |
+| **≥ 3 ans** | **31,4 %** (12,8 % IR + 18,6 % PS) — PV mobilière |
+| **< 3 ans** | 50 % (30 % IR + 20 % PS — contribution salariale spécifique) |
+
+Note : pour les cessions ≥ 3 ans, le PS suit le taux applicable aux PV mobilières (revenus du patrimoine, L. 136-6 CSS), soit 18,6 % dès 2025. Pour les cessions < 3 ans, la part PS reste à 20 % (contribution salariale spécifique, distincte du PS de droit commun).
 
 La pénalité pour départ précoce (< 3 ans) est forte. À intégrer dans les décisions de départ.
 

--- a/fiscaliste/references/pea-assurance-vie.md
+++ b/fiscaliste/references/pea-assurance-vie.md
@@ -31,7 +31,10 @@ Les plafonds concernent les **versements**, pas la valeur du plan. Un plan peut 
 
 - **Retraits libres** sans clôture du plan
 - **EXONÉRATION TOTALE d'IR** sur les gains
-- **Prélèvements sociaux 17,2%** dus sur les gains à chaque retrait
+- **Prélèvements sociaux** dus sur les gains à chaque retrait, au taux applicable à la date du retrait :
+  - **Retraits avant le 01/01/2026** : 17,2 %
+  - **Retraits à partir du 01/01/2026** : **18,6 %** (LFSS 2026, art. 12, modifiant L. 136-7 CSS) — applicable sur la **totalité du gain au retrait**, y compris la fraction acquise avant 2026
+- Référence : les gains PEA sont qualifiés de "produits de placement" (PS prélevés à la source au moment du retrait), pas de "revenus du patrimoine"
 
 ### Taux historiques PS
 
@@ -50,7 +53,7 @@ Les gains acquis avant certaines dates peuvent bénéficier de taux PS historiqu
 | Critère | PEA | AV |
 |---------|-----|-----|
 | Exonération IR | **Oui** après 5 ans | Non (abattement seulement) |
-| PS sur gains | 17,2% à chaque retrait | 17,2% PFU ou barème |
+| PS sur gains | 17,2 % puis 18,6 % à partir du 01/01/2026, à chaque retrait | 17,2 % inchangé (cas exclu de la hausse LFSS 2026) |
 | Composition | Actions EUR uniquement | Libre (actions, obligations, fonds €) |
 | Retrait avant échéance | Clôture avant 5 ans | Libre à tout moment |
 | Transmission | Dans succession classique | Régime spécifique (voir notaire) |

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -84,7 +84,9 @@ Les époux/pacsés soumis à imposition commune peuvent **mutualiser leurs plafo
 
 2. **Sortie en capital**
    - **Versements déduits à l'entrée** : imposés au barème progressif (part capital)
-   - **Gains** : imposés séparément au PFU 30%
+   - **Gains** : imposés séparément au PFU (12,8 % IR + PS), les gains PER étant qualifiés de "produits de placement" (L. 136-7 CSS) :
+     - **Sortie avant le 01/01/2026** : PFU 30 % (PS 17,2 %)
+     - **Sortie à partir du 01/01/2026** : PFU 31,4 % (PS 18,6 %, LFSS 2026)
    - Possibilité de fractionner la sortie sur plusieurs années (à demander à l'assureur)
 
 **Piège sortie capital** : ne pas confondre le régime du capital (barème, écrase la tranche) et celui des gains (PFU fixe). Bien distinguer.
@@ -93,7 +95,7 @@ Les époux/pacsés soumis à imposition commune peuvent **mutualiser leurs plafo
 
 Si l'on a choisi de ne pas déduire les versements (case à cocher à la souscription) :
 - Sortie partiellement exonérée
-- Seuls les gains sont imposés (PFU)
+- Seuls les gains sont imposés au PFU (30 % avant 01/01/2026, 31,4 % à partir du 01/01/2026 — voir taux PS PER ci-dessus)
 - Utile si on anticipe un TMI sortie > TMI entrée — rare
 
 ### Sortie anticipée autorisée

--- a/fiscaliste/references/revenus-capital.md
+++ b/fiscaliste/references/revenus-capital.md
@@ -4,10 +4,20 @@
 
 Les revenus mobiliers (dividendes, intérêts, plus-values de titres) sont soumis au choix :
 
-| Régime | Taux | Caractéristiques |
-|--------|------|------------------|
-| **PFU (flat tax)** | 30% (12,8% IR + 17,2% PS) | Par défaut. Pas d'abattement. Pas de CSG déductible. |
+| Régime | Taux 2025 | Caractéristiques |
+|--------|-----------|------------------|
+| **PFU (flat tax)** | **30 % pour dividendes / intérêts ; 31,4 % pour PV mobilières et crypto** (voir tableau ci-dessous) | Par défaut. Pas d'abattement. Pas de CSG déductible. |
 | **Barème progressif** | Selon TMI | Sur option **globale** (tous les revenus du capital de l'année). Abattement 40% sur dividendes. CSG déductible 6,8% en N+1. |
+
+### Taux PS différenciés (LFSS 2026)
+
+La LFSS 2026 (loi n° 2025-1403 du 30/12/2025, art. 12) modifie le taux de CSG (9,2 % → 10,6 %, soit total PS 17,2 % → 18,6 %) avec **deux dates d'entrée en vigueur distinctes** :
+
+| Catégorie | PS revenus 2025 | PS revenus 2026+ | Base CSS |
+|---|---|---|---|
+| Revenus du patrimoine (PV mobilières, crypto, LMNP) | **18,6 %** | 18,6 % | L. 136-6 |
+| Produits de placement (dividendes, intérêts, PEA à la sortie, PER) | 17,2 % | **18,6 % à partir du 01/01/2026** | L. 136-7 |
+| AV, foncier nu, SCPI, PEL/CEL anciens, livrets réglementés | 17,2 % | 17,2 % (inchangé) | n/a |
 
 Voir `data/pfu-prelevements-sociaux.json` pour les taux exacts.
 
@@ -23,9 +33,9 @@ Voir `data/pfu-prelevements-sociaux.json` pour les taux exacts.
 
 ### Exemple de calcul comparatif
 
-Foyer célibataire, TMI 30%, dividendes 10 000 € :
+Foyer célibataire, TMI 30%, **dividendes 10 000 € encaissés en 2025** :
 
-**Sous PFU** :
+**Sous PFU** (dividende = produit de placement, PS 17,2 % en 2025) :
 - IR : 10 000 × 12,8% = 1 280 €
 - PS : 10 000 × 17,2% = 1 720 €
 - Total : 3 000 €
@@ -39,17 +49,19 @@ Foyer célibataire, TMI 30%, dividendes 10 000 € :
 
 → Ici, PFU avantageux (3 000 € < 3 316 €) malgré l'abattement 40%.
 
-Mais si le même foyer a aussi **5 000 € de PV mobilière** sans abattement :
-- PFU : 5 000 × 30% = 1 500 €
-- Barème : 5 000 × 30% IR + 5 000 × 17,2% PS = 2 360 €
-- → PFU toujours plus favorable
+Mais si le même foyer a aussi **5 000 € de PV mobilière réalisée en 2025** (revenu du patrimoine, PS 18,6 %) :
+- PFU : 5 000 × 31,4 % = 1 570 €
+- Barème : 5 000 × 30% IR + 5 000 × 18,6% PS = 2 430 €
+- → PFU toujours plus favorable, mais l'écart se resserre
+
+**Attention** : à partir des revenus 2026, le dividende passera aussi à 18,6 % PS (PFU effectif 31,4 %).
 
 ## Types de revenus du capital
 
 ### Dividendes (case 2DC)
 
-- Par défaut : PFU 30%
-- Option barème : abattement 40% puis IR barème + PS 17,2%
+- Par défaut : PFU 30 % en 2025 (12,8 % IR + 17,2 % PS), passe à 31,4 % à compter des dividendes encaissés en 2026
+- Option barème : abattement 40 % puis IR barème + PS (17,2 % en 2025, 18,6 % à partir de 2026)
 - **Dividendes étrangers** : peuvent avoir été soumis à une retenue à la source dans le pays d'origine — crédit d'impôt possible sous convention fiscale
 
 ### Intérêts, RCM (case 2TR)
@@ -76,15 +88,17 @@ Régime distinct : méthode PAMC (prix acquisition moyen pondéré) sur l'ensemb
 
 **À ne jamais confondre avec l'IR.** Les PS sont prélevés en plus sur la quasi-totalité des revenus du capital.
 
-- Taux global : 17,2% (ou 18,6% selon LFSS 2026 — vérifier)
 - Composition : CSG + CRDS + prélèvement de solidarité
-- **Sous PFU** : PS inclus dans le taux global de 30%
-- **Sous barème** : PS séparés de l'IR (mais CSG 6,8% déductible en N+1)
+- Taux différencié depuis la LFSS 2026 (voir table en haut du document) : 18,6 % pour les revenus du patrimoine dès 2025, 17,2 % puis 18,6 % au 01/01/2026 pour les produits de placement, 17,2 % inchangé pour AV/foncier nu/SCPI/PEL-CEL anciens
+- **Sous PFU** : PS inclus dans le taux global (30 % ou 31,4 % selon la nature du revenu)
+- **Sous barème** : PS séparés de l'IR (mais CSG 6,8 % déductible en N+1)
 
-**Exceptions de taux (17,2% au lieu du taux courant)** :
-- AV et contrats de capitalisation anciens
+**Cas restant à 17,2 % de manière permanente** (exclus de la hausse LFSS 2026) :
+- Assurance-vie et contrats de capitalisation
+- Revenus fonciers (foncier nu, SCPI)
 - CEL/PEL ouverts avant le 31/12/2017
 - PEP
+- Livrets réglementés (Livret A, LDDS, LEP : totalement exonérés)
 
 ### CSG déductible
 
@@ -95,8 +109,9 @@ Régime distinct : méthode PAMC (prix acquisition moyen pondéré) sur l'ensemb
 
 ## Enveloppes fiscales spécifiques
 
-**PEA** : exonération IR après 5 ans, PS 17,2% restent dus.
-**AV** : abattement annuel après 8 ans, fiscalité selon date des versements.
+**PEA** : exonération IR après 5 ans. PS dus à chaque retrait : **17,2 % pour les retraits effectués avant le 01/01/2026**, **18,6 % à partir du 01/01/2026** (sur la totalité du gain, y compris la fraction acquise avant cette date). Cf. art. L. 136-7 CSS.
+
+**AV** : abattement annuel après 8 ans, fiscalité selon date des versements. PS **17,2 % inchangés** (cas exclu de la hausse LFSS 2026).
 
 Règles complètes (retrait avant/après 5 ans PEA, abattements AV par tranche de versement, 152 500 € succession AV) dans la section PEA/AV listée depuis SKILL.md.
 
@@ -108,11 +123,13 @@ Règles complètes (retrait avant/après 5 ans PEA, abattements AV par tranche d
 4. **Abattement 40% sous PFU** — n'existe que sous barème.
 5. **Retenue à la source étrangère** — créditer contre l'IR français (conventions fiscales) — à ne pas oublier.
 
-## Références CGI / BOFiP
+## Références CGI / BOFiP / CSS
 
 - PFU : art. 200 A CGI
 - Option barème : art. 200 A-2 CGI
 - Abattement dividendes 40% : art. 158-3° CGI
 - Plus-values mobilières : art. 150-0 A à 150-0 D CGI
 - Prélèvements sociaux : art. L. 136-1 et s. CSS
+- Différenciation revenus du patrimoine vs produits de placement : art. L. 136-6 et L. 136-7 CSS
+- LFSS 2026 (hausse CSG) : loi n° 2025-1403 du 30/12/2025, art. 12 (modifie L. 136-8 CSS)
 - BOFiP : BOI-RPPM-RCM (dividendes/RCM) et BOI-RPPM-PVBMI (PV mobilières)


### PR DESCRIPTION
## Problème

Deux erreurs factuelles signalées par @StephanAlluchon dans #29, **les deux confirmées** sur sources officielles (Légifrance, BOFiP, impots.gouv.fr).

### Erreur 1 — Différenciation des taux PS sur revenus 2025

Le skill affirmait que **tous** les revenus du capital 2025 étaient à 17,2 % PS. C'est partiellement faux.

La **LFSS 2026** (loi n° 2025-1403 du 30/12/2025, art. 12) modifie l'art. L. 136-8 CSS et introduit **deux dates d'entrée en vigueur distinctes** :

| Catégorie | Base CSS | PS revenus 2025 | PS revenus 2026+ |
|---|---|---|---|
| Revenus du patrimoine (PV mobilières CTO, crypto, LMNP) | L. 136-6 | **18,6 %** (PFU 31,4 %) | 18,6 % |
| Produits de placement (dividendes, intérêts, PEA à la sortie, PER capital) | L. 136-7 | 17,2 % (PFU 30 %) | **18,6 % à partir du 01/01/2026** |
| AV, foncier nu, SCPI, PEL/CEL anciens, livrets réglementés | n/a | 17,2 % | 17,2 % inchangé |

### Erreur 2 — CDHR absente

Le skill mentionne la CEHR (art. 223 sexies CGI) mais pas la **CDHR** (Contribution Différentielle sur les Hauts Revenus). Art. 224 CGI, créée par l'art. 10 LFI 2025 (loi n° 2025-127 du 14/02/2025), **pérennisée par la LFI 2026** jusqu'au retour du déficit public sous 3 % du PIB.

Mécanisme : plancher d'imposition à 20 % sur les foyers à RFR > 250 k€ (célibataire) / 500 k€ (couple). Distincte de la CEHR (les deux peuvent s'appliquer simultanément). Acompte 95 % à verser entre le 1er et le 15 décembre.

## Corrections apportées

### Fichiers modifiés (8)

1. **`fiscaliste/SKILL.md`** : refonte du bloc "PFU et prélèvements sociaux" avec table différenciée + ajout pointeur CDHR à côté de CEHR + corrections crypto/RSU (31,4 % au lieu de 30 %) + mise à jour de la note du script `calc_ir.py`
2. **`fiscaliste/references/revenus-capital.md`** : table PFU différenciée, exemples chiffrés à jour, sections "PS" et "Cas exclus à 17,2 %" reformulées, références CSS/CGI ajoutées
3. **`fiscaliste/references/cas-speciaux.md`** : nouvelle section CDHR complète (base légale, seuils, mécanisme, distinction CEHR/CDHR, calendrier acompte, cas typiques)
4. **`fiscaliste/references/pea-assurance-vie.md`** : précision sur PS PEA à la sortie (17,2 % avant 01/01/2026, 18,6 % à partir du 01/01/2026 sur la totalité du gain)
5. **`fiscaliste/references/equity-salarial.md`** : PV de cession RSU/BSPCE classées en PV mobilière (revenus du patrimoine) → PFU 31,4 % pour cessions 2025
6. **`fiscaliste/references/per.md`** : sortie en capital PER (produits de placement, PFU 30 % avant 01/01/2026, 31,4 % à partir du 01/01/2026)
7. **`fiscaliste/data/pfu-prelevements-sociaux.json`** : refonte du schéma pour exposer la différenciation par catégorie (`revenus_du_patrimoine`, `produits_de_placement_2025`, `produits_de_placement_2026`, `taux_inchanges_17_2`)
8. **`fiscaliste/data/bareme-ir-2025.json`** : ajout d'une clé `cdhr` (description, base légale, seuils RFR, plancher 20 %, calendrier, pérennisation)

## Sources officielles vérifiées

- Légifrance : [LOI n° 2025-1403 du 30 décembre 2025 (LFSS 2026)](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000053226384) → art. 12 (modifie L. 136-8 CSS, dates différenciées L. 136-6 / L. 136-7)
- impots.gouv.fr : [Contribution Différentielle sur les Hauts Revenus (CDHR)](https://www.impots.gouv.fr/actualite/contribution-differentielle-sur-les-hauts-revenus-cdhr)
- Légifrance : [LOI n° 2025-127 du 14 février 2025 (LFI 2025), art. 10](https://www.legifrance.gouv.fr/loda/id/JORFTEXT000051168007) → création art. 224 CGI

## Corrections du sourcing initial de @StephanAlluchon (mineures)

- Numéro et date de la LFSS 2026 : il citait "2025-1560 du 22/12/2025", vraie ref Légifrance = **2025-1403 du 30/12/2025**
- Numéro d'article : il citait art. 19, vrai numéro = **art. 12**

Substance et diagnostic 100 % corrects de sa part, seuls les identifiants exacts ont été ajustés contre les sources officielles.

Closes #29
