### PR TITLE
feat(notaire): régime fiscal AV avant 20/11/1991 — matrice complète succession

### DIFF
--- a/notaire/references/cas-speciaux.md
+++ b/notaire/references/cas-speciaux.md
@@ -34,6 +34,12 @@
 - Primes après 70 ans : abattement global **30 500 EUR** puis droits de succession sur le surplus des primes (art. 757 B CGI). Les intérêts sont exonérés.
 - Attention aux **primes manifestement excessives** (réintégration possible dans la succession)
 
+**Contrats souscrits avant le 20 novembre 1991 — régime dérogatoire :**
+- Versements avant le 13/10/1998 : **exonération totale** de droits de succession
+- Versements après le 13/10/1998 : abattement **152 500 EUR/bénéficiaire** même si les primes ont été versées après 70 ans (art. 990 I, pas art. 757 B)
+- Ne jamais clôturer ces vieux contrats : le régime est attaché au contrat, un rachat total le détruit définitivement
+- Voir `succession.md` § "Assurance-Vie" pour le détail et un exemple chiffré
+
 ## SCI : IR vs IS et Impact sur la Plus-Value
 
 | | SCI à l'IR | SCI à l'IS |

--- a/notaire/references/cas-speciaux.md
+++ b/notaire/references/cas-speciaux.md
@@ -38,7 +38,8 @@
 - Versements avant le 13/10/1998 : **exonération totale** de droits de succession
 - Versements après le 13/10/1998 : abattement **152 500 EUR/bénéficiaire** même si les primes ont été versées après 70 ans (art. 990 I, pas art. 757 B)
 - Ne jamais clôturer ces vieux contrats : le régime est attaché au contrat, un rachat total le détruit définitivement
-- Voir `succession.md` § "Assurance-Vie" pour le détail et un exemple chiffré
+- Pour en faire bénéficier enfants/petits-enfants : modifier la clause bénéficiaire en leur faveur
+- Voir `succession.md` § "Assurance-Vie" pour la matrice complète et un exemple chiffré
 
 ## SCI : IR vs IS et Impact sur la Plus-Value
 

--- a/notaire/references/succession.md
+++ b/notaire/references/succession.md
@@ -156,15 +156,44 @@ Référence complète pour le droit des successions : dévolution, droits, abatt
 
 **Base légale** : art. 757 B et 990 I CGI
 
+### Régime général (contrats souscrits à partir du 20 novembre 1991)
+
 | Primes versées | Régime | Base légale |
 |----------------|--------|-------------|
 | Avant 70 ans | Abattement 152 500 EUR par bénéficiaire, puis 20% jusqu'à 700 000 EUR, puis 31,25% | art. 990 I CGI |
-| Après 70 ans | Abattement global 30 500 EUR (tous bénéficiaires), puis droits de succession selon le lien | art. 757 B CGI |
+| Après 70 ans | Abattement global 30 500 EUR (tous bénéficiaires), puis droits de succession selon le lien. Les intérêts sont exonérés. | art. 757 B CGI |
 
