### PR TITLE
Fiscaliste — épargne salariale TNS et approfondissement PER

### DIFF
--- a/fiscaliste/data/equity-salarial.json
+++ b/fiscaliste/data/equity-salarial.json
@@ -194,7 +194,14 @@
         "plafond_avec_accord_interessement": 6000,
         "exoneration_cotisations": "Totale (patronales + salariales) dans le plafond",
         "exoneration_ir": "Pour salariés < 3 SMIC brut/mois (≈ 5 430 €/mois 2025) — jusqu'au 31/12/2026",
-        "mise_en_place": "Décision unilatérale de l'employeur (DUE) — pas d'accord requis"
+        "mise_en_place": "Décision unilatérale de l'employeur (DUE) — pas d'accord requis",
+        "piege_reduction_fillon": {
+          "applicable_depuis": "2025-01-01",
+          "description": "Depuis 2025, la PPV est intégrée dans la rémunération brute servant au calcul de la réduction générale de cotisations patronales (réduction Fillon). Pour les salariés proches du SMIC, la PPV réduit mécaniquement le coefficient Fillon → l'employeur perd des allègements.",
+          "exemple": "PPV 1 500 € pour un salarié au SMIC : coût réel employeur ≈ 2 300 € après perte de réduction Fillon",
+          "recommandation": "Simuler l'impact Fillon avant de verser une PPV à un salarié < 1,6 SMIC. L'intéressement peut s'avérer moins coûteux dans cette zone.",
+          "zone_risque": "Salaire entre 1 et 1,6 SMIC — au-delà, la réduction Fillon est nulle et l'effet disparaît"
+        }
       },
       "interessement_participation": {
         "interessement_pee_plafond_2025": 34776,

--- a/fiscaliste/data/equity-salarial.json
+++ b/fiscaliste/data/equity-salarial.json
@@ -87,7 +87,7 @@
       "sortie": "Après 5 ans : exonération IR, PS 17,2% sur les gains uniquement",
       "dividendes_reinvestis": "Exonérés IR tant qu'ils restent dans l'enveloppe"
     },
-    "perco_pero": {
+    "perco_pereco": {
       "description": "Équivalent PER collectif — PERCO remplacé par PERO depuis loi Pacte",
       "sortie_retraite": "Rente ou capital, même fiscalité que PER individuel (versements au barème, gains au PFU)",
       "abondement_employeur": "Exonéré IR et PS dans les plafonds (plafond distinct du PEE)",
@@ -101,7 +101,7 @@
         "Cessation d'activité non salariée suite à liquidation judiciaire",
         "Acquisition résidence principale (PERO uniquement — compartiment versements volontaires)"
       ],
-      "note_pero_vs_pee": "Cas de déblocage beaucoup plus restreints que le PEE. Mariage, naissance, divorce, rupture contrat travail, création entreprise : NON déblocables sur PERCO/PERO."
+      "note_pero_vs_pee": "Cas de déblocage beaucoup plus restreints que le PEE. Mariage, naissance, divorce, rupture contrat travail, création entreprise : NON déblocables sur PERCO/PERECO."
     },
     "arbitrage_vs_per_individuel": "PEE / PERCO = abondement employeur (levier immédiat +30% à +300%). PER individuel = déduction du RNI. À combiner : abonder d'abord PEE/PERCO pour capter l'abondement, puis PER individuel."
   },

--- a/fiscaliste/data/equity-salarial.json
+++ b/fiscaliste/data/equity-salarial.json
@@ -85,6 +85,149 @@
     "arbitrage_vs_per_individuel": "PEE / PERCO = abondement employeur (levier immédiat +30% à +300%). PER individuel = déduction du RNI. À combiner : abonder d'abord PEE/PERCO pour capter l'abondement, puis PER individuel."
   },
 
+  "pee_perco_tns": {
+    "description": "PEE/PERECO mis en place par un dirigeant TNS dans sa propre société (SARL gérant majoritaire, EURL IS) — cas distinct du salarié classique",
+    "references_legales": {
+      "eligibilite_mandataires": "Art. L. 3332-2 Code du travail — mandataires sociaux inclus parmi les bénéficiaires",
+      "loi_pacte": "Loi n° 2019-486 du 22 mai 2019, art. 150 — ouverture aux entreprises sans salarié",
+      "decret_modalites": "Décret n° 2021-1131 du 30 août 2021 — DUE possible pour entreprises sans salarié",
+      "exoneration_ir": "Art. 81-18° CGI — exonération IR sur abondement dans les plafonds",
+      "exoneration_cotisations": "Art. L. 242-1 CSS modifié — exonération cotisations sociales sur abondement",
+      "dividendes_tns": "Art. L. 131-6 CSS — dividendes SARL > 10% capital+CC soumis aux cotisations TNS",
+      "per_tns_madelin": "Art. 154 bis CGI — PER TNS (ex-Madelin), déduction cotisations du revenu professionnel",
+      "bofip": "BOI-RSA-ES-10-10-20 — épargne salariale, abondement"
+    },
+    "eligibilite_formes_juridiques": {
+      "sarl_gerant_majoritaire": {
+        "eligible": true,
+        "regime_social": "TNS",
+        "note": "Gérant détenant + de 50% des parts (conjoint/partenaire/enfants mineurs cumulés). Inclus depuis loi Pacte."
+      },
+      "eurl_is": {
+        "eligible": true,
+        "regime_social": "TNS",
+        "note": "Gérant associé unique à l'IS. Même règles que SARL gérant majoritaire."
+      },
+      "eurl_ir": {
+        "eligible": true,
+        "regime_social": "TNS",
+        "note": "Déductibilité de l'abondement indirecte (bénéfice → IR associé). Vérifier impact avant mise en place."
+      },
+      "sas_sasu": {
+        "eligible": true,
+        "regime_social": "Assimilé salarié",
+        "note": "Règles droit commun salarié. Pas de cotisations TNS sur dividendes — arbitrage distinct."
+      },
+      "ei": {
+        "eligible": false,
+        "note": "Pas de personnalité morale distincte — impossible de jouer le rôle d'employeur vis-à-vis de soi-même."
+      }
+    },
+    "pass_2025": 46368,
+    "plafonds_2025": {
+      "pee_abondement": {
+        "montant": 3709,
+        "base_calcul": "8% × PASS 2025",
+        "ratio_max_abondement": 3,
+        "note_ratio": "L'abondement ne peut dépasser 3× le versement du dirigeant"
+      },
+      "pereco_abondement": {
+        "montant": 7418,
+        "base_calcul": "16% × PASS 2025",
+        "ratio_max_abondement": 3
+      },
+      "total_cumule_max": 11127,
+      "note_cumul": "PEE et PERECO ont des plafonds distincts et non fongibles"
+    },
+    "fiscalite_abondement": {
+      "deductibilite_is": "Charge déductible du résultat de la société (IS 25% ou 15% PME sur les 42 500 premiers €)",
+      "exoneration_cotisations_tns": "Abondement exclu de l'assiette des cotisations sociales TNS dans les plafonds",
+      "exoneration_ir": "Abondement exclu du revenu imposable du dirigeant (art. 81-18° CGI)",
+      "au_dela_plafond": "Fraction excédentaire soumise aux cotisations TNS et à l'IR — piège à éviter"
+    },
+    "arbitrage_per_tns": {
+      "description": "Comparaison PEE/PERECO (abondement) vs PER TNS (ex-Madelin, art. 154 bis CGI)",
+      "pee_pereco_avantages": [
+        "Liquidité supérieure : PEE débloquable après 5 ans (ou anticipément)",
+        "Double exonération IS + cotisations TNS",
+        "Sortie PEE : exo IR (PS 17,2% sur gains seulement)"
+      ],
+      "per_tns_avantages": [
+        "Plafond potentiellement plus élevé pour les forts bénéfices",
+        "Déduction cotisations du revenu professionnel (réduction assiette cotisations TNS)",
+        "Adapté à l'horizon retraite long"
+      ],
+      "ordre_priorite": "1. Saturer PEE + PERECO (11 127 €) / 2. PER TNS (ex-Madelin) pour le surplus / 3. PER individuel 163 quatervicies en complément",
+      "tmi_30_41": "PEE/PERECO généralement plus avantageux — double exonération + liquidité",
+      "tmi_45": "PEE reste attractif (sortie PFU gains) ; PER TNS moins pertinent si TMI retraite reste élevé"
+    },
+    "conjoint_salarie": {
+      "description": "Leviers additionnels quand le gérant embauche son conjoint",
+      "ppv": {
+        "nom": "Prime de Partage de la Valeur",
+        "references_legales": "Loi n° 2022-1158 du 16 août 2022 ; loi n° 2023-1107 du 29 novembre 2023",
+        "beneficiaires": "Salariés uniquement (le gérant TNS ne peut pas en bénéficier directement)",
+        "plafond_standard": 3000,
+        "plafond_avec_accord_interessement": 6000,
+        "exoneration_cotisations": "Totale (patronales + salariales) dans le plafond",
+        "exoneration_ir": "Pour salariés < 3 SMIC brut/mois (≈ 5 430 €/mois 2025) — jusqu'au 31/12/2026",
+        "mise_en_place": "Décision unilatérale de l'employeur (DUE) — pas d'accord requis"
+      },
+      "interessement_participation": {
+        "interessement_pee_plafond_2025": 34776,
+        "interessement_pee_base": "75% × PASS 2025",
+        "exoneration_cotisations": "Oui (si versement direct ou placement PEE)",
+        "exoneration_ir_si_place_pee": true,
+        "exoneration_ir_si_non_place": false,
+        "note_accord": "Accord d'intéressement requis — DUE possible pour TPE/PME depuis loi Pacte. Ouvre le plafond PPV à 6 000 €."
+      },
+      "mutuelle_famille": {
+        "base_legale": "Art. L. 911-7 CSS (mutuelle obligatoire) ; art. 83-1° quater CGI (déductibilité patronale) ; art. R. 242-1-6 CSS (dispense)",
+        "principe": "Mutuelle 'famille' couvrant le salarié (conjoint) + enfants + le gérant (en tant que conjoint du salarié)",
+        "participation_patronale_min": "50% de la cotisation obligatoire",
+        "exoneration_patronale": "Dans la limite de 6% PASS + 1,5% PASS par enfant à charge (art. D. 242-1 CSS)",
+        "dispense_conjoint_salarie_ailleurs": {
+          "possible_si": "Couverture obligatoire chez l'autre employeur (pas optionnelle)",
+          "formalisme": "Demande écrite conservée au dossier RH",
+          "piege": "Si la couverture chez l'autre employeur est optionnelle, la dispense n'est pas valide",
+          "point_vigilance": "Comparer le niveau de couverture avant de renoncer à la mutuelle de l'autre employeur"
+        }
+      }
+    },
+    "pieges_specifiques_tns": [
+      {
+        "id": 1,
+        "piege": "Dépassement plafond abondement",
+        "detail": "Fraction > 8% PASS (PEE) ou 16% PASS (PERECO) → cotisations TNS + IR sur l'excédent"
+      },
+      {
+        "id": 2,
+        "piege": "Confusion versement volontaire / abondement",
+        "detail": "Le versement du dirigeant provient de sa rémunération nette déjà taxée. Seul l'abondement société est exonéré."
+      },
+      {
+        "id": 3,
+        "piege": "Dividendes SARL et seuil 10% capital",
+        "detail": "Dividendes > 10% (capital + CC + primes) soumis aux cotisations TNS (art. L. 131-6 CSS). Indépendant du PEE mais impact l'optimisation globale."
+      },
+      {
+        "id": 4,
+        "piege": "EURL à l'IR : déductibilité indirecte",
+        "detail": "L'abondement réduit le bénéfice qui remonte directement à l'IR de l'associé — effet réel mais mécanique différente de l'IS."
+      },
+      {
+        "id": 5,
+        "piege": "Formalisme DUE/accord non respecté",
+        "detail": "Sans dépôt DREETS conforme, l'abondement est requalifié en complément de rémunération → cotisations + IR."
+      },
+      {
+        "id": 6,
+        "piege": "Appliquer les règles TNS à une SASU",
+        "detail": "Le président de SASU est assimilé salarié — pas de cotisations TNS sur dividendes. L'arbitrage est fondamentalement différent."
+      }
+    ]
+  },
+
   "quotient_revenus_exceptionnels": {
     "description": "Lissage fiscal pour revenus ponctuels exceptionnels (vesting massif, prime exceptionnelle, indemnité départ)",
     "mecanisme": "Revenu exceptionnel divisé par coefficient (généralement 4), ajouté au revenu ordinaire, impôt supplémentaire multiplié par le même coefficient",

--- a/fiscaliste/data/equity-salarial.json
+++ b/fiscaliste/data/equity-salarial.json
@@ -88,8 +88,13 @@
       "dividendes_reinvestis": "Exonérés IR tant qu'ils restent dans l'enveloppe"
     },
     "perco_pereco": {
-      "description": "Équivalent PER collectif — PERCO remplacé par PERO depuis loi Pacte",
-      "sortie_retraite": "Rente ou capital, même fiscalité que PER individuel (versements au barème, gains au PFU)",
+      "description": "Équivalent PER collectif — PERCO remplacé par PERECO (PER d'Entreprise Collectif) depuis loi Pacte",
+      "sortie_retraite": {
+        "compartiment_2_capital": "Capital exonéré IR (seuls les gains soumis à PS 17,2%) — régime distinct du PER individuel",
+        "compartiment_2_rente": "RVCTO (Rente Viagère à Titre Onéreux) — fraction imposable : <50 ans=70%, 50-59=50%, 60-69=40%, 70+=30%",
+        "compartiment_1_capital": "Versements volontaires déduits → imposés au barème comme PER individuel ; gains au PFU",
+        "note": "Compartiment 2 (intéressement/participation/abondement) bénéficie d'un régime fiscal plus favorable que le PER individuel"
+      },
       "abondement_employeur": "Exonéré IR et PS dans les plafonds (plafond distinct du PEE)",
       "plafond_base": "16% × PASS de l'année de versement — voir per-plafonds.json → epargne_salariale_abondement.pereco",
       "deblocage_anticipe_reference": "Art. L. 3334-14 Code du travail (PERCO) ; art. L. 224-4 CMF (PERO)",
@@ -103,7 +108,7 @@
       ],
       "note_pero_vs_pee": "Cas de déblocage beaucoup plus restreints que le PEE. Mariage, naissance, divorce, rupture contrat travail, création entreprise : NON déblocables sur PERCO/PERECO."
     },
-    "arbitrage_vs_per_individuel": "PEE / PERCO = abondement employeur (levier immédiat +30% à +300%). PER individuel = déduction du RNI. À combiner : abonder d'abord PEE/PERCO pour capter l'abondement, puis PER individuel."
+    "arbitrage_vs_per_individuel": "PEE / PERECO = abondement employeur (levier immédiat +30% à +300%). PER individuel = déduction du RNI. À combiner : abonder d'abord PEE/PERECO pour capter l'abondement, puis PER individuel."
   },
 
   "pee_perco_tns": {
@@ -170,7 +175,7 @@
         "Déduction cotisations du revenu professionnel (réduction assiette cotisations TNS)",
         "Adapté à l'horizon retraite long"
       ],
-      "ordre_priorite": "1. Saturer PEE + PERECO (11 127 €) / 2. PER TNS (ex-Madelin) pour le surplus / 3. PER individuel 163 quatervicies en complément",
+      "ordre_priorite": "1. Saturer PEE + PERECO (11 304 € pour 2025) / 2. PER TNS (ex-Madelin) pour le surplus / 3. PER individuel 163 quatervicies en complément",
       "tmi_30_41": "PEE/PERECO généralement plus avantageux — double exonération + liquidité",
       "tmi_45": "PEE reste attractif (sortie PFU gains) ; PER TNS moins pertinent si TMI retraite reste élevé"
     },
@@ -194,8 +199,8 @@
         }
       },
       "interessement_participation": {
-        "interessement_pee_plafond_2025": 34776,
-        "interessement_pee_base": "75% × PASS 2025",
+        "interessement_pee_plafond_2025": 35325,
+        "interessement_pee_base": "75% × PASS de l'année de versement — voir per-plafonds.json",
         "exoneration_cotisations": "Oui (si versement direct ou placement PEE)",
         "exoneration_ir_si_place_pee": true,
         "exoneration_ir_si_non_place": false,

--- a/fiscaliste/data/equity-salarial.json
+++ b/fiscaliste/data/equity-salarial.json
@@ -69,8 +69,7 @@
     "description": "Plans d'Épargne Entreprise et Plans d'Épargne Retraite Collective — enveloppes collectives",
     "pee": {
       "abondement_employeur": "Exonéré IR et PS dans les plafonds — AVANTAGE MAJEUR vs versement direct",
-      "plafond_abondement_pee_2025": 3709,
-      "plafond_base": "8% × PASS par bénéficiaire (à vérifier annuellement)",
+      "plafond_base": "8% × PASS de l'année de versement — voir per-plafonds.json → epargne_salariale_abondement.pee",
       "blocage_duree": "5 ans",
       "deblocage_anticipe_reference": "Art. R. 3332-28 Code du travail — délai 6 mois par cas (sauf décès et surendettement : immédiat)",
       "deblocage_anticipe_cas": [
@@ -92,8 +91,7 @@
       "description": "Équivalent PER collectif — PERCO remplacé par PERO depuis loi Pacte",
       "sortie_retraite": "Rente ou capital, même fiscalité que PER individuel (versements au barème, gains au PFU)",
       "abondement_employeur": "Exonéré IR et PS dans les plafonds (plafond distinct du PEE)",
-      "plafond_abondement_perco_2025": 7418,
-      "plafond_base": "16% × PASS par bénéficiaire",
+      "plafond_base": "16% × PASS de l'année de versement — voir per-plafonds.json → epargne_salariale_abondement.pereco",
       "deblocage_anticipe_reference": "Art. L. 3334-14 Code du travail (PERCO) ; art. L. 224-4 CMF (PERO)",
       "deblocage_anticipe_cas": [
         "Décès (bénéficiaire ou conjoint/PACS)",
@@ -146,20 +144,12 @@
         "note": "Pas de personnalité morale distincte — impossible de jouer le rôle d'employeur vis-à-vis de soi-même."
       }
     },
-    "pass_2025": 46368,
-    "plafonds_2025": {
-      "pee_abondement": {
-        "montant": 3709,
-        "base_calcul": "8% × PASS 2025",
-        "ratio_max_abondement": 3,
-        "note_ratio": "L'abondement ne peut dépasser 3× le versement du dirigeant"
-      },
-      "pereco_abondement": {
-        "montant": 7418,
-        "base_calcul": "16% × PASS 2025",
-        "ratio_max_abondement": 3
-      },
-      "total_cumule_max": 11127,
+    "plafonds": {
+      "source": "per-plafonds.json → epargne_salariale_abondement (PASS de l'année de versement)",
+      "formule_pee": "8% × PASS",
+      "formule_pereco": "16% × PASS",
+      "ratio_max_abondement": 3,
+      "note_ratio": "L'abondement ne peut dépasser 3× le versement du dirigeant",
       "note_cumul": "PEE et PERECO ont des plafonds distincts et non fongibles"
     },
     "fiscalite_abondement": {

--- a/fiscaliste/data/equity-salarial.json
+++ b/fiscaliste/data/equity-salarial.json
@@ -71,16 +71,39 @@
       "abondement_employeur": "Exonéré IR et PS dans les plafonds — AVANTAGE MAJEUR vs versement direct",
       "plafond_abondement_pee_2025": 3709,
       "plafond_base": "8% × PASS par bénéficiaire (à vérifier annuellement)",
-      "blocage": "5 ans sauf cas de déblocage anticipé (mariage, naissance 3e enfant, achat RP, divorce avec enfant à charge, fin contrat travail, surendettement, invalidité, décès, violences conjugales)",
-      "sortie": "Après 5 ans : exonération IR, PS sur les gains uniquement",
+      "blocage_duree": "5 ans",
+      "deblocage_anticipe_reference": "Art. R. 3332-28 Code du travail — délai 6 mois par cas (sauf décès et surendettement : immédiat)",
+      "deblocage_anticipe_cas": [
+        "Mariage ou PACS du bénéficiaire",
+        "Naissance ou adoption portant la famille à 3 enfants ou plus",
+        "Divorce / séparation / dissolution PACS avec garde d'au moins 1 enfant",
+        "Invalidité (bénéficiaire, conjoint/PACS ou enfant — toute catégorie)",
+        "Décès (bénéficiaire ou conjoint/PACS)",
+        "Rupture du contrat de travail (démission, licenciement, retraite, rupture conventionnelle)",
+        "Création ou reprise d'entreprise (bénéficiaire, conjoint ou enfant)",
+        "Acquisition ou agrandissement de la résidence principale",
+        "Surendettement (sur demande commission de surendettement)",
+        "Violences conjugales (loi n° 2021-1774 du 24 décembre 2021)"
+      ],
+      "sortie": "Après 5 ans : exonération IR, PS 17,2% sur les gains uniquement",
       "dividendes_reinvestis": "Exonérés IR tant qu'ils restent dans l'enveloppe"
     },
     "perco_pero": {
-      "description": "Équivalent PER collectif",
-      "sortie_retraite": "Rente ou capital, même fiscalité que PER individuel",
+      "description": "Équivalent PER collectif — PERCO remplacé par PERO depuis loi Pacte",
+      "sortie_retraite": "Rente ou capital, même fiscalité que PER individuel (versements au barème, gains au PFU)",
       "abondement_employeur": "Exonéré IR et PS dans les plafonds (plafond distinct du PEE)",
       "plafond_abondement_perco_2025": 7418,
-      "plafond_base": "16% × PASS par bénéficiaire"
+      "plafond_base": "16% × PASS par bénéficiaire",
+      "deblocage_anticipe_reference": "Art. L. 3334-14 Code du travail (PERCO) ; art. L. 224-4 CMF (PERO)",
+      "deblocage_anticipe_cas": [
+        "Décès (bénéficiaire ou conjoint/PACS)",
+        "Invalidité 2e ou 3e catégorie SS (bénéficiaire, conjoint ou enfants)",
+        "Surendettement",
+        "Expiration des droits à l'assurance chômage",
+        "Cessation d'activité non salariée suite à liquidation judiciaire",
+        "Acquisition résidence principale (PERO uniquement — compartiment versements volontaires)"
+      ],
+      "note_pero_vs_pee": "Cas de déblocage beaucoup plus restreints que le PEE. Mariage, naissance, divorce, rupture contrat travail, création entreprise : NON déblocables sur PERCO/PERO."
     },
     "arbitrage_vs_per_individuel": "PEE / PERCO = abondement employeur (levier immédiat +30% à +300%). PER individuel = déduction du RNI. À combiner : abonder d'abord PEE/PERCO pour capter l'abondement, puis PER individuel."
   },

--- a/fiscaliste/data/equity-salarial.json
+++ b/fiscaliste/data/equity-salarial.json
@@ -210,7 +210,7 @@
         "base_legale": "Art. L. 911-7 CSS (mutuelle obligatoire) ; art. 83-1° quater CGI (déductibilité patronale) ; art. R. 242-1-6 CSS (dispense)",
         "principe": "Mutuelle 'famille' couvrant le salarié (conjoint) + enfants + le gérant (en tant que conjoint du salarié)",
         "participation_patronale_min": "50% de la cotisation obligatoire",
-        "exoneration_patronale": "Dans la limite de 6% PASS + 1,5% PASS par enfant à charge (art. D. 242-1 CSS)",
+        "exoneration_patronale": "Dans la limite de 6% du PASS + 1,5% de la rémunération annuelle brute soumise à cotisations, le total étant plafonné à 12% du PASS (art. D. 242-1 CSS)",
         "dispense_conjoint_salarie_ailleurs": {
           "possible_si": "Couverture obligatoire chez l'autre employeur (pas optionnelle)",
           "formalisme": "Demande écrite conservée au dossier RH",

--- a/fiscaliste/data/equity-salarial.json
+++ b/fiscaliste/data/equity-salarial.json
@@ -84,13 +84,13 @@
         "Surendettement (sur demande commission de surendettement)",
         "Violences conjugales (loi n° 2021-1774 du 24 décembre 2021)"
       ],
-      "sortie": "Après 5 ans : exonération IR, PS 17,2% sur les gains uniquement",
+      "sortie": "Après 5 ans : exonération IR, PS sur les gains uniquement (taux en vigueur — cf. SKILL.md, 18,6% depuis LFSS 2026)",
       "dividendes_reinvestis": "Exonérés IR tant qu'ils restent dans l'enveloppe"
     },
     "perco_pereco": {
       "description": "Équivalent PER collectif — PERCO remplacé par PERECO (PER d'Entreprise Collectif) depuis loi Pacte",
       "sortie_retraite": {
-        "compartiment_2_capital": "Capital exonéré IR (seuls les gains soumis à PS 17,2%) — régime distinct du PER individuel",
+        "compartiment_2_capital": "Capital exonéré IR (seuls les gains soumis aux PS, taux en vigueur — cf. SKILL.md, 18,6% depuis LFSS 2026) — régime distinct du PER individuel",
         "compartiment_2_rente": "RVCTO (Rente Viagère à Titre Onéreux) — fraction imposable : <50 ans=70%, 50-59=50%, 60-69=40%, 70+=30%",
         "compartiment_1_capital": "Versements volontaires déduits → imposés au barème comme PER individuel ; gains au PFU",
         "note": "Compartiment 2 (intéressement/participation/abondement) bénéficie d'un régime fiscal plus favorable que le PER individuel"
@@ -168,7 +168,7 @@
       "pee_pereco_avantages": [
         "Liquidité supérieure : PEE débloquable après 5 ans (ou anticipément)",
         "Double exonération IS + cotisations TNS",
-        "Sortie PEE : exo IR (PS 17,2% sur gains seulement)"
+        "Sortie PEE : exo IR (PS sur gains seulement, taux en vigueur — cf. SKILL.md, 18,6% depuis LFSS 2026)"
       ],
       "per_tns_avantages": [
         "Plafond potentiellement plus élevé pour les forts bénéfices",
@@ -188,7 +188,7 @@
         "plafond_standard": 3000,
         "plafond_avec_accord_interessement": 6000,
         "exoneration_cotisations": "Totale (patronales + salariales) dans le plafond",
-        "exoneration_ir": "Pour salariés < 3 SMIC brut/mois (≈ 5 430 €/mois 2025) — jusqu'au 31/12/2026",
+        "exoneration_ir": "Réservée aux entreprises de moins de 50 salariés, pour salariés < 3 SMIC brut/mois (≈ 5 430 €/mois 2025) — jusqu'au 31/12/2026. Entreprises ≥ 50 salariés : exonération de cotisations sociales maintenue mais PPV imposable à l'IR dès le premier euro.",
         "mise_en_place": "Décision unilatérale de l'employeur (DUE) — pas d'accord requis",
         "piege_reduction_fillon": {
           "applicable_depuis": "2025-01-01",

--- a/fiscaliste/data/per-plafonds.json
+++ b/fiscaliste/data/per-plafonds.json
@@ -13,16 +13,41 @@
 
   "per_individuel": {
     "description": "Plafond de déduction PER pour les versements 2025 (déclaration 2026)",
-    "calcul": "10% des revenus professionnels nets (salaires après abattement 10%, BNC, BIC) de l'année N-1",
+    "calcul": "max(plancher, 10% × revenus professionnels nets N-1) — salaires après abattement 10%, BNC, BIC, hors revenus du capital",
+    "plancher_formule": "10% × PASS_annee_versement",
     "plancher_euros": 4710,
-    "plancher_base": "10% × PASS 2025 (47 100 €) — garanti même sans revenus",
+    "plafond_absolu_formule": "10% × 8 × PASS_annee_versement",
     "plafond_absolu_euros": 37680,
-    "plafond_absolu_base": "10% × 8 × PASS 2025",
     "report": {
-      "description": "Plafonds non utilisés des 3 années précédentes mobilisables",
-      "ordre": "Utiliser le plafond N en premier, puis les plafonds N-3, N-2, N-1 (ordre FIFO le plus ancien en premier)"
+      "duree_avant_2026": "3 ans",
+      "duree_depuis_2026": "5 ans (loi de finances 2026 — non rétroactif, plafonds antérieurs à 2026 restent à 3 ans)",
+      "ordre": "N en premier, puis N-3, N-2, N-1 (FIFO — le plus ancien en premier pour éviter expiration)"
     },
     "mutualisation_couple": "Les époux/pacsés soumis à imposition commune peuvent mutualiser leurs plafonds (case à cocher sur 2042)"
+  },
+
+  "epargne_salariale_abondement": {
+    "description": "Plafonds d'abondement employeur PEE et PERECO — calculés sur le PASS de l'année de versement",
+    "pee": {
+      "formule": "8% × PASS_annee_versement",
+      "plafond_2024": 3709,
+      "plafond_2025": 3768,
+      "plafond_2026": 3845
+    },
+    "pereco": {
+      "formule": "16% × PASS_annee_versement",
+      "plafond_2024": 7418,
+      "plafond_2025": 7536,
+      "plafond_2026": 7690
+    },
+    "cumul_pee_pereco": {
+      "plafond_2024": 11127,
+      "plafond_2025": 11304,
+      "plafond_2026": 11535,
+      "note": "Plafonds distincts et non fongibles — peuvent être atteints simultanément"
+    },
+    "ratio_max_abondement": 3,
+    "note_ratio": "L'abondement employeur ne peut excéder 3× le versement du bénéficiaire"
   },
 
   "sortie_per": {

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -96,7 +96,7 @@ Demander à la société :
 - Régime fiscal (IS obligatoire)
 - Historique des restructurations éventuelles
 
-## Épargne salariale (PEE / PERCO / PERO)
+## Épargne salariale (PEE / PERCO / PERECO)
 
 ### PEE (Plan d'Épargne Entreprise)
 
@@ -125,31 +125,106 @@ Chaque cas ouvre un délai de 6 mois pour effectuer le retrait (sauf décès et 
 | Surendettement | Sur demande de la commission de surendettement |
 | Violences conjugales | Loi n° 2021-1774 du 24 décembre 2021 |
 
-### PERCO / PERO (PER d'entreprise)
+### PERCO / PERECO / PERO : clarification terminologique
 
-- **Sortie à la retraite** : rente ou capital
-- **Fiscalité sortie** : même que PER individuel (versements à barème, gains au PFU)
-- **Abondement employeur** : exonéré dans plafonds (16% × PASS, distinct du plafond PEE — voir `data/per-plafonds.json` → `epargne_salariale_abondement.pereco`)
+Trois générations de plans, souvent confondus :
 
-#### Cas de déblocage anticipé PERCO / PERO
+| Sigle | Nom complet | Statut | Remplace |
+|-------|------------|--------|---------|
+| **PERCO** | Plan d'Épargne pour la Retraite Collectif | Fermé (plus créable depuis oct. 2020) | — |
+| **PERECO** (ou PERCOL) | PER d'Entreprise Collectif | Actif — successeur du PERCO | PERCO |
+| **PERO** | PER d'Entreprise Obligatoire | Actif — différent du PERECO | Article 83 |
 
-Le PERCO/PERO est une enveloppe retraite — les cas de sortie anticipée sont beaucoup plus restreints que le PEE (art. L. 3334-14 Code du travail et art. L. 224-4 CMF pour le PERO) :
+**PERECO et PERO sont deux produits distincts** et peuvent coexister dans la même entreprise : le PERECO est volontaire (alimenté par intéressement, participation, abondement, versements volontaires) ; le PERO est obligatoire pour une catégorie de salariés définie, avec des cotisations patronales imposées. Dans les petites structures (SARL, EURL), le PERO est rare — c'est le PERECO qui est pertinent.
+
+### Sortie PERCO / PERECO : rente ou capital
+
+La fiscalité de sortie dépend de **l'origine des fonds**, pas du plan lui-même.
+
+#### Fonds issus de l'épargne salariale (intéressement, participation, abondement — compartiment 2)
+
+Ces sommes ont été **exonérées d'IR à l'entrée** (pas déduites). La sortie est donc avantageuse :
+
+| Mode de sortie | IR | Prélèvements sociaux |
+|---------------|----|--------------------|
+| **Capital** | **Exonéré** (sommes déjà exonérées à l'entrée) | 17,2% sur les gains uniquement |
+| **Rente** | Régime des rentes viagères à titre onéreux — fraction taxable selon l'âge | PS sur la fraction taxable |
+
+**Fractions taxables de la rente (rente viagère à titre onéreux)** selon l'âge au premier versement :
+
+| Âge au premier versement de rente | Fraction imposable à l'IR |
+|----------------------------------|--------------------------|
+| Moins de 50 ans | 70% |
+| 50 à 59 ans | 50% |
+| 60 à 69 ans | 40% |
+| 70 ans et plus | 30% |
+
+La rente viagère à titre onéreux est plus favorable que la rente pension (PER individuel avec déduction) car seule une fraction est imposée — sans abattement 10% mais sur une base réduite.
+
+#### Fonds issus de versements volontaires déduits (compartiment 1, PERECO uniquement)
+
+| Mode de sortie | IR | Prélèvements sociaux |
+|---------------|----|--------------------|
+| **Capital** | Versements au barème IR (comme revenu ordinaire) | PFU 17,2% sur les gains |
+| **Rente** | Régime des pensions (barème + abattement 10%) | PS 9,1% |
+
+#### Rente ou capital : quand choisir quoi ?
+
+| Critère | Capital | Rente |
+|---------|---------|-------|
+| Encours modeste (< 30 k€) | Préférable | Rente dérisoire |
+| Encours important + longévité | — | Protège contre le risque de longévité |
+| TMI retraite élevé | Étaler la sortie en capital sur plusieurs années | Rente imposée chaque année |
+| Besoin de liquidité | Oui | Non |
+
+**Conseil pratique** : la sortie en capital peut être fractionnée sur plusieurs années (à demander à l'assureur) pour lisser l'imposition.
+
+### PERCO ancien : qu'est-il devenu ?
+
+Depuis le **1er octobre 2020**, aucun nouveau PERCO ne peut être créé. Les plans existants ont trois destins :
+
+1. **Ils continuent de fonctionner** avec leurs règles d'origine — certains ne permettaient que la sortie en rente
+2. **L'entreprise les transfère vers un PERECO** — transfert à l'initiative de l'employeur, neutre fiscalement
+3. **Ils s'éteignent** naturellement quand tous les bénéficiaires ont liquidé leurs droits
+
+### Migration PERCO → PERECO : faut-il le faire ?
+
+**Avantages :**
+- Accès à la **sortie en capital** si le PERCO ancien ne la permettait pas (rente uniquement)
+- Meilleure **portabilité** lors d'un changement d'employeur
+- Gestion d'actifs souvent plus moderne (gamme de fonds élargie)
+
+**Contraintes :**
+- Décision de **l'entreprise**, pas du salarié seul
+- Frais plafonnés à **1% de l'encours** si transfert avant 5 ans de détention ; **gratuit** au-delà
+- Délai administratif : **2 à 3 mois**
+- Les avoirs PERCO migrent dans le **compartiment 2** du PERECO (épargne salariale)
+
+**Ce que la migration ne permet PAS :**
+
+Le déblocage anticipé pour **achat de la résidence principale** n'est possible que sur le **compartiment 1** (versements volontaires) du PERECO. Les avoirs issus d'un ancien PERCO migrent en compartiment 2 — ils ne donnent pas droit à ce déblocage.
+
+**Migrer son PERCO juste avant un achat RP ne sert donc à rien** : les fonds restent bloqués jusqu'à la retraite (ou autre cas de déblocage restreint). Pour profiter du déblocage RP, il faut avoir alimenté volontairement le compartiment 1 du PERECO séparément, en amont.
+
+#### Cas de déblocage anticipé PERCO / PERECO
+
+Les cas de sortie anticipée sont beaucoup plus restreints que le PEE (art. L. 3334-14 C. trav., art. L. 224-4 CMF) :
 
 - Décès (bénéficiaire ou conjoint/PACS)
 - Invalidité 2e ou 3e catégorie SS (bénéficiaire, conjoint ou enfants)
 - Surendettement
 - Expiration des droits à l'assurance chômage
 - Cessation d'activité non salariée suite à liquidation judiciaire
-- Acquisition de la résidence principale (**PERO uniquement** — compartiment versements volontaires, pas intéressement/participation/abondement)
+- Acquisition de la résidence principale (**compartiment 1 PERECO uniquement** — pas sur les avoirs issus de PERCO migré)
 
-Mariage, naissance, divorce, rupture de contrat, création d'entreprise, violences conjugales : **non déblocables** sur PERCO/PERO.
+Mariage, naissance, divorce, rupture de contrat, création d'entreprise, violences conjugales : **non déblocables** sur PERCO/PERECO.
 
 ### Arbitrage PEE/PERCO vs PER individuel
 
 | Enveloppe | Avantage unique | Quand privilégier |
 |-----------|----------------|-------------------|
 | PEE | Abondement employeur (levier +30% à +300%) | D'abord, toujours — tant qu'il y a abondement |
-| PERCO / PERO | Abondement employeur sur épargne retraite | En second après PEE max |
+| PERECO | Abondement employeur sur épargne retraite | En second après PEE max |
 | PER individuel | Déduction RNI (pas de plafond d'abondement) | En complément, après saturation PEE/PERCO |
 
 **Règle d'or** : ne jamais abonder un PER individuel avant d'avoir saturé l'abondement employeur PEE + PERCO. L'abondement est de l'argent gratuit.

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -104,15 +104,53 @@ Enveloppe collective distincte du PER individuel.
 
 - **Abondement employeur** : exonéré IR et PS dans les plafonds — **AVANTAGE MAJEUR**
 - **Plafond abondement** : ~3 709 € par bénéficiaire (8% PASS — vérifier annuellement)
-- **Blocage** : 5 ans sauf cas de déblocage anticipé (mariage, naissance 3e enfant, achat RP, divorce avec enfant, fin contrat travail, surendettement, invalidité, décès, violences conjugales)
+- **Blocage** : 5 ans, sauf cas de déblocage anticipé (art. R. 3332-28 Code du travail)
 - **Sortie après 5 ans** : exonération IR, seuls PS 17,2% sur les gains
 - **Dividendes réinvestis** : exonérés IR tant qu'ils restent dans l'enveloppe
+
+#### Cas de déblocage anticipé PEE
+
+Chaque cas ouvre un délai de 6 mois pour effectuer le retrait (sauf décès et surendettement : retrait immédiat possible).
+
+| Cas | Précisions |
+|-----|-----------|
+| Mariage ou PACS du bénéficiaire | — |
+| Naissance ou adoption (3e enfant et suivants) | Famille portée à 3 enfants minimum |
+| Divorce / séparation / dissolution PACS | Avec garde d'au moins 1 enfant |
+| Invalidité | Bénéficiaire, conjoint/PACS, ou enfant (toute catégorie) |
+| Décès | Bénéficiaire ou conjoint/PACS |
+| Rupture du contrat de travail | Démission, licenciement, retraite, rupture conventionnelle |
+| Création ou reprise d'entreprise | Bénéficiaire, conjoint ou enfant |
+| Acquisition ou agrandissement de la résidence principale | Y compris construction, remise en état après catastrophe naturelle |
+| Surendettement | Sur demande de la commission de surendettement |
+| Violences conjugales | Loi n° 2021-1774 du 24 décembre 2021 |
 
 ### PERCO / PERO (PER d'entreprise)
 
 - **Sortie à la retraite** : rente ou capital
 - **Fiscalité sortie** : même que PER individuel (versements à barème, gains au PFU)
 - **Abondement employeur** : exonéré dans plafonds (~7 418 €, distinct du plafond PEE)
+
+#### Cas de déblocage anticipé PERCO / PERO
+
+Le PERCO/PERO est une enveloppe retraite — les cas de sortie anticipée sont **beaucoup plus restreints** que le PEE (art. L. 3334-14 Code du travail et art. L. 224-4 CMF pour le PERO).
+
+| Cas | PEE | PERCO / PERO |
+|-----|-----|-------------|
+| Décès (bénéficiaire ou conjoint) | Oui | Oui |
+| Invalidité (bénéficiaire, conjoint ou enfant) | Oui | Oui (2e ou 3e catégorie SS) |
+| Surendettement | Oui | Oui |
+| Expiration des droits à l'assurance chômage | Non | Oui |
+| Cessation d'activité non salariée (liquidation judiciaire) | Non | Oui |
+| Acquisition de la résidence principale | Oui | **PERO uniquement** (compartiment versements volontaires) |
+| Mariage / PACS | Oui | **Non** |
+| Naissance 3e enfant | Oui | **Non** |
+| Divorce / séparation | Oui | **Non** |
+| Rupture du contrat de travail | Oui | **Non** |
+| Création / reprise d'entreprise | Oui | **Non** |
+| Violences conjugales | Oui | **Non** |
+
+**Point d'attention PERO vs PERCO** : depuis la loi Pacte, le PERO (PER d'entreprise collectif) remplace progressivement le PERCO. L'acquisition de la résidence principale est un cas de déblocage uniquement pour le compartiment "versements volontaires" du PERO — pas pour les compartiments intéressement/participation/abondement.
 
 ### Arbitrage PEE/PERCO vs PER individuel
 

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -124,6 +124,161 @@ Enveloppe collective distincte du PER individuel.
 
 **Règle d'or** : ne jamais abonder un PER individuel avant d'avoir saturé l'abondement employeur PEE + PERCO. L'abondement est de l'argent gratuit.
 
+## Épargne salariale pour TNS : PEE/PERECO dans sa propre société
+
+Section dédiée au gérant TNS (gérant majoritaire SARL, gérant EURL à l'IS) qui met en place un PEE/PERECO dans sa propre société — situation distincte du salarié classique.
+
+Voir `data/equity-salarial.json` → `pee_perco_tns` pour les paramètres chiffrés.
+
+### Éligibilité selon la forme juridique
+
+| Forme juridique | Régime social dirigeant | Éligibilité PEE/PERECO | Notes |
+|----------------|------------------------|------------------------|-------|
+| SARL (gérant majoritaire > 50%) | TNS | **Oui** | Inclus explicitement depuis loi Pacte |
+| EURL à l'IS (gérant associé unique) | TNS | **Oui** | Idem |
+| EURL à l'IR | TNS | Oui (avec précautions) | Déductibilité indirecte — voir piège n°4 |
+| SAS / SASU (président) | Assimilé salarié | Oui (droit commun salarié) | Pas de cotisations TNS sur dividendes |
+| EI | TNS | **Non** | Pas de personnalité morale distincte |
+
+**Loi Pacte (art. 150, loi n° 2019-486 du 22 mai 2019)** : les entreprises sans salarié (hors dirigeant) peuvent mettre en place un PEE/PERECO. Les mandataires sociaux — gérant de SARL, gérant d'EURL — sont explicitement inclus parmi les bénéficiaires potentiels, même en l'absence de tout autre salarié.
+
+**Décret n° 2021-1131 du 30 août 2021** : pour les entreprises sans salarié, le plan peut être mis en place par décision unilatérale de l'employeur (DUE) — sans accord collectif. Dépôt obligatoire auprès de la DREETS ; à défaut, l'exonération ne s'applique pas.
+
+**Condition de présence de salariés** : supprimée depuis loi Pacte. Avant 2019, un salarié (hors dirigeant) était requis pour mettre en place un accord d'intéressement.
+
+### Mécanique de l'abondement TNS
+
+**Circuit :**
+1. Le dirigeant TNS effectue un versement volontaire sur le PEE/PERECO (depuis sa rémunération nette déjà taxée)
+2. La société verse l'abondement (charge déductible du résultat IS)
+3. L'abondement est exonéré de cotisations sociales TNS et d'IR dans les plafonds
+
+**Plafonds 2025 (PASS 2025 = 46 368 €) :**
+
+| Plan | Plafond abondement annuel | Base |
+|------|--------------------------|------|
+| PEE | 3 709 € | 8% × PASS |
+| PERECO | 7 418 € | 16% × PASS |
+| **Total cumulable** | **11 127 €** | PEE + PERECO = plafonds distincts non fongibles |
+
+L'abondement de la société ne peut dépasser 3× le versement du dirigeant (règle générale des plans).
+
+**Déductibilité IS :**
+L'abondement est une charge déductible du résultat (compte 6474 — charges de personnel liées à la participation et à l'intéressement, ou assimilé). Économie IS = abondement × taux IS (25%, ou 15% sur les 42 500 premiers € pour les PME éligibles).
+
+**Exonération cotisations sociales dans les plafonds :**
+- Côté société : pas de cotisations patronales sur l'abondement
+- Côté dirigeant TNS : l'abondement n'est pas intégré dans l'assiette des cotisations sociales TNS
+- Côté IR : abondement exclu du revenu imposable (art. 81-18° CGI)
+
+**Exemple chiffré — gérant SARL IS, IS 25%, cotisations TNS ≈ 42% :**
+
+Pour un abondement plafonné PEE de 3 709 € :
+- Coût net société après IS : 3 709 × (1 − 25%) = **2 782 €**
+- Économie cotisations TNS évitées sur cette somme : 3 709 × 42% ≈ **1 558 €** (si la société avait versé cet équivalent en rémunération)
+- Abondement reçu dans le PEE : **3 709 €**, bloqué 5 ans, sorti exonéré IR (PS 17,2% sur les gains seulement)
+
+### Arbitrage PEE/PERECO vs PER TNS (ex-Madelin)
+
+Deux enveloppes concurrentes pour l'optimisation fiscale du dirigeant TNS :
+
+| Critère | PEE / PERECO (abondement) | PER TNS (ex-Madelin, art. 154 bis CGI) |
+|---------|--------------------------|----------------------------------------|
+| Déduction du résultat société | Oui (charge IS) | Oui (cotisations déductibles) |
+| Économie cotisations TNS | Oui, dans plafonds | Oui (assiette cotisations réduite) |
+| Exonération IR entrée | Oui (abondement exclu du revenu) | Oui (déduction revenu professionnel) |
+| Plafond annuel | 11 127 € (PEE + PERECO) | 10% bénéfice + 15% fraction > PASS (plafond souvent plus élevé pour fort bénéfice) |
+| Liquidité | PEE : déblocage après 5 ans (cas anticipés nombreux) | Bloqué jusqu'à la retraite |
+| Sortie | PEE : exo IR, PS 17,2% gains / PERECO : barème + PFU gains | Barème IR (anciens Madelin : rente obligatoire) |
+| Complexité mise en place | DUE ou accord + dépôt DREETS | Souscription contrat individuel |
+
+**Recommandation pour TMI 30-41% :**
+1. Saturer d'abord PEE + PERECO (11 127 €) — double exonération IS + cotisations, liquidité supérieure
+2. Puis PER TNS (ex-Madelin) pour les montants supplémentaires si le bénéfice le justifie
+3. Enfin PER individuel (163 quatervicies) en complément, plafond partiellement commun
+
+**Recommandation pour TMI 45% :**
+- L'avantage du PER diminue si le TMI à la retraite reste élevé (report d'imposition, pas exonération)
+- PEE reste attractif : sortie en PFU sur gains (pas au barème), horizon 5 ans seulement
+
+### Conjoint salarié : leviers additionnels
+
+Quand le gérant embauche son conjoint, de nouveaux outils de rémunération optimisée deviennent accessibles.
+
+#### Prime de Partage de la Valeur (PPV)
+
+Dispositif issu de la loi n° 2022-1158 du 16 août 2022, pérennisé par la loi n° 2023-1107 du 29 novembre 2023 (transposition ANI).
+
+- **Bénéficiaires** : tous les salariés (dont le conjoint salarié). Le dirigeant TNS ne peut pas en bénéficier lui-même.
+- **Plafond exonération** : 3 000 € par bénéficiaire (ou 6 000 € si accord d'intéressement en vigueur)
+- **Exonérations dans le plafond** : cotisations sociales patronales et salariales
+- **Exonération IR** : pour les salariés dont la rémunération est < 3 SMIC (≈ 5 430 €/mois brut 2025) — jusqu'au 31/12/2026
+- **Au-delà du plafond ou > 3 SMIC** : imposable à l'IR et soumis aux cotisations sociales comme une prime ordinaire
+- **Pas de condition d'accord** : versable par décision unilatérale de l'employeur
+
+Intérêt pour la SARL unipersonnelle avec conjoint salarié : la PPV permet de verser jusqu'à 3 000 € (ou 6 000 €) sans cotisations ni IR pour le conjoint, déductible IS pour la société.
+
+#### Intéressement et participation
+
+Dès qu'un salarié (le conjoint) est embauché, l'accord d'intéressement s'applique à tous les salariés.
+
+| Dispositif | Exonération cotisations | Exonération IR | Plafond par bénéficiaire |
+|------------|------------------------|----------------|--------------------------|
+| Intéressement (placé PEE) | Oui | Oui | 75% PASS ≈ 34 776 € (2025) |
+| Participation (placée PEE) | Oui | Oui | 75% PASS ≈ 34 776 € (2025) |
+| Intéressement (non placé) | Oui | Non (IR) | Idem |
+
+L'intéressement ouvre également droit à un abondement employeur majoré (plafond PEE passe de 3× à toujours 3× le versement salarié, mais le plafond absolu reste 8% PASS). La PPV versée avec un accord d'intéressement est plafonnée à 6 000 € (au lieu de 3 000 €).
+
+#### Mutuelle santé famille
+
+L'employeur est tenu de proposer une complémentaire santé collective obligatoire (art. L. 911-7 CSS) avec prise en charge patronale ≥ 50% de la cotisation.
+
+**Option mutuelle famille :**
+- La société peut souscrire une mutuelle "famille" couvrant le salarié (conjoint) + enfants + le conjoint du salarié (i.e. le gérant)
+- La cotisation patronale est déductible IS et exonérée de cotisations sociales dans la limite de 6% du PASS + 1,5% par enfant à charge (art. 83-1° quater CGI et art. D. 242-1 CSS)
+- Le gérant TNS est couvert en tant que "conjoint" du salarié — sans être lui-même salarié
+
+**Dispense d'adhésion du conjoint salarié ailleurs :**
+Si le conjoint est par ailleurs salarié d'une autre entreprise et bénéficie à ce titre d'une mutuelle collective obligatoire, il peut demander une dispense d'adhésion à la mutuelle de la SARL (art. R. 242-1-6 CSS). Conditions à réunir :
+- La couverture existante est **obligatoire** chez l'autre employeur (pas une couverture optionnelle)
+- La dispense doit être demandée par écrit et conservée au dossier RH
+- Le nombre d'heures du contrat ne doit pas être déconnant (temps partiel très faible → couverture parfois insuffisante)
+
+**Point de vigilance** : une couverture obligatoire minimale chez l'autre employeur peut être moins avantageuse qu'une mutuelle famille bien choisie. Comparer avant de décider.
+
+### Pièges spécifiques TNS
+
+**1. Dépassement des plafonds d'abondement**
+La fraction d'abondement excédant 8% PASS (PEE) ou 16% PASS (PERECO) est réintégrée dans l'assiette des cotisations sociales TNS et dans l'IR. Surveiller en fin d'année.
+
+**2. Versement volontaire ≠ abondement**
+Le versement volontaire du dirigeant sur le PEE provient de sa rémunération nette déjà taxée — il n'est pas lui-même exonéré. Seul l'abondement versé par la société bénéficie de l'exonération. Ne pas confondre les deux flux.
+
+**3. Dividendes SARL et seuil 10% du capital**
+Pour un gérant majoritaire de SARL, les dividendes excédant 10% du (capital + comptes courants + primes d'émission) sont soumis aux cotisations sociales TNS (art. L. 131-6 CSS). Mécanisme indépendant du PEE/PERECO, mais à intégrer dans l'optimisation globale — des dividendes élevés déjà soumis aux cotisations réduisent l'intérêt de certaines stratégies.
+
+**4. EURL à l'IR : déductibilité indirecte**
+Si l'EURL est soumise à l'IR (transparence fiscale), l'abondement réduit le bénéfice de la société qui remonte directement dans le revenu de l'associé unique. L'effet est réel mais mécanique moins lisible. Vérifier le régime IS/IR de l'EURL avant la mise en place.
+
+**5. Formalisme obligatoire**
+- Mise en place par accord collectif ou DUE (post loi Pacte pour entreprises sans salarié)
+- Dépôt auprès de la DREETS dans les délais légaux
+- En l'absence de dépôt conforme : l'abondement est requalifié en complément de rémunération → cotisations + IR
+
+**6. SAS/SASU : régime différent**
+Le président de SAS/SASU est assimilé salarié. Pas de cotisations TNS sur les dividendes (quel que soit le montant). L'arbitrage PEE vs PER vs dividendes est distinct — ne pas appliquer les règles TNS à une SASU.
+
+### Références légales
+
+- **Code du travail** : art. L. 3332-1 et s. (PEE), L. 3332-2 (bénéficiaires, mandataires sociaux), L. 3334-1 et s. (PERECO), L. 3314-1 et s. (intéressement), L. 3323-1 et s. (participation)
+- **Loi Pacte** : loi n° 2019-486 du 22 mai 2019, art. 150 (ouverture aux entreprises sans salarié)
+- **Décret** : n° 2021-1131 du 30 août 2021 (modalités entreprises sans salarié)
+- **PPV** : loi n° 2022-1158 du 16 août 2022 ; loi n° 2023-1107 du 29 novembre 2023
+- **CGI** : art. 81-18° (exonération IR abondement), art. 83-1° quater (mutuelle collective), art. 154 bis (PER TNS / Madelin)
+- **CSS** : art. L. 131-6 (assiette cotisations TNS, dont dividendes SARL > 10%), L. 242-1 (exonération cotisations sur abondement), L. 911-7 (mutuelle obligatoire), R. 242-1-6 (dispense d'adhésion)
+- **BOFiP** : BOI-RSA-ES-10-10-20 (épargne salariale, abondement)
+
 ## Quotient pour revenus exceptionnels
 
 Vesting massif, cession d'entreprise, indemnité de départ → à activer.

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -133,24 +133,16 @@ Chaque cas ouvre un délai de 6 mois pour effectuer le retrait (sauf décès et 
 
 #### Cas de déblocage anticipé PERCO / PERO
 
-Le PERCO/PERO est une enveloppe retraite — les cas de sortie anticipée sont **beaucoup plus restreints** que le PEE (art. L. 3334-14 Code du travail et art. L. 224-4 CMF pour le PERO).
+Le PERCO/PERO est une enveloppe retraite — les cas de sortie anticipée sont beaucoup plus restreints que le PEE (art. L. 3334-14 Code du travail et art. L. 224-4 CMF pour le PERO) :
 
-| Cas | PEE | PERCO / PERO |
-|-----|-----|-------------|
-| Décès (bénéficiaire ou conjoint) | Oui | Oui |
-| Invalidité (bénéficiaire, conjoint ou enfant) | Oui | Oui (2e ou 3e catégorie SS) |
-| Surendettement | Oui | Oui |
-| Expiration des droits à l'assurance chômage | Non | Oui |
-| Cessation d'activité non salariée (liquidation judiciaire) | Non | Oui |
-| Acquisition de la résidence principale | Oui | **PERO uniquement** (compartiment versements volontaires) |
-| Mariage / PACS | Oui | **Non** |
-| Naissance 3e enfant | Oui | **Non** |
-| Divorce / séparation | Oui | **Non** |
-| Rupture du contrat de travail | Oui | **Non** |
-| Création / reprise d'entreprise | Oui | **Non** |
-| Violences conjugales | Oui | **Non** |
+- Décès (bénéficiaire ou conjoint/PACS)
+- Invalidité 2e ou 3e catégorie SS (bénéficiaire, conjoint ou enfants)
+- Surendettement
+- Expiration des droits à l'assurance chômage
+- Cessation d'activité non salariée suite à liquidation judiciaire
+- Acquisition de la résidence principale (**PERO uniquement** — compartiment versements volontaires, pas intéressement/participation/abondement)
 
-**Point d'attention PERO vs PERCO** : depuis la loi Pacte, le PERO (PER d'entreprise collectif) remplace progressivement le PERCO. L'acquisition de la résidence principale est un cas de déblocage uniquement pour le compartiment "versements volontaires" du PERO — pas pour les compartiments intéressement/participation/abondement.
+Mariage, naissance, divorce, rupture de contrat, création d'entreprise, violences conjugales : **non déblocables** sur PERCO/PERO.
 
 ### Arbitrage PEE/PERCO vs PER individuel
 

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -266,7 +266,14 @@ Dispositif issu de la loi n° 2022-1158 du 16 août 2022, pérennisé par la loi
 - **Au-delà du plafond ou > 3 SMIC** : imposable à l'IR et soumis aux cotisations sociales comme une prime ordinaire
 - **Pas de condition d'accord** : versable par décision unilatérale de l'employeur
 
-Intérêt pour la SARL unipersonnelle avec conjoint salarié : la PPV permet de verser jusqu'à 3 000 € (ou 6 000 €) sans cotisations ni IR pour le conjoint, déductible IS pour la société.
+**Piège depuis le 1er janvier 2025 — effet Fillon :**
+Depuis 2025, la PPV est intégrée dans la rémunération brute servant à calculer la **réduction générale de cotisations patronales** (réduction Fillon). Pour un conjoint salarié proche du SMIC, chaque euro de PPV augmente mécaniquement la base de calcul → le coefficient Fillon diminue → l'employeur perd une partie de ses allègements de charges.
+
+Exemple : une PPV de 1 500 € pour un salarié au SMIC peut coûter en réalité ~2 300 € à l'employeur une fois la perte de réduction Fillon comptabilisée. **Avant de verser une PPV à un salarié proche du SMIC, simuler l'impact sur la réduction Fillon.**
+
+Dans cette configuration, **l'intéressement peut être plus avantageux que la PPV** : il n'est pas intégré dans l'assiette de la réduction Fillon de la même façon et peut s'avérer moins coûteux pour l'employeur.
+
+Intérêt pour la SARL unipersonnelle avec conjoint salarié : la PPV reste pertinente si le conjoint est bien au-dessus du SMIC (rémunération éloignée de la zone d'effet Fillon) ou si la SARL ne bénéficie pas de la réduction Fillon (salaire > 1,6 SMIC).
 
 #### Intéressement et participation
 

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -268,6 +268,10 @@ Voir `data/equity-salarial.json` → `pee_perco_tns` pour les paramètres chiffr
 
 L'abondement de la société ne peut dépasser 3× le versement du dirigeant (règle générale des plans).
 
+**Plafond de versement du bénéficiaire sur le PEE :** les versements volontaires personnels sur un PEE sont plafonnés à **25% de la rémunération annuelle brute**. Pour le dirigeant TNS : 25% de la rémunération annuelle déclarée (ou 25% du bénéfice imposable si EI). Ce plafond de versement salarié est distinct du plafond d'abondement employeur.
+
+**Versements volontaires PERECO (compartiment 1) :** le dirigeant peut également alimenter volontairement le compartiment 1 du PERECO, ce qui ouvre le droit au déblocage anticipé pour **achat de la résidence principale**. Les avoirs issus d'abondement/intéressement (compartiment 2) ne donnent pas ce droit.
+
 **Déductibilité IS :**
 L'abondement est une charge déductible du résultat (compte 6474 — charges de personnel liées à la participation et à l'intéressement, ou assimilé). Économie IS = abondement × taux IS (25%, ou 15% sur les 42 500 premiers € pour les PME éligibles).
 
@@ -348,8 +352,8 @@ Dès qu'un salarié (le conjoint) est embauché, l'accord d'intéressement s'app
 
 | Dispositif | Exonération cotisations | Exonération IR | Plafond par bénéficiaire |
 |------------|------------------------|----------------|--------------------------|
-| Intéressement (placé PEE) | Oui | Oui | 75% PASS ≈ 34 776 € (2025) |
-| Participation (placée PEE) | Oui | Oui | 75% PASS ≈ 34 776 € (2025) |
+| Intéressement (placé PEE) | Oui | Oui | 75% PASS ≈ 35 325 € (2025) |
+| Participation (placée PEE) | Oui | Oui | 75% PASS ≈ 35 325 € (2025) |
 | Intéressement (non placé) | Oui | Non (IR) | Idem |
 
 L'intéressement ouvre également droit à un abondement employeur majoré (plafond PEE passe de 3× à toujours 3× le versement salarié, mais le plafond absolu reste 8% PASS). La PPV versée avec un accord d'intéressement est plafonnée à 6 000 € (au lieu de 3 000 €).

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -227,7 +227,7 @@ Mariage, naissance, divorce, rupture de contrat, création d'entreprise, violenc
 | PERECO | Abondement employeur sur épargne retraite | En second après PEE max |
 | PER individuel | Déduction RNI (pas de plafond d'abondement) | En complément, après saturation PEE/PERCO |
 
-**Règle d'or** : ne jamais abonder un PER individuel avant d'avoir saturé l'abondement employeur PEE + PERCO. L'abondement est de l'argent gratuit.
+**Règle d'or** : ne jamais abonder un PER individuel avant d'avoir saturé l'abondement employeur PEE + PERECO. La société abonde pour chaque euro versé par le bénéficiaire.
 
 ## Épargne salariale pour TNS : PEE/PERECO dans sa propre société
 

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -239,6 +239,18 @@ Deux enveloppes concurrentes pour l'optimisation fiscale du dirigeant TNS :
 - L'avantage du PER diminue si le TMI à la retraite reste élevé (report d'imposition, pas exonération)
 - PEE reste attractif : sortie en PFU sur gains (pas au barème), horizon 5 ans seulement
 
+**Point crucial — plafond partagé (163 quatervicies) :**
+L'abondement PERECO versé par la société est déclaré en **case 6QS** et réduit le plafond disponible pour les versements volontaires sur un PER individuel. PER individuel et PERECO pompent sur la même enveloppe fiscale.
+
+| Flux | Consomme le plafond 163 quatervicies ? |
+|------|----------------------------------------|
+| Versements volontaires PER individuel (6NS) | **Oui** |
+| Versements volontaires PERECO compartiment 1 (6NS) | **Oui** |
+| Abondement employeur PERECO (6QS) | **Oui** — réduit le plafond résiduel |
+| Intéressement / participation placés en PERECO | **Non** — exonération séparée |
+
+Un abondement PERECO de 7 418 € (plafond max) peut donc épuiser une grande partie du plafond annuel, laissant peu de marge pour un PER individuel complémentaire. À simuler avant de souscrire un PER individuel en parallèle.
+
 ### Conjoint salarié : leviers additionnels
 
 Quand le gérant embauche son conjoint, de nouveaux outils de rémunération optimisée deviennent accessibles.

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -103,7 +103,7 @@ Demander à la société :
 Enveloppe collective distincte du PER individuel.
 
 - **Abondement employeur** : exonéré IR et PS dans les plafonds — **AVANTAGE MAJEUR**
-- **Plafond abondement** : ~3 709 € par bénéficiaire (8% PASS — vérifier annuellement)
+- **Plafond abondement** : 8% × PASS de l'année de versement — voir `data/per-plafonds.json` → `epargne_salariale_abondement.pee`
 - **Blocage** : 5 ans, sauf cas de déblocage anticipé (art. R. 3332-28 Code du travail)
 - **Sortie après 5 ans** : exonération IR, seuls PS 17,2% sur les gains
 - **Dividendes réinvestis** : exonérés IR tant qu'ils restent dans l'enveloppe
@@ -129,7 +129,7 @@ Chaque cas ouvre un délai de 6 mois pour effectuer le retrait (sauf décès et 
 
 - **Sortie à la retraite** : rente ou capital
 - **Fiscalité sortie** : même que PER individuel (versements à barème, gains au PFU)
-- **Abondement employeur** : exonéré dans plafonds (~7 418 €, distinct du plafond PEE)
+- **Abondement employeur** : exonéré dans plafonds (16% × PASS, distinct du plafond PEE — voir `data/per-plafonds.json` → `epargne_salariale_abondement.pereco`)
 
 #### Cas de déblocage anticipé PERCO / PERO
 
@@ -183,13 +183,13 @@ Voir `data/equity-salarial.json` → `pee_perco_tns` pour les paramètres chiffr
 2. La société verse l'abondement (charge déductible du résultat IS)
 3. L'abondement est exonéré de cotisations sociales TNS et d'IR dans les plafonds
 
-**Plafonds 2025 (PASS 2025 = 46 368 €) :**
+**Plafonds** (recalculés chaque année sur le PASS — voir `data/per-plafonds.json` → `epargne_salariale_abondement`) :
 
-| Plan | Plafond abondement annuel | Base |
-|------|--------------------------|------|
-| PEE | 3 709 € | 8% × PASS |
-| PERECO | 7 418 € | 16% × PASS |
-| **Total cumulable** | **11 127 €** | PEE + PERECO = plafonds distincts non fongibles |
+| Plan | Formule | Exemple 2025 (PASS = 47 100 €) |
+|------|---------|-------------------------------|
+| PEE | 8% × PASS | 3 768 € |
+| PERECO | 16% × PASS | 7 536 € |
+| **Total cumulable** | **24% × PASS** | **11 304 €** — plafonds distincts non fongibles |
 
 L'abondement de la société ne peut dépasser 3× le versement du dirigeant (règle générale des plans).
 
@@ -203,10 +203,10 @@ L'abondement est une charge déductible du résultat (compte 6474 — charges de
 
 **Exemple chiffré — gérant SARL IS, IS 25%, cotisations TNS ≈ 42% :**
 
-Pour un abondement plafonné PEE de 3 709 € :
-- Coût net société après IS : 3 709 × (1 − 25%) = **2 782 €**
-- Économie cotisations TNS évitées sur cette somme : 3 709 × 42% ≈ **1 558 €** (si la société avait versé cet équivalent en rémunération)
-- Abondement reçu dans le PEE : **3 709 €**, bloqué 5 ans, sorti exonéré IR (PS 17,2% sur les gains seulement)
+Pour un abondement PEE au plafond (ex. 3 768 € en 2025) :
+- Coût net société après IS : 3 768 × (1 − 25%) = **2 826 €**
+- Économie cotisations TNS évitées : 3 768 × 42% ≈ **1 583 €** (vs versement en rémunération)
+- Abondement reçu dans le PEE : **3 768 €**, bloqué 5 ans, sorti exonéré IR (PS 17,2% sur les gains seulement)
 
 ### Arbitrage PEE/PERECO vs PER TNS (ex-Madelin)
 
@@ -217,13 +217,13 @@ Deux enveloppes concurrentes pour l'optimisation fiscale du dirigeant TNS :
 | Déduction du résultat société | Oui (charge IS) | Oui (cotisations déductibles) |
 | Économie cotisations TNS | Oui, dans plafonds | Oui (assiette cotisations réduite) |
 | Exonération IR entrée | Oui (abondement exclu du revenu) | Oui (déduction revenu professionnel) |
-| Plafond annuel | 11 127 € (PEE + PERECO) | 10% bénéfice + 15% fraction > PASS (plafond souvent plus élevé pour fort bénéfice) |
+| Plafond annuel | 24% × PASS (PEE + PERECO — voir per-plafonds.json) | 10% bénéfice + 15% fraction > PASS (plafond souvent plus élevé pour fort bénéfice) |
 | Liquidité | PEE : déblocage après 5 ans (cas anticipés nombreux) | Bloqué jusqu'à la retraite |
 | Sortie | PEE : exo IR, PS 17,2% gains / PERECO : barème + PFU gains | Barème IR (anciens Madelin : rente obligatoire) |
 | Complexité mise en place | DUE ou accord + dépôt DREETS | Souscription contrat individuel |
 
 **Recommandation pour TMI 30-41% :**
-1. Saturer d'abord PEE + PERECO (11 127 €) — double exonération IS + cotisations, liquidité supérieure
+1. Saturer d'abord PEE + PERECO (24% × PASS — voir per-plafonds.json) — double exonération IS + cotisations, liquidité supérieure
 2. Puis PER TNS (ex-Madelin) pour les montants supplémentaires si le bénéfice le justifie
 3. Enfin PER individuel (163 quatervicies) en complément, plafond partiellement commun
 
@@ -241,7 +241,7 @@ L'abondement PERECO versé par la société est déclaré en **case 6QS** et ré
 | Abondement employeur PERECO (6QS) | **Oui** — réduit le plafond résiduel |
 | Intéressement / participation placés en PERECO | **Non** — exonération séparée |
 
-Un abondement PERECO de 7 418 € (plafond max) peut donc épuiser une grande partie du plafond annuel, laissant peu de marge pour un PER individuel complémentaire. À simuler avant de souscrire un PER individuel en parallèle.
+Un abondement PERECO au plafond (16% × PASS) peut donc épuiser une grande partie du plafond annuel, laissant peu de marge pour un PER individuel complémentaire. À simuler avant de souscrire un PER individuel en parallèle.
 
 ### Conjoint salarié : leviers additionnels
 

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -365,7 +365,7 @@ L'employeur est tenu de proposer une complémentaire santé collective obligatoi
 
 **Option mutuelle famille :**
 - La société peut souscrire une mutuelle "famille" couvrant le salarié (conjoint) + enfants + le conjoint du salarié (i.e. le gérant)
-- La cotisation patronale est déductible IS et exonérée de cotisations sociales dans la limite de 6% du PASS + 1,5% par enfant à charge (art. 83-1° quater CGI et art. D. 242-1 CSS)
+- La cotisation patronale est déductible IS et exonérée de cotisations sociales dans la limite de 6% du PASS + 1,5% de la rémunération annuelle brute soumise à cotisations, le total étant plafonné à 12% du PASS (art. 83-1° quater CGI et art. D. 242-1 CSS)
 - Le gérant TNS est couvert en tant que "conjoint" du salarié — sans être lui-même salarié
 
 **Dispense d'adhésion du conjoint salarié ailleurs :**

--- a/fiscaliste/references/equity-salarial.md
+++ b/fiscaliste/references/equity-salarial.md
@@ -105,7 +105,7 @@ Enveloppe collective distincte du PER individuel.
 - **Abondement employeur** : exonéré IR et PS dans les plafonds — **AVANTAGE MAJEUR**
 - **Plafond abondement** : 8% × PASS de l'année de versement — voir `data/per-plafonds.json` → `epargne_salariale_abondement.pee`
 - **Blocage** : 5 ans, sauf cas de déblocage anticipé (art. R. 3332-28 Code du travail)
-- **Sortie après 5 ans** : exonération IR, seuls PS 17,2% sur les gains
+- **Sortie après 5 ans** : exonération IR, seuls les PS sur les gains (taux en vigueur au moment de la sortie — cf. SKILL.md § PFU et prélèvements sociaux ; 17,2% jusqu'au 31/12/2025, 18,6% à compter du 01/01/2026 suite à la LFSS 2026)
 - **Dividendes réinvestis** : exonérés IR tant qu'ils restent dans l'enveloppe
 
 #### Cas de déblocage anticipé PEE
@@ -147,7 +147,7 @@ Ces sommes ont été **exonérées d'IR à l'entrée** (pas déduites). La sorti
 
 | Mode de sortie | IR | Prélèvements sociaux |
 |---------------|----|--------------------|
-| **Capital** | **Exonéré** (sommes déjà exonérées à l'entrée) | 17,2% sur les gains uniquement |
+| **Capital** | **Exonéré** (sommes déjà exonérées à l'entrée) | PS sur les gains uniquement (taux en vigueur — cf. SKILL.md, 18,6% depuis la LFSS 2026) |
 | **Rente** | Régime des rentes viagères à titre onéreux — fraction taxable selon l'âge | PS sur la fraction taxable |
 
 **Fractions taxables de la rente (rente viagère à titre onéreux)** selon l'âge au premier versement :
@@ -165,7 +165,7 @@ La rente viagère à titre onéreux est plus favorable que la rente pension (PER
 
 | Mode de sortie | IR | Prélèvements sociaux |
 |---------------|----|--------------------|
-| **Capital** | Versements au barème IR (comme revenu ordinaire) | PFU 17,2% sur les gains |
+| **Capital** | Versements au barème IR (comme revenu ordinaire) | PFU sur les gains (taux PS en vigueur — cf. SKILL.md, 18,6% depuis la LFSS 2026) |
 | **Rente** | Régime des pensions (barème + abattement 10%) | PS 9,1% |
 
 #### Rente ou capital : quand choisir quoi ?
@@ -285,7 +285,7 @@ L'abondement est une charge déductible du résultat (compte 6474 — charges de
 Pour un abondement PEE au plafond (ex. 3 768 € en 2025) :
 - Coût net société après IS : 3 768 × (1 − 25%) = **2 826 €**
 - Économie cotisations TNS évitées : 3 768 × 42% ≈ **1 583 €** (vs versement en rémunération)
-- Abondement reçu dans le PEE : **3 768 €**, bloqué 5 ans, sorti exonéré IR (PS 17,2% sur les gains seulement)
+- Abondement reçu dans le PEE : **3 768 €**, bloqué 5 ans, sorti exonéré IR (PS sur les gains seulement, taux en vigueur — cf. SKILL.md, 18,6% depuis la LFSS 2026)
 
 ### Arbitrage PEE/PERECO vs PER TNS (ex-Madelin)
 
@@ -298,7 +298,7 @@ Deux enveloppes concurrentes pour l'optimisation fiscale du dirigeant TNS :
 | Exonération IR entrée | Oui (abondement exclu du revenu) | Oui (déduction revenu professionnel) |
 | Plafond annuel | 24% × PASS (PEE + PERECO — voir per-plafonds.json) | 10% bénéfice + 15% fraction > PASS (plafond souvent plus élevé pour fort bénéfice) |
 | Liquidité | PEE : déblocage après 5 ans (cas anticipés nombreux) | Bloqué jusqu'à la retraite |
-| Sortie | PEE : exo IR, PS 17,2% gains / PERECO : barème + PFU gains | Barème IR (anciens Madelin : rente obligatoire) |
+| Sortie | PEE : exo IR, PS gains (taux en vigueur — cf. SKILL.md) / PERECO : barème + PFU gains | Barème IR (anciens Madelin : rente obligatoire) |
 | Complexité mise en place | DUE ou accord + dépôt DREETS | Souscription contrat individuel |
 
 **Recommandation pour TMI 30-41% :**
@@ -333,8 +333,9 @@ Dispositif issu de la loi n° 2022-1158 du 16 août 2022, pérennisé par la loi
 - **Bénéficiaires** : tous les salariés (dont le conjoint salarié). Le dirigeant TNS ne peut pas en bénéficier lui-même.
 - **Plafond exonération** : 3 000 € par bénéficiaire (ou 6 000 € si accord d'intéressement en vigueur)
 - **Exonérations dans le plafond** : cotisations sociales patronales et salariales
-- **Exonération IR** : pour les salariés dont la rémunération est < 3 SMIC (≈ 5 430 €/mois brut 2025) — jusqu'au 31/12/2026
-- **Au-delà du plafond ou > 3 SMIC** : imposable à l'IR et soumis aux cotisations sociales comme une prime ordinaire
+- **Exonération IR** : réservée aux entreprises de **moins de 50 salariés**, pour les salariés dont la rémunération est < 3 SMIC (≈ 5 430 €/mois brut 2025) — jusqu'au 31/12/2026
+- **Entreprises ≥ 50 salariés** : la PPV reste exonérée de cotisations sociales dans le plafond, mais est imposable à l'IR (et soumise à CSG/CRDS) dès le premier euro, quelle que soit la rémunération
+- **Au-delà du plafond, ou > 3 SMIC dans une entreprise < 50 salariés** : imposable à l'IR et soumis aux cotisations sociales comme une prime ordinaire
 - **Pas de condition d'accord** : versable par décision unilatérale de l'employeur
 
 **Piège depuis le 1er janvier 2025 — effet Fillon :**

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -35,11 +35,18 @@ Exemple : versement 5 000 €, TMI 30% → économie IR = 1 500 €.
 
 ### Report des plafonds non utilisés
 
-Les plafonds non utilisés des **3 années précédentes** sont mobilisables. Ordre : plafond de l'année en cours d'abord, puis plafonds N-3, N-2, N-1 (ordre FIFO — le plus ancien en premier).
+Les plafonds non utilisés des années précédentes sont mobilisables. Ordre d'imputation : plafond de l'année en cours d'abord, puis plafonds reportés **en commençant par le plus ancien** (N-3, N-2, N-1).
 
-**Exemple** :
-- Plafond N : 5 000 €, utilisé 3 000 € → reste 2 000 € reportables sur N+1 à N+3
-- Au-delà de N+3, le plafond non utilisé est **perdu**
+**Durée du report :**
+- Jusqu'au 31/12/2025 : report sur les **3 années suivantes**
+- À compter du 01/01/2026 : report sur les **5 années suivantes** (loi de finances 2026)
+
+**Exemple (revenus 2025, déclaration 2026) :**
+- Plafond N : 5 000 €, utilisé 3 000 € → reste 2 000 € reportables
+- Si inutilisé, ce reliquat est disponible jusqu'en 2031 (5 ans)
+- Au-delà, le plafond non utilisé est **perdu**
+
+**Ordre FIFO obligatoire :** on consomme N-3 avant N-2 avant N-1 pour que les droits les plus anciens ne périment pas.
 
 ### Mutualisation couple
 

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -105,6 +105,8 @@ En versant aujourd'hui dans un PER, on accepte de **ne pas connaître les condit
 - Le TMI à la retraite dépend de la pension, des revenus du patrimoine, de la composition du foyer
 - Les règles fiscales sur les PER peuvent évoluer (c'est arrivé avec les PERP, les Madelin)
 
+> **⚠ Changement de résidence fiscale** : si vous quittez la France avant la retraite, la situation se complique. La France conserve un droit d'imposition sur les sommes déduites (retenue à la source sur les distributions à des non-résidents). Le régime exact dépend de la convention fiscale avec le pays de destination — certaines conventions attribuent le droit d'imposer à la France (pays source), d'autres au pays de résidence, certaines prévoient une imposition partagée. Le déblocage anticipé n'est pas autorisé pour ce motif. **Consulter un fiscaliste spécialisé en mobilité internationale avant tout versement significatif si un départ à l'étranger est envisagé.**
+
 **Contraste avec le PEE** : l'abondement est acquis immédiatement, exonéré d'IR de façon certaine, et la sortie après 5 ans est exonérée d'IR selon des règles stables. Pas de pari sur le futur.
 
 ### Cas favorables

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -38,13 +38,21 @@ Exemple : versement 5 000 €, TMI 30% → économie IR = 1 500 €.
 Les plafonds non utilisés des années précédentes sont mobilisables. Ordre d'imputation : plafond de l'année en cours d'abord, puis plafonds reportés **en commençant par le plus ancien** (N-3, N-2, N-1).
 
 **Durée du report :**
-- Jusqu'au 31/12/2025 : report sur les **3 années suivantes**
-- À compter du 01/01/2026 : report sur les **5 années suivantes** (loi de finances 2026)
+- Plafonds générés jusqu'en 2025 : report sur les **3 années suivantes**
+- Plafonds générés à partir de 2026 : report sur les **5 années suivantes** (loi de finances 2026 — non rétroactif)
+
+**Expiration des plafonds antérieurs :**
+
+| Plafond généré en | Expire fin | Règle |
+|------------------|-----------|-------|
+| 2023 | 2026 | 3 ans |
+| 2024 | 2027 | 3 ans |
+| 2025 | 2028 | 3 ans |
+| 2026 | 2031 | 5 ans (nouveau) |
 
 **Exemple (revenus 2025, déclaration 2026) :**
-- Plafond N : 5 000 €, utilisé 3 000 € → reste 2 000 € reportables
-- Si inutilisé, ce reliquat est disponible jusqu'en 2031 (5 ans)
-- Au-delà, le plafond non utilisé est **perdu**
+- Plafond N (2025) : 5 000 €, utilisé 3 000 € → reliquat 2 000 € disponible jusqu'à fin 2028 (3 ans, règle ancienne)
+- Plafond N (2026) : même scénario → reliquat disponible jusqu'à fin 2031 (5 ans)
 
 **Ordre FIFO obligatoire :** on consomme N-3 avant N-2 avant N-1 pour que les droits les plus anciens ne périment pas.
 

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -129,6 +129,44 @@ L'abondement est un complément versé par l'entreprise pour chaque euro versé 
 - Versements : case 6NS (déclarant 1) / 6NT (déclarant 2) sur la 2042
 - Plafond calculé automatiquement par la DGFIP (figure sur l'avis d'imposition N-1, rubrique "Plafond pour l'épargne retraite")
 
+## PER TNS (ex-Madelin) : spécificités du travailleur non salarié
+
+Le PER individuel (art. 163 quatervicies CGI) est accessible à tous, mais les TNS (gérant majoritaire SARL, gérant EURL, EI) disposent en plus du **PER TNS issu du contrat Madelin** (art. 154 bis CGI), avec un plafond de déduction spécifique.
+
+### Plafond de déduction PER TNS (art. 154 bis CGI)
+
+Plafond = **10% du bénéfice imposable** (dans la limite de 8 PASS) **+ 15% de la fraction du bénéfice comprise entre 1 PASS et 8 PASS**.
+
+| Composante | Calcul | Plafond 2025 |
+|------------|--------|--------------|
+| Fraction 10% | 10% × bénéfice (max 8 PASS) | Max 37 094 € |
+| Fraction 15% | 15% × (bénéfice − 46 368 €) si bénéfice > PASS | Variable |
+| Plancher | Même plancher que PER individuel | 4 710 € |
+
+Le plafond TNS est donc potentiellement **supérieur** au plafond du PER individuel (37 680 €) pour les bénéfices élevés. Consulter l'avis d'imposition pour le plafond exact calculé par la DGFIP.
+
+### Double avantage TNS
+
+Les cotisations versées sur un PER TNS sont :
+1. Déductibles du revenu professionnel (réduction IR)
+2. Déductibles de l'assiette des cotisations sociales TNS (réduction cotisations URSSAF)
+
+Ce double avantage est plus puissant que le PER individuel (qui ne joue que sur l'IR). Le taux effectif d'économie peut atteindre TMI + taux marginal de cotisations TNS.
+
+### Arbitrage PER TNS vs PEE/PERECO pour le dirigeant TNS
+
+Pour un dirigeant TNS qui peut mettre en place un PEE/PERECO dans sa société (voir `equity-salarial.md` → section dédiée TNS) :
+
+**Ordre de priorité recommandé :**
+1. Saturer l'abondement PEE + PERECO (11 127 € pour 2025) — double exonération IS + cotisations, liquidité PEE après 5 ans
+2. PER TNS (art. 154 bis) pour les montants supplémentaires — plafond plus élevé, double avantage IR + cotisations
+3. PER individuel (art. 163 quatervicies) en complément si plafond Madelin atteint
+
+**Pourquoi PEE/PERECO d'abord ?**
+- L'abondement société est exonéré de cotisations TNS côté dirigeant ET de charges patronales côté société
+- La sortie PEE est en PFU sur les gains (pas au barème) — avantage si TMI retraite = TMI actuel
+- Liquidité supérieure : PEE débloquable après 5 ans (nombreux cas anticipés)
+
 ## Différence PER individuel vs PERCO / PERO
 
 - **PER individuel** (présent doc) : versements volontaires, déductibles dans la limite du plafond, sortie imposée au barème.

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -22,16 +22,23 @@ Exemple : versement 5 000 €, TMI 30% → économie IR = 1 500 €.
 
 ### Formule
 
-**Plafond = 10% des revenus professionnels nets** de l'année N-1 (salaires après abattement 10%, BNC, BIC — pas les revenus du capital).
+**Plafond = max(plancher, 10% × revenus professionnels nets N-1)**, dans la limite du plafond absolu.
+
+```
+Plafond = max(4 710 €,  10% × revenus pro N-1)
+                  ↑                    ↑
+          garanti même          salaires après abattement 10%,
+          sans revenus          BNC, BIC — pas les revenus du capital
+```
 
 ### Bornes (revenus 2025)
 
-| Borne | Valeur | Base |
-|-------|--------|------|
-| Plancher | 4 710 € | 10% × PASS 2025 |
+| | Valeur | Base |
+|--|--------|------|
+| Plancher (minimum garanti) | 4 710 € | 10% × PASS 2025 |
 | Plafond absolu | 37 680 € | 10% × 8 × PASS 2025 |
 
-**Plancher garanti** même sans revenus professionnels → toujours au moins 4 710 € déductibles.
+Le plancher s'applique même sans aucun revenu professionnel — un foyer sans activité peut toujours déduire 4 710 €.
 
 ### Report des plafonds non utilisés
 

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -159,6 +159,27 @@ Cas de déblocage avant la retraite (sans pénalité fiscale sur le capital) :
 
 Hors ces cas : déblocage impossible (capital bloqué jusqu'à la retraite).
 
+### Décès avant la retraite : transmission du PER
+
+Le PER individuel est quasi-systématiquement souscrit sous forme assurance (contrat d'assurance-vie dédié). En cas de décès, il fonctionne **hors succession** via la clause bénéficiaire — comme une assurance-vie classique.
+
+**Avantage clé : l'IR différé est effacé au décès.** Les bénéficiaires ne paient pas l'impôt sur le revenu qui aurait été dû à la sortie — seule la fiscalité assurance s'applique.
+
+| Âge au décès | Régime fiscal pour les bénéficiaires |
+|---|---|
+| < 70 ans | 152 500 € par bénéficiaire exonéré, puis 20% jusqu'à 852 500 €, 31,25% au-delà (art. 990 I CGI) |
+| ≥ 70 ans | 30 500 € global exonéré tous bénéficiaires confondus, excédent soumis aux droits de succession (art. 757 B CGI) |
+
+**Mourir avant 70 ans avec un PER bien alimenté = transmission très efficace.** Le capital transmis bénéficie du même abattement que l'assurance-vie, et l'IR différé disparaît.
+
+**Piège de la rente en cas de décès :** si le titulaire a opté pour la rente viagère, les fonds sont aliénés — les héritiers ne récupèrent rien à la mort, sauf :
+- Clause de **réversion** (la rente continue au conjoint, à taux réduit)
+- **Annuités garanties** (la rente est versée jusqu'à un terme fixe même en cas de décès)
+
+Ces options réduisent le montant de la rente. À négocier à la souscription si la transmission est un objectif.
+
+**PER compte-titres (rare) :** tombe dans la succession classique — IR et droits de succession s'appliquent. Vérifier la forme du contrat.
+
 ## Priorité absolue : abondement employeur avant PER individuel
 
 **Avant tout versement PER individuel, vérifier que l'abondement PEE / PERECO de l'employeur est saturé.**

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -31,14 +31,16 @@ Plafond = max(4 710 €,  10% × revenus pro N-1)
           sans revenus          BNC, BIC — pas les revenus du capital
 ```
 
-### Bornes (revenus 2025)
+### Bornes
 
-| | Valeur | Base |
-|--|--------|------|
-| Plancher (minimum garanti) | 4 710 € | 10% × PASS 2025 |
-| Plafond absolu | 37 680 € | 10% × 8 × PASS 2025 |
+Voir `data/per-plafonds.json` → `per_individuel` pour les montants à jour (plancher et plafond absolu recalculés chaque année sur le PASS).
 
-Le plancher s'applique même sans aucun revenu professionnel — un foyer sans activité peut toujours déduire 4 710 €.
+| | Formule | Exemple 2025 (PASS = 47 100 €) |
+|--|---------|-------------------------------|
+| Plancher (minimum garanti) | 10% × PASS | 4 710 € |
+| Plafond absolu | 10% × 8 × PASS | 37 680 € |
+
+Le plancher s'applique même sans aucun revenu professionnel — un foyer sans activité peut toujours déduire au moins le plancher.
 
 ### Report des plafonds non utilisés
 

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -71,29 +71,54 @@ Les époux/pacsés soumis à imposition commune peuvent **mutualiser leurs plafo
 
 ## Arbitrage : le PER est-il vraiment utile ?
 
-**Le PER est un REPORT d'imposition, pas une exonération.**
+**Le PER est un report d'imposition, pas une exonération.** À la sortie, les versements sont imposés au barème et les gains au PFU. On ne sait pas aujourd'hui à quelle TMI on sortira, ni quelles seront les règles fiscales dans 10, 20 ou 30 ans.
 
-À la sortie, les versements sont imposés comme revenu (barème). Les gains sont imposés au PFU.
+### Le seul vrai avantage : les intérêts composés sur l'économie d'impôt
+
+Le mécanisme réel du PER n'est pas une économie d'impôt — c'est un **prêt sans intérêt de l'État** que vous investissez pendant plusieurs années.
+
+```
+Versement 10 000 €, TMI 41%
+→ Économie IR immédiate : 4 100 € (l'État vous "prête" cette somme)
+→ Vous investissez 10 000 € au lieu de 5 900 € (si vous aviez payé l'IR)
+→ Sur 20 ans à 5%/an : 10 000 € → 26 533 € vs 5 900 € → 15 654 €
+→ Écart brut avant impôt sortie : +10 879 €
+→ À la sortie TMI 30% : impôt sur les 10 000 € = 3 000 € (vs 4 100 € payés à l'entrée)
+→ Gain net = différentiel TMI (1 100 €) + rendement sur l'économie d'impôt investie
+```
+
+Plus l'horizon est long, plus l'effet de capitalisation sur les 4 100 € "prêtés" est puissant — indépendamment du différentiel de TMI.
 
 ### Gagnant / perdant
 
 | Situation | Résultat |
 |-----------|----------|
-| TMI entrée > TMI sortie | **Gain net** — économie à l'entrée > imposition sortie |
-| TMI entrée = TMI sortie | **Neutre fiscalement** — seul l'effet capitalisation sur l'économie initiale joue |
-| TMI entrée < TMI sortie | **Perte nette** — rare mais possible (carrière ascendante, sortie capital massif) |
+| TMI entrée > TMI sortie + horizon long | **Gain double** — différentiel TMI ET capitalisation |
+| TMI entrée = TMI sortie + horizon long | **Gain modeste** — capitalisation seule sur l'économie d'impôt |
+| TMI entrée < TMI sortie | **Perte nette** — rare (carrière très ascendante, sortie en capital massif une seule année) |
+| Horizon court (< 10 ans) | **Intérêt faible** — peu de temps pour la capitalisation |
 
-### Cas typiques favorables
+### Incertitude fiscale : le risque réel du PER
 
-- **Actif TMI 30-41% avec retraite estimée TMI 11-30%** : gain net substantiel
-- **Année de revenus exceptionnels** : versement pour écraser l'IR de l'année, sortie étalée plus tard
-- **Quotient pour revenus exceptionnels + PER** : combinaison puissante pour un vesting RSU important
+En versant aujourd'hui dans un PER, on accepte de **ne pas connaître les conditions de sortie** :
+- Le barème IR dans 20 ans est inconnu
+- Le TMI à la retraite dépend de la pension, des revenus du patrimoine, de la composition du foyer
+- Les règles fiscales sur les PER peuvent évoluer (c'est arrivé avec les PERP, les Madelin)
 
-### Cas défavorables ou neutres
+**Contraste avec le PEE** : l'abondement est acquis immédiatement, exonéré d'IR de façon certaine, et la sortie après 5 ans est exonérée d'IR selon des règles stables. Pas de pari sur le futur.
 
-- **TMI 11% stable** : intérêt marginal — seul l'effet capitalisation compte
-- **TMI 45% stable (hauts revenus à la retraite)** : pas d'avantage, imposition identique entrée/sortie
-- **Horizon court (< 10 ans avant retraite)** : peu d'effet de capitalisation
+### Cas favorables
+
+- **TMI 41-45% aujourd'hui → TMI estimée 30% à la retraite** : gain double (différentiel + capitalisation) — cas le plus favorable
+- **Horizon > 15 ans** : la capitalisation sur l'économie d'impôt devient significative même sans différentiel TMI
+- **Année de revenus exceptionnels** : versement ponctuel pour écraser une tranche marginale élevée, sortie étalée
+- **Quotient revenus exceptionnels + PER** : combinaison puissante pour un vesting RSU important
+
+### Cas peu intéressants
+
+- **TMI 11% stable** : économie d'impôt faible (1 100 € pour 10 000 € versés), capitalisation sur une base réduite
+- **TMI 45% stable à la retraite** : report sans gain fiscal, pari sur la capitalisation uniquement
+- **Horizon court (< 10 ans)** : capitalisation insuffisante, blocage contraignant pour peu de gain
 
 ## Sortie du PER
 

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -181,6 +181,22 @@ Pour un dirigeant TNS qui peut mettre en place un PEE/PERECO dans sa société (
 
 **Règle d'or** : toujours saturer l'abondement employeur (PEE + PERCO) AVANT d'abonder un PER individuel. L'abondement est de l'argent gratuit — aucun rendement PER individuel n'égale un match à 50-300%.
 
+### Plafond partagé : ce qui consomme le plafond 163 quatervicies
+
+Le plafond de déduction (art. 163 quatervicies) est commun à toutes les enveloppes retraite déductibles. Plusieurs flux le consomment ou le réduisent :
+
+| Flux | Case déclaration | Consomme le plafond ? |
+|------|-----------------|----------------------|
+| Versements volontaires PER individuel | 6NS / 6NT | **Oui** |
+| Versements volontaires PERECO (compartiment 1) | 6NS / 6NT | **Oui** |
+| Abondement employeur PERECO / PERCO | **6QS** | **Oui** — réduit le plafond disponible pour les versements volontaires |
+| Intéressement / participation placés en PERECO | — (non déclarés) | **Non** — exonération séparée, hors plafond |
+| Cotisations obligatoires PERO (compartiment 3) | 6QS | Oui (dans la limite exonérée) |
+
+**Conséquence pratique** : si l'employeur abonde 7 418 € sur le PERECO, ce montant est déclaré en 6QS et réduit d'autant le plafond restant pour les versements volontaires PER individuel. Un salarié qui reçoit le plafond maximum d'abondement PERECO peut se retrouver avec un plafond résiduel nul pour son PER individuel si son plafond global est modeste.
+
+**Pour les TNS** : l'abondement que la société verse sur le PERECO du dirigeant réduit de la même façon le plafond disponible pour un PER individuel — à intégrer dans l'arbitrage (voir `equity-salarial.md` → section TNS).
+
 ## Pièges fréquents
 
 1. **Oublier le plafond** : versement > plafond → fraction non déductible (mais remboursable sans frais ou reportable selon le contrat)

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -165,7 +165,7 @@ L'abondement est un complément versé par l'entreprise pour chaque euro versé 
 
 | Dispositif | Avantage |
 |------------|----------|
-| **PEE + abondement** | Prime gratuite de l'employeur + exonération IR sur l'abondement + PFU 17,2 % à la sortie (pas 30 %) |
+| **PEE + abondement** | La société abonde chaque versement + exonération IR sur l'abondement + PFU 17,2 % à la sortie (pas 30 %) |
 | **PERECO + abondement** | Idem + blocage jusqu'à la retraite |
 | **PER individuel** | Uniquement économie d'impôt immédiate × TMI, pas de match employeur |
 
@@ -221,7 +221,7 @@ Pour un dirigeant TNS qui peut mettre en place un PEE/PERECO dans sa société (
 - **PER individuel** (présent doc) : versements volontaires, déductibles dans la limite du plafond, sortie imposée au barème.
 - **PERECO / PEE** (plans d'épargne entreprise) : alimenté par intéressement, participation, abondement employeur. Voir la section Equity salarial listée depuis SKILL.md pour le détail.
 
-**Règle d'or** : toujours saturer l'abondement employeur (PEE + PERECO) AVANT d'abonder un PER individuel. L'abondement est de l'argent gratuit — aucun rendement PER individuel n'égale un match à 50-300%.
+**Règle d'or** : toujours saturer l'abondement employeur (PEE + PERECO) AVANT d'abonder un PER individuel. La société abonde pour chaque euro versé — aucun rendement PER individuel n'égale un match à 50-300%.
 
 ### Plafond partagé : ce qui consomme le plafond 163 quatervicies
 

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -159,17 +159,17 @@ Hors ces cas : déblocage impossible (capital bloqué jusqu'à la retraite).
 
 ## Priorité absolue : abondement employeur avant PER individuel
 
-**Avant tout versement PER individuel, vérifier que l'abondement PEE / PERCO de l'employeur est saturé.**
+**Avant tout versement PER individuel, vérifier que l'abondement PEE / PERECO de l'employeur est saturé.**
 
-L'abondement est un complément versé par l'entreprise pour chaque euro versé par le salarié sur son PEE ou son PERCO — typiquement 50 à 300 % du versement salarié, dans une limite annuelle (8 % du PASS pour le PEE, 16 % du PASS pour le PERCO).
+L'abondement est un complément versé par l'entreprise pour chaque euro versé par le salarié sur son PEE ou son PERECO — typiquement 50 à 300 % du versement salarié, dans une limite annuelle (8 % du PASS pour le PEE, 16 % du PASS pour le PERECO).
 
 | Dispositif | Avantage |
 |------------|----------|
 | **PEE + abondement** | Prime gratuite de l'employeur + exonération IR sur l'abondement + PFU 17,2 % à la sortie (pas 30 %) |
-| **PERCO + abondement** | Idem + blocage jusqu'à la retraite |
+| **PERECO + abondement** | Idem + blocage jusqu'à la retraite |
 | **PER individuel** | Uniquement économie d'impôt immédiate × TMI, pas de match employeur |
 
-**Règle** : un abondement employeur de 100 % représente un rendement immédiat de 100 %. Aucune défiscalisation PER n'égale ce rendement. Toujours saturer PEE/PERCO en premier si l'option existe.
+**Règle** : un abondement employeur de 100 % représente un rendement immédiat de 100 %. Aucune défiscalisation PER n'égale ce rendement. Toujours saturer PEE/PERECO en premier si l'option existe.
 
 ## Mécanique pratique
 
@@ -188,8 +188,8 @@ Plafond = **10% du bénéfice imposable** (dans la limite de 8 PASS) **+ 15% de 
 
 | Composante | Calcul | Plafond 2025 |
 |------------|--------|--------------|
-| Fraction 10% | 10% × bénéfice (max 8 PASS) | Max 37 094 € |
-| Fraction 15% | 15% × (bénéfice − 46 368 €) si bénéfice > PASS | Variable |
+| Fraction 10% | 10% × bénéfice (max 8 PASS) | Max 37 680 € |
+| Fraction 15% | 15% × (bénéfice − 47 100 €) si bénéfice > PASS | Variable |
 | Plancher | Même plancher que PER individuel | 4 710 € |
 
 Le plafond TNS est donc potentiellement **supérieur** au plafond du PER individuel (37 680 €) pour les bénéfices élevés. Consulter l'avis d'imposition pour le plafond exact calculé par la DGFIP.
@@ -207,7 +207,7 @@ Ce double avantage est plus puissant que le PER individuel (qui ne joue que sur 
 Pour un dirigeant TNS qui peut mettre en place un PEE/PERECO dans sa société (voir `equity-salarial.md` → section dédiée TNS) :
 
 **Ordre de priorité recommandé :**
-1. Saturer l'abondement PEE + PERECO (11 127 € pour 2025) — double exonération IS + cotisations, liquidité PEE après 5 ans
+1. Saturer l'abondement PEE + PERECO (11 304 € pour 2025) — double exonération IS + cotisations, liquidité PEE après 5 ans
 2. PER TNS (art. 154 bis) pour les montants supplémentaires — plafond plus élevé, double avantage IR + cotisations
 3. PER individuel (art. 163 quatervicies) en complément si plafond Madelin atteint
 
@@ -216,12 +216,12 @@ Pour un dirigeant TNS qui peut mettre en place un PEE/PERECO dans sa société (
 - La sortie PEE est en PFU sur les gains (pas au barème) — avantage si TMI retraite = TMI actuel
 - Liquidité supérieure : PEE débloquable après 5 ans (nombreux cas anticipés)
 
-## Différence PER individuel vs PERCO / PERO
+## Différence PER individuel vs PERECO / PERO
 
 - **PER individuel** (présent doc) : versements volontaires, déductibles dans la limite du plafond, sortie imposée au barème.
-- **PERCO / PEE** (plans d'épargne entreprise) : alimenté par intéressement, participation, abondement employeur. Voir la section Equity salarial listée depuis SKILL.md pour le détail.
+- **PERECO / PEE** (plans d'épargne entreprise) : alimenté par intéressement, participation, abondement employeur. Voir la section Equity salarial listée depuis SKILL.md pour le détail.
 
-**Règle d'or** : toujours saturer l'abondement employeur (PEE + PERCO) AVANT d'abonder un PER individuel. L'abondement est de l'argent gratuit — aucun rendement PER individuel n'égale un match à 50-300%.
+**Règle d'or** : toujours saturer l'abondement employeur (PEE + PERECO) AVANT d'abonder un PER individuel. L'abondement est de l'argent gratuit — aucun rendement PER individuel n'égale un match à 50-300%.
 
 ### Plafond partagé : ce qui consomme le plafond 163 quatervicies
 
@@ -245,7 +245,7 @@ Le plafond de déduction (art. 163 quatervicies) est commun à toutes les envelo
 2. **Sortie en capital sur un TMI 45%** : imposition quasi équivalente à un revenu normal — intérêt limité
 3. **Mutualisation couple oubliée** : conjoint sans revenu laisse 4 710 € de plafond inemployé
 4. **Assurer le plafond N-1 sur l'avis** : ne pas se fier aux calculs manuels, utiliser le plafond officiel DGFIP
-5. **PER individuel avant PEE/PERCO** : manque l'abondement employeur
+5. **PER individuel avant PEE/PERECO** : manque l'abondement employeur
 
 ## Références CGI / BOFiP
 

--- a/fiscaliste/references/per.md
+++ b/fiscaliste/references/per.md
@@ -188,7 +188,7 @@ L'abondement est un complément versé par l'entreprise pour chaque euro versé 
 
 | Dispositif | Avantage |
 |------------|----------|
-| **PEE + abondement** | La société abonde chaque versement + exonération IR sur l'abondement + PFU 17,2 % à la sortie (pas 30 %) |
+| **PEE + abondement** | La société abonde chaque versement + exonération IR sur l'abondement + seuls les PS à la sortie (taux en vigueur — cf. SKILL.md, pas le PFU à 30 %) |
 | **PERECO + abondement** | Idem + blocage jusqu'à la retraite |
 | **PER individuel** | Uniquement économie d'impôt immédiate × TMI, pas de match employeur |
 


### PR DESCRIPTION
Contexte

Le skill fiscaliste couvrait l'épargne salariale du point de vue du salarié classique. Cette PR ajoute le cas du dirigeant TNS qui met en place un PEE/PERECO dans sa propre société, approfondit la documentation PER, et corrige plusieurs imprécisions terminologiques et chiffrées.
Contenu

Épargne salariale TNS (equity-salarial.md + equity-salarial.json)

    Éligibilité par forme juridique (SARL gérant majoritaire, EURL IS, SASU — et pourquoi l'EI est exclue)
    Mécanique de l'abondement : circuit versement dirigeant → abondement société, plafonds 8%/16% PASS, ratio 3×, déductibilité IS
    Exemple chiffré : coût net après IS et exonération de cotisations TNS
    Arbitrage PEE/PERECO vs PER TNS (ex-Madelin, art. 154 bis CGI) — ordre de priorité recommandé
    Leviers conjoint salarié : PPV (avec le piège réduction Fillon depuis 2025), intéressement, mutuelle famille
    Plafond versement salarié PEE (25% rémunération brute) et compartiment 1 PERECO pour déblocage résidence principale

PER individuel (per.md)

    Reformulation de l'arbitrage autour des intérêts composés sur l'économie d'impôt ("prêt sans intérêt de l'État") plutôt que d'un simple différentiel de TMI
    Ajout section PER TNS / Madelin (art. 154 bis) : plafond spécifique, double avantage IR + cotisations
    LFI 2026 : extension du report des plafonds non utilisés de 3 à 5 ans — non rétroactif, table d'expiration par année
    Plafond partagé art. 163 quatervicies : tableau des flux qui consomment ou non le plafond (abondement PERECO case 6QS, intéressement hors plafond…)
    Warning changement de résidence fiscale : rétention à la source France, dépendance à la convention bilatérale, recommandation fiscaliste mobilité

Terminologie et données (per-plafonds.json)

    PERCO → PERECO corrigé partout (PERCO = ancien plan éteint depuis oct. 2020 ; PERECO = successeur loi Pacte ; PERO = PER Obligatoire, distinct)
    Centralisation des plafonds PASS dans per-plafonds.json — source unique, les autres fichiers référencent les formules
    Montants 2025 corrigés (PASS 47 100 €) : intéressement 35 325 €, cumul PEE+PERECO 11 304 €, PER TNS max 37 680 €
    Fiscalité sortie compartiment 2 PERECO corrigée : capital IR-exonéré + PS 17,2% sur gains uniquement (≠ barème comme PER individuel)