-**Points clés :**
+### Contrats souscrits avant le 20 novembre 1991 — régime dérogatoire
+
+Deux dates charnières à croiser : la date d'ouverture du contrat (avant/après le 20/11/1991) et la date des versements (avant/après le 13/10/1998).
+
+| Date des versements | Régime fiscal au décès |
+|--------------------|------------------------|
+| Avant le 13 octobre 1998 | **Exonération totale** de droits de succession, quel que soit l'âge du souscripteur |
+| Après le 13 octobre 1998 | Abattement **152 500 EUR par bénéficiaire** (art. 990 I CGI), même si les primes ont été versées après 70 ans |
+
+**Avantage clé** : pour les contrats ouverts avant le 20/11/1991, les versements effectués **après 70 ans** relèvent de l'art. 990 I (abattement individuel 152 500 EUR), et non de l'art. 757 B (abattement global 30 500 EUR). C'est nettement plus favorable.
+
+**Exemple** (contrat ouvert en 1989, bénéficiaire unique = un enfant) :
+
+| Versements | Régime | Fiscalité |
+|-----------|--------|-----------|
+| 200 000 EUR avant le 13/10/1998 | Exonération totale | 0 EUR |
+| 200 000 EUR après le 13/10/1998 | Abattement 152 500 EUR → 47 500 EUR taxés à 20% | 9 500 EUR |
+| **Total transmis : 400 000 EUR** | | **Impôt : 9 500 EUR** |
+
+**Points de vigilance :**
+- Le régime dérogatoire est attaché au contrat, pas au souscripteur : des versements récents sur un vieux contrat en bénéficient.
+- Un rachat total clôture le contrat → perte définitive du régime dérogatoire.
+- La Cour de cassation a admis l'adhésion d'enfants ou petits-enfants à un vieux contrat pour leur faire bénéficier de ce régime (à vérifier selon les conditions de l'assureur).
+- Exonération totale si le bénéficiaire est le conjoint survivant ou le partenaire pacsé (art. 796-0 bis CGI), quelle que soit la date du contrat.
+
+### Points clés communs
+
 - L'assurance-vie est hors succession (art. L132-12 Code des assurances)
 - Clause bénéficiaire : vérifier sa rédaction (acceptation, démembrement, etc.)
 - Contrats non dénoués au décès du conjoint : régime spécifique selon le régime matrimonial
+- Primes manifestement excessives : réintégration possible dans la succession (Cass. civ.)
 
 ## Options du Conjoint Survivant
 

--- a/notaire/references/succession.md
+++ b/notaire/references/succession.md
@@ -172,14 +172,6 @@ Trois variables déterminent le régime applicable :
 - La date 20/11/1991 (date du contrat) détermine si les versements post-70 ans bénéficient de l'art. 990 I (152 500 EUR/bénéf.) ou de l'art. 757 B moins favorable (30 500 EUR global).
 - Le seul cas défavorable est : contrat post-20/11/1991 + versements post-13/10/1998 + après 70 ans → art. 757 B.
 
-**Exemple** (contrat ouvert en 1989, bénéficiaire unique = un enfant) :
-
-| Versements | Régime | Fiscalité |
-|-----------|--------|-----------|
-| 200 000 EUR avant le 13/10/1998 | Exonération totale | 0 EUR |
-| 200 000 EUR après le 13/10/1998 | Abattement 152 500 EUR → 47 500 EUR taxés à 20% | 9 500 EUR |
-| **Total transmis : 400 000 EUR** | | **Impôt : 9 500 EUR** |
-
 ### Points clés communs
 
 - L'assurance-vie est hors succession (art. L132-12 Code des assurances)

--- a/notaire/references/succession.md
+++ b/notaire/references/succession.md
@@ -188,7 +188,7 @@ Trois variables déterminent le régime applicable :
 - Primes manifestement excessives : réintégration possible dans la succession (Cass. civ.)
 - Ne jamais clôturer un contrat pre-20/11/1991 : le régime dérogatoire est attaché au contrat, un rachat total le détruit définitivement
 - Exonération totale si le bénéficiaire est le conjoint survivant ou le partenaire pacsé (art. 796-0 bis CGI), quelle que soit la date du contrat
-- La Cour de cassation a admis l'adhésion d'enfants ou petits-enfants à un vieux contrat pour leur faire bénéficier de ce régime (à vérifier selon les conditions de l'assureur)
+- Pour faire bénéficier enfants/petits-enfants du régime dérogatoire : modifier la clause bénéficiaire du vieux contrat en leur faveur (opération courante, pas de changement de souscripteur)
 
 ## Options du Conjoint Survivant
 

--- a/notaire/references/succession.md
+++ b/notaire/references/succession.md
@@ -156,23 +156,21 @@ Référence complète pour le droit des successions : dévolution, droits, abatt
 
 **Base légale** : art. 757 B et 990 I CGI
 
-### Régime général (contrats souscrits à partir du 20 novembre 1991)
+### Matrice complète : âge × date du contrat × date des versements
 
-| Primes versées | Régime | Base légale |
-|----------------|--------|-------------|
-| Avant 70 ans | Abattement 152 500 EUR par bénéficiaire, puis 20% jusqu'à 700 000 EUR, puis 31,25% | art. 990 I CGI |
-| Après 70 ans | Abattement global 30 500 EUR (tous bénéficiaires), puis droits de succession selon le lien. Les intérêts sont exonérés. | art. 757 B CGI |
+Trois variables déterminent le régime applicable :
 
-### Contrats souscrits avant le 20 novembre 1991 — régime dérogatoire
+| Âge lors des versements | Date de souscription | Versements avant le 13/10/1998 | Versements après le 13/10/1998 |
+|-------------------------|----------------------|-------------------------------|-------------------------------|
+| Avant 70 ans | Avant le 20/11/1991 | **Exonération totale** | **Exonération totale** |
+| Avant 70 ans | Après le 20/11/1991 | **Exonération totale** | Abattement 152 500 EUR/bénéf., 20% de 152 500 à 852 500, 31,25% au-delà (art. 990 I CGI) |
+| Après 70 ans | Avant le 20/11/1991 | **Exonération totale** | Abattement 152 500 EUR/bénéf., 20% de 152 500 à 852 500, 31,25% au-delà (art. 990 I CGI) |
+| Après 70 ans | Après le 20/11/1991 | Abattement global 30 500 EUR (tous bénéf.), puis droits de succession sur les primes. Intérêts exonérés. (art. 757 B CGI) | Abattement global 30 500 EUR (tous bénéf.), puis droits de succession sur les primes. Intérêts exonérés. (art. 757 B CGI) |
 
-Deux dates charnières à croiser : la date d'ouverture du contrat (avant/après le 20/11/1991) et la date des versements (avant/après le 13/10/1998).
-
-| Date des versements | Régime fiscal au décès |
-|--------------------|------------------------|
-| Avant le 13 octobre 1998 | **Exonération totale** de droits de succession, quel que soit l'âge du souscripteur |
-| Après le 13 octobre 1998 | Abattement **152 500 EUR par bénéficiaire** (art. 990 I CGI), même si les primes ont été versées après 70 ans |
-
-**Avantage clé** : pour les contrats ouverts avant le 20/11/1991, les versements effectués **après 70 ans** relèvent de l'art. 990 I (abattement individuel 152 500 EUR), et non de l'art. 757 B (abattement global 30 500 EUR). C'est nettement plus favorable.
+**Lecture de la matrice :**
+- La date 13/10/1998 crée une exonération totale pour tous les versements antérieurs, quel que soit l'âge ou la date du contrat.
+- La date 20/11/1991 (date du contrat) détermine si les versements post-70 ans bénéficient de l'art. 990 I (152 500 EUR/bénéf.) ou de l'art. 757 B moins favorable (30 500 EUR global).
+- Le seul cas défavorable est : contrat post-20/11/1991 + versements post-13/10/1998 + après 70 ans → art. 757 B.
 
 **Exemple** (contrat ouvert en 1989, bénéficiaire unique = un enfant) :
 
@@ -182,18 +180,15 @@ Deux dates charnières à croiser : la date d'ouverture du contrat (avant/après
 | 200 000 EUR après le 13/10/1998 | Abattement 152 500 EUR → 47 500 EUR taxés à 20% | 9 500 EUR |
 | **Total transmis : 400 000 EUR** | | **Impôt : 9 500 EUR** |
 
-**Points de vigilance :**
-- Le régime dérogatoire est attaché au contrat, pas au souscripteur : des versements récents sur un vieux contrat en bénéficient.
-- Un rachat total clôture le contrat → perte définitive du régime dérogatoire.
-- La Cour de cassation a admis l'adhésion d'enfants ou petits-enfants à un vieux contrat pour leur faire bénéficier de ce régime (à vérifier selon les conditions de l'assureur).
-- Exonération totale si le bénéficiaire est le conjoint survivant ou le partenaire pacsé (art. 796-0 bis CGI), quelle que soit la date du contrat.
-
 ### Points clés communs
 
 - L'assurance-vie est hors succession (art. L132-12 Code des assurances)
 - Clause bénéficiaire : vérifier sa rédaction (acceptation, démembrement, etc.)
 - Contrats non dénoués au décès du conjoint : régime spécifique selon le régime matrimonial
 - Primes manifestement excessives : réintégration possible dans la succession (Cass. civ.)
+- Ne jamais clôturer un contrat pre-20/11/1991 : le régime dérogatoire est attaché au contrat, un rachat total le détruit définitivement
+- Exonération totale si le bénéficiaire est le conjoint survivant ou le partenaire pacsé (art. 796-0 bis CGI), quelle que soit la date du contrat
+- La Cour de cassation a admis l'adhésion d'enfants ou petits-enfants à un vieux contrat pour leur faire bénéficier de ce régime (à vérifier selon les conditions de l'assureur)
 
 ## Options du Conjoint Survivant
 


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><p><strong>Titre :</strong> <code>feat(notaire): régime fiscal AV avant 20/11/1991 — matrice complète succession</code></p>
<hr>
<p><strong>Description :</strong></p>
<h2>Contexte</h2>
<p>Le skill <code>notaire</code> documentait la fiscalité AV à la succession uniquement sous l'angle avant/après 70 ans, sans mentionner les deux dates charnières qui créent un régime dérogatoire très favorable.</p>
<h2>Changements</h2>
<p>Ajout de la matrice complète à 3 variables dans <code>succession.md</code> et rappel dans <code>cas-speciaux.md</code> :</p>

Âge lors des versements | Date de souscription | Versements avant le 13/10/1998 | Versements après le 13/10/1998
-- | -- | -- | --
Avant 70 ans | Avant le 20/11/1991 | Exonération totale | Exonération totale
Avant 70 ans | Après le 20/11/1991 | Exonération totale | 152 500 €/bénéf. (art. 990 I)
Après 70 ans | Avant le 20/11/1991 | Exonération totale | 152 500 €/bénéf. (art. 990 I)
Après 70 ans | Après le 20/11/1991 | 30 500 € global (art. 757 B) | 30 500 € global (art. 757 B)


<p>Le point clé : pour un contrat souscrit avant le 20/11/1991, les versements effectués après 70 ans relèvent de l'art. 990 I (152 500 €/bénéf.) et non de l'art. 757 B (30 500 € global). C'est un avantage significatif, souvent méconnu.</p>
<p>Ajout également des points de vigilance : ne pas clôturer ces contrats, modifier la clause bénéficiaire pour en faire profiter les héritiers.</p></body></html><!--EndFragment-->
</body>
</html>