### PR TITLE
feat(fiscaliste+notaire): AV succession — matrice 3 variables, PV latentes, décès

### DIFF
--- a/fiscaliste/data/pea-assurance-vie.json
+++ b/fiscaliste/data/pea-assurance-vie.json
@@ -37,6 +37,46 @@
     }
   },
 
+  "assurance_vie_deces": {
+    "description": "Fiscalité de la transmission AV au décès (distincte des rachats de vivant). Voir aussi skill notaire.",
+    "base_legale": ["art. 990 I CGI", "art. 757 B CGI", "art. L132-12 Code des assurances"],
+    "hors_succession": true,
+
+    "matrice_regimes": {
+      "description": "3 variables déterminent le régime applicable : date souscription contrat, âge au versement, date du versement",
+      "seul_cas_defavorable_757B": {
+        "condition": "Contrat souscrit APRÈS le 20/11/1991 ET primes versées APRÈS 70 ans ET versements À PARTIR du 13/10/1998",
+        "regime": "art. 757 B",
+        "abattement": "30 500 EUR global (tous bénéficiaires confondus)",
+        "assiette": "Primes uniquement (les gains/intérêts sont exonérés)",
+        "imposition_surplus": "Droits de succession selon le lien de parenté"
+      },
+      "tous_autres_cas_990I": {
+        "condition": "Tout autre cas : contrat pré-20/11/1991, OU primes avant 70 ans, OU versements avant 13/10/1998",
+        "regime": "art. 990 I",
+        "abattement_par_beneficiaire": 152500,
+        "taux": [
+          { "tranche": "0 à 700 000 EUR (après abattement)", "taux": "20%" },
+          { "tranche": "Au-delà de 700 000 EUR", "taux": "31,25%" }
+        ],
+        "assiette": "Capital décès total (primes + gains latents)"
+      }
+    },
+
+    "contrats_pre_1991_derogation": {
+      "description": "Contrats souscrits avant le 20/11/1991 : régime dérogatoire favorable — même les primes versées après 70 ans et après le 13/10/1998 relèvent de l'art. 990 I",
+      "conseil": "Ne jamais fermer un contrat pré-1991 sans vérifier cet avantage successoral",
+      "source": "BOI-RESS-000009 / art. 990 I CGI — interprétation date de souscription"
+    },
+
+    "pv_latentes_deces": {
+      "fait_generateur": false,
+      "description": "Le décès n'est pas un fait générateur de l'IR ni des PS. Les PV latentes sur UC s'effacent définitivement.",
+      "uc": "PV latentes exonérées d'IR et de PS — jamais imposées",
+      "fonds_euros": "PS prélevés annuellement au fil de l'eau (déjà acquittés) ; IR jamais dû"
+    }
+  },
+
   "assurance_vie_rachats": {
     "description": "Fiscalité des rachats de vivant (distincte de la transmission — voir skill notaire)",
 

--- a/fiscaliste/data/pea-assurance-vie.json
+++ b/fiscaliste/data/pea-assurance-vie.json
@@ -45,21 +45,22 @@
     "matrice_regimes": {
       "description": "3 variables déterminent le régime applicable : date souscription contrat, âge au versement, date du versement",
       "seul_cas_defavorable_757B": {
-        "condition": "Contrat souscrit APRÈS le 20/11/1991 ET primes versées APRÈS 70 ans ET versements À PARTIR du 13/10/1998",
+        "condition": "Contrat souscrit APRÈS le 20/11/1991 ET primes versées APRÈS 70 ans — quelle que soit la date de versement (le seuil du 13/10/1998 ne concerne que les primes versées AVANT 70 ans)",
         "regime": "art. 757 B",
         "abattement": "30 500 EUR global (tous bénéficiaires confondus)",
         "assiette": "Primes uniquement (les gains/intérêts sont exonérés)",
-        "imposition_surplus": "Droits de succession selon le lien de parenté"
+        "imposition_surplus": "Droits de succession selon le lien de parenté",
+        "note": "L'art. 757 B s'applique aux primes versées après 70 ans dès lors que le contrat est souscrit à compter du 20/11/1991, y compris pour les versements antérieurs au 13/10/1998. Il ne s'applique jamais aux contrats souscrits avant le 20/11/1991."
       },
       "tous_autres_cas_990I": {
-        "condition": "Tout autre cas : contrat pré-20/11/1991, OU primes avant 70 ans, OU versements avant 13/10/1998",
+        "condition": "Tout autre cas : contrat pré-20/11/1991 (quels que soient l'âge et la date de versement), OU primes versées avant 70 ans (quel que soit le contrat)",
         "regime": "art. 990 I",
         "abattement_par_beneficiaire": 152500,
         "taux": [
           { "tranche": "0 à 700 000 EUR (après abattement)", "taux": "20%" },
           { "tranche": "Au-delà de 700 000 EUR", "taux": "31,25%" }
         ],
-        "assiette": "Capital décès total (primes + gains latents)"
+        "assiette": "Capital décès total (primes + gains latents, nets des PS dus sur les gains UC — voir pv_latentes_deces)"
       }
     },
 
@@ -71,9 +72,10 @@
 
     "pv_latentes_deces": {
       "fait_generateur": false,
-      "description": "Le décès n'est pas un fait générateur de l'IR ni des PS. Les PV latentes sur UC s'effacent définitivement.",
-      "uc": "PV latentes exonérées d'IR et de PS — jamais imposées",
-      "fonds_euros": "PS prélevés annuellement au fil de l'eau (déjà acquittés) ; IR jamais dû"
+      "description": "Le décès n'est pas un fait générateur de l'IR. Les PV latentes sur UC ne sont en revanche PAS exonérées de PS au décès : depuis la LFSS 2010 (art. L136-7 II 3° CSS), l'assureur prélève les PS sur les gains UC au dénouement, nets des PS déjà acquittés, et les déduit du capital avant versement. Mécanisme validé par le Conseil d'État (CE 18/02/2026, n° 504077).",
+      "uc": "IR définitivement exonéré (pas de fait générateur) ; PS (17,2%) dus sur les gains constatés au décès, prélevés par l'assureur avant versement du capital — seul l'IR est purgé, pas les PS",
+      "fonds_euros": "PS prélevés annuellement au fil de l'eau (déjà acquittés) ; IR jamais dû",
+      "exemple": "500 000 EUR de PV latentes en UC → environ 86 000 EUR de PS (17,2%) prélevés par l'assureur avant versement aux bénéficiaires"
     }
   },
 

--- a/fiscaliste/data/pea-assurance-vie.json
+++ b/fiscaliste/data/pea-assurance-vie.json
@@ -52,8 +52,14 @@
         "imposition_surplus": "Droits de succession selon le lien de parenté",
         "note": "L'art. 757 B s'applique aux primes versées après 70 ans dès lors que le contrat est souscrit à compter du 20/11/1991, y compris pour les versements antérieurs au 13/10/1998. Il ne s'applique jamais aux contrats souscrits avant le 20/11/1991."
       },
-      "tous_autres_cas_990I": {
-        "condition": "Tout autre cas : contrat pré-20/11/1991 (quels que soient l'âge et la date de versement), OU primes versées avant 70 ans (quel que soit le contrat)",
+      "cas_exoneration_totale": {
+        "condition": "Primes versées AVANT le 13/10/1998, sur un contrat pré-20/11/1991 (tout âge) ou sur un contrat post-20/11/1991 avec versement AVANT 70 ans",
+        "regime": "Exonération totale",
+        "imposition": "Ni art. 990 I ni droits de succession — aucune imposition au titre de la transmission",
+        "note": "C'est le seuil du 13/10/1998, et non l'âge, qui fait basculer ces primes anciennes vers l'art. 990 I."
+      },
+      "cas_990I": {
+        "condition": "Primes versées À PARTIR du 13/10/1998 avant 70 ans (tout contrat), OU primes versées à partir du 13/10/1998 sur un contrat pré-20/11/1991 même après 70 ans (dérogation favorable)",
         "regime": "art. 990 I",
         "abattement_par_beneficiaire": 152500,
         "taux": [
@@ -65,7 +71,7 @@
     },
 
     "contrats_pre_1991_derogation": {
-      "description": "Contrats souscrits avant le 20/11/1991 : régime dérogatoire favorable — même les primes versées après 70 ans et après le 13/10/1998 relèvent de l'art. 990 I",
+      "description": "Contrats souscrits avant le 20/11/1991 : régime dérogatoire favorable. Primes versées avant le 13/10/1998 = exonération totale ; à partir du 13/10/1998, même après 70 ans, relèvent de l'art. 990 I (jamais 757 B)",
       "conseil": "Ne jamais fermer un contrat pré-1991 sans vérifier cet avantage successoral",
       "source": "BOI-RESS-000009 / art. 990 I CGI — interprétation date de souscription"
     },

--- a/fiscaliste/references/pea-assurance-vie.md
+++ b/fiscaliste/references/pea-assurance-vie.md
@@ -123,15 +123,32 @@ Taux dégressif selon ancienneté du contrat. Prélèvement libératoire (PFL) o
 
 ### Option barème
 
-**Avantageuse si TMI ≤ 11%** — le barème peut être meilleur que le PFU après 8 ans (car abattement annuel + taux IR faible).
+**Avantageuse si TMI ≤ 11%** — le barème peut être meilleur que le PFU après 8 ans (car taux IR faible).
 
 Option **globale** et irrévocable pour l'année.
+
+**Important** : l'abattement annuel (4 600 EUR / 9 200 EUR après 8 ans) s'applique **aussi bien au PFU qu'au barème** — ce n'est pas un avantage propre à l'option barème. La comparaison PFU vs barème se fait donc à abattement égal : seul le taux d'IR marginal diffère (7,5% sous PFU vs TMI sous barème).
 
 ### Contrats très anciens (avant 1983)
 
 Régime de faveur pour les contrats souscrits **avant le 1er janvier 1983** : exonération totale d'IR sur les gains.
 
 Extrêmement rare — à vérifier si le contrat est très ancien.
+
+## PV Latentes au Décès — Fiscalité Spécifique
+
+> **Périmètre** : ce qui suit concerne la fiscalité au décès de l'assuré. La transmission successorale AV (990 I / 757 B) est couverte par le skill `notaire`.
+
+**Le décès n'est pas un fait générateur de l'IR ni des prélèvements sociaux.** Les gains non réalisés au moment du décès ne sont jamais soumis à la fiscalité des rachats.
+
+| Support | Sort des gains latents au décès |
+|---------|----------------------------------|
+| Unités de compte (UC) | PV latentes définitivement exonérées d'IR et de PS — elles "s'effacent" |
+| Fonds en euros | PS déjà prélevés annuellement (au fil de l'eau) ; IR jamais dû (pas de rachat) |
+
+**Conséquence** : un contrat AV avec 300 000 EUR de PV latentes en UC transmet ces gains sans IR (12,8%) ni PS (17,2%). La seule taxation applicable est successorale (990 I ou 757 B), de nature différente.
+
+C'est l'un des avantages les plus méconnus de l'AV pour la transmission : **les PV latentes sur UC ne seront jamais fiscalisées à l'IR/PS si le contrat se dénoue par décès**.
 
 ## Stratégies courantes
 

--- a/fiscaliste/references/pea-assurance-vie.md
+++ b/fiscaliste/references/pea-assurance-vie.md
@@ -139,16 +139,18 @@ Extrêmement rare — à vérifier si le contrat est très ancien.
 
 > **Périmètre** : ce qui suit concerne la fiscalité au décès de l'assuré. La transmission successorale AV (990 I / 757 B) est couverte par le skill `notaire`.
 
-**Le décès n'est pas un fait générateur de l'IR ni des prélèvements sociaux.** Les gains non réalisés au moment du décès ne sont jamais soumis à la fiscalité des rachats.
+**Le décès n'est pas un fait générateur de l'IR.** Les gains non réalisés au moment du décès ne sont jamais soumis à la fiscalité des rachats au titre de l'IR — mais, pour les UC, les **prélèvements sociaux restent dus** (voir ci-dessous).
 
 | Support | Sort des gains latents au décès |
 |---------|----------------------------------|
-| Unités de compte (UC) | PV latentes définitivement exonérées d'IR et de PS — elles "s'effacent" |
+| Unités de compte (UC) | **IR** définitivement exonéré (le décès n'est pas un rachat) — mais **PS dus** sur les gains constatés au dénouement, nets des PS déjà acquittés le cas échéant |
 | Fonds en euros | PS déjà prélevés annuellement (au fil de l'eau) ; IR jamais dû (pas de rachat) |
 
-**Conséquence** : un contrat AV avec 300 000 EUR de PV latentes en UC transmet ces gains sans IR (12,8%) ni PS (17,2%). La seule taxation applicable est successorale (990 I ou 757 B), de nature différente.
+**Attention — piège fréquent : les PV latentes en UC ne sont PAS exonérées de prélèvements sociaux au décès.** Depuis la LFSS 2010 (art. L136-7 II 3° CSS), l'assureur prélève les PS sur les gains constatés en UC lors du dénouement par décès et les déduit du capital avant versement aux bénéficiaires. Le Conseil d'État a confirmé la validité de ce mécanisme (CE 18/02/2026, n° 504077). **Seul l'IR est définitivement évité — pas les PS.**
 
-C'est l'un des avantages les plus méconnus de l'AV pour la transmission : **les PV latentes sur UC ne seront jamais fiscalisées à l'IR/PS si le contrat se dénoue par décès**.
+**Conséquence** : un contrat AV avec 300 000 EUR de PV latentes en UC transmet ces gains sans IR (12,8%), mais l'assureur prélève environ 51 600 EUR de PS (17,2%) avant versement du capital aux bénéficiaires. La fiscalité successorale (990 I ou 757 B) s'applique ensuite sur le capital net de ces PS.
+
+Point souvent mal compris : **seul l'IR est purgé au décès sur les PV latentes en UC — les PS restent dus**. C'est différent des fonds en euros, où les PS ont déjà été prélevés au fil de l'eau (rien à prélever de plus au décès), et différent aussi du régime des cryptoactifs (voir `crypto.md`), où IR et PS sont tous deux purgés au décès — ne pas transposer ce raisonnement à l'assurance-vie en UC.
 
 ## Stratégies courantes
 

--- a/notaire/references/cas-speciaux.md
+++ b/notaire/references/cas-speciaux.md
@@ -30,9 +30,22 @@
 
 - **Hors succession** (art. L132-12 Code des assurances)
 - Clause bénéficiaire : vérifier systématiquement (acceptée ou non)
-- Primes avant 70 ans : abattement **152 500 EUR/bénéficiaire** puis 20% jusqu'à 700k, 31,25% au-delà (art. 990 I CGI)
-- Primes après 70 ans : abattement global **30 500 EUR** puis droits de succession sur le surplus des primes (art. 757 B CGI). Les intérêts sont exonérés.
-- Attention aux **primes manifestement excessives** (réintégration possible dans la succession)
+- Le régime fiscal dépend de **3 variables** : date de souscription, âge au versement, date du versement — voir le tableau complet dans `succession.md`
+
+**Régime de droit commun :**
+- Primes avant 70 ans (ou contrat pré-20/11/1991 + primes avant 13/10/1998) : abattement **152 500 EUR/bénéficiaire** puis 20%/31,25% (art. 990 I CGI)
+- Primes après 70 ans sur contrat post-20/11/1991 et versements post-13/10/1998 : abattement global **30 500 EUR** puis droits de succession sur les primes uniquement — les gains sont exonérés (art. 757 B CGI)
+
+**Contrats souscrits avant le 20/11/1991 — cas dérogatoire favorable :**
+- Même les primes versées **après 70 ans** et **après le 13/10/1998** relèvent de l'art. 990 I (abattement 152 500 EUR/bénéf.)
+- Le plafond défavorable de 30 500 EUR ne s'applique **jamais** à ces contrats anciens
+- **Ne jamais fermer un contrat pré-1991** sans vérifier cet avantage successoral
+
+**PV latentes au décès :**
+- UC : les plus-values latentes sont définitivement exonérées d'IR et de PS (le décès n'est pas un fait générateur)
+- Fonds € : PS prélevés chaque année au fil de l'eau ; IR jamais dû
+
+- Attention aux **primes manifestement excessives** (réintégration possible dans la succession, art. L132-13 Code des assurances)
 
 ## SCI : IR vs IS et Impact sur la Plus-Value
 

--- a/notaire/references/cas-speciaux.md
+++ b/notaire/references/cas-speciaux.md
@@ -33,11 +33,13 @@
 - Le régime fiscal dépend de **3 variables** : date de souscription, âge au versement, date du versement — voir le tableau complet dans `succession.md`
 
 **Régime de droit commun :**
-- Primes avant 70 ans (ou contrat pré-20/11/1991 + primes avant 13/10/1998) : abattement **152 500 EUR/bénéficiaire** puis 20%/31,25% (art. 990 I CGI)
+- **Exonération totale** (ni 990 I ni droits) : primes versées **avant le 13/10/1998**, que ce soit sur un contrat pré-20/11/1991 (tout âge) ou sur un contrat post-1991 avec versement avant 70 ans
+- Primes versées avant 70 ans **à partir du 13/10/1998** : abattement **152 500 EUR/bénéficiaire** puis 20%/31,25% (art. 990 I CGI)
 - Primes après 70 ans sur contrat post-20/11/1991 : abattement global **30 500 EUR** puis droits de succession sur les primes uniquement — les gains sont exonérés (art. 757 B CGI), **quelle que soit la date de versement** (le seuil du 13/10/1998 ne joue que pour les primes versées avant 70 ans)
 
 **Contrats souscrits avant le 20/11/1991 — cas dérogatoire favorable :**
-- Même les primes versées **après 70 ans** et **après le 13/10/1998** relèvent de l'art. 990 I (abattement 152 500 EUR/bénéf.)
+- Primes versées **avant le 13/10/1998** : exonération totale
+- Primes versées **à partir du 13/10/1998**, même après 70 ans, relèvent de l'art. 990 I (abattement 152 500 EUR/bénéf.)
 - Le plafond défavorable de 30 500 EUR ne s'applique **jamais** à ces contrats anciens
 - **Ne jamais fermer un contrat pré-1991** sans vérifier cet avantage successoral
 

--- a/notaire/references/cas-speciaux.md
+++ b/notaire/references/cas-speciaux.md
@@ -34,7 +34,7 @@
 
 **Régime de droit commun :**
 - Primes avant 70 ans (ou contrat pré-20/11/1991 + primes avant 13/10/1998) : abattement **152 500 EUR/bénéficiaire** puis 20%/31,25% (art. 990 I CGI)
-- Primes après 70 ans sur contrat post-20/11/1991 et versements post-13/10/1998 : abattement global **30 500 EUR** puis droits de succession sur les primes uniquement — les gains sont exonérés (art. 757 B CGI)
+- Primes après 70 ans sur contrat post-20/11/1991 : abattement global **30 500 EUR** puis droits de succession sur les primes uniquement — les gains sont exonérés (art. 757 B CGI), **quelle que soit la date de versement** (le seuil du 13/10/1998 ne joue que pour les primes versées avant 70 ans)
 
 **Contrats souscrits avant le 20/11/1991 — cas dérogatoire favorable :**
 - Même les primes versées **après 70 ans** et **après le 13/10/1998** relèvent de l'art. 990 I (abattement 152 500 EUR/bénéf.)
@@ -42,8 +42,8 @@
 - **Ne jamais fermer un contrat pré-1991** sans vérifier cet avantage successoral
 
 **PV latentes au décès :**
-- UC : les plus-values latentes sont définitivement exonérées d'IR et de PS (le décès n'est pas un fait générateur)
-- Fonds € : PS prélevés chaque année au fil de l'eau ; IR jamais dû
+- UC : l'**IR** est définitivement exonéré (le décès n'est pas un fait générateur), mais les **PS restent dus** sur les gains constatés au dénouement, prélevés par l'assureur avant versement du capital (LFSS 2010, art. L136-7 II 3° CSS ; CE 18/02/2026, n° 504077). Seul l'IR est purgé, pas les PS — ne pas confondre avec le régime des cryptoactifs où IR et PS sont tous deux purgés au décès.
+- Fonds € : PS prélevés chaque année au fil de l'eau (déjà acquittés) ; IR jamais dû
 
 - Attention aux **primes manifestement excessives** (réintégration possible dans la succession, art. L132-13 Code des assurances)
 

--- a/notaire/references/succession.md
+++ b/notaire/references/succession.md
@@ -156,15 +156,50 @@ Référence complète pour le droit des successions : dévolution, droits, abatt
 
 **Base légale** : art. 757 B et 990 I CGI
 
-| Primes versées | Régime | Base légale |
-|----------------|--------|-------------|
-| Avant 70 ans | Abattement 152 500 EUR par bénéficiaire, puis 20% jusqu'à 700 000 EUR, puis 31,25% | art. 990 I CGI |
-| Après 70 ans | Abattement global 30 500 EUR (tous bénéficiaires), puis droits de succession selon le lien | art. 757 B CGI |
+L'assurance-vie est **hors succession** (art. L132-12 Code des assurances). Les capitaux décès sont versés directement aux bénéficiaires désignés. Le régime fiscal dépend de **trois variables** : date de souscription du contrat, âge à la date du versement, et date du versement.
 
-**Points clés :**
-- L'assurance-vie est hors succession (art. L132-12 Code des assurances)
-- Clause bénéficiaire : vérifier sa rédaction (acceptation, démembrement, etc.)
+### Matrice des régimes fiscaux (3 variables)
+
+| Contrat souscrit | Âge à la date du versement | Date du versement | Régime |
+|------------------|:--------------------------:|-------------------|--------|
+| Avant le 20/11/1991 | < 70 ans | Peu importe | **Art. 990 I** : abattement 152 500 EUR/bénéf. |
+| Avant le 20/11/1991 | ≥ 70 ans | Avant le 13/10/1998 | **Art. 990 I** : abattement 152 500 EUR/bénéf. |
+| Avant le 20/11/1991 | ≥ 70 ans | À partir du 13/10/1998 | **Art. 990 I** : abattement 152 500 EUR/bénéf. (régime dérogatoire — contrat pré-1991 prime) |
+| Après le 20/11/1991 | < 70 ans | Peu importe | **Art. 990 I** : abattement 152 500 EUR/bénéf. |
+| Après le 20/11/1991 | ≥ 70 ans | Avant le 13/10/1998 | **Art. 990 I** : abattement 152 500 EUR/bénéf. |
+| Après le 20/11/1991 | ≥ 70 ans | À partir du 13/10/1998 | **Art. 757 B** : abattement global 30 500 EUR, puis droits de succession sur les primes |
+
+**Le seul cas défavorable** (757 B / plafond 30 500 EUR global) : contrat souscrit **après** le 20/11/1991 **ET** primes versées **après** 70 ans **ET** versements effectués **à partir** du 13/10/1998.
+
+**Règle clé pour les contrats pré-1991** : même des primes versées après 70 ans et après le 13/10/1998 relèvent de l'art. 990 I (abattement de 152 500 EUR par bénéficiaire) — le régime dérogatoire favorable s'applique dès lors que le contrat a été souscrit avant le 20/11/1991. Ne pas fermer ces contrats anciens.
+
+### Barèmes 990 I et 757 B
+
+| Régime | Assiette | Abattement | Taux |
+|--------|----------|:----------:|------|
+| Art. 990 I | Capital décès (valeur totale au décès, primes + gains latents) par bénéficiaire | 152 500 EUR/bénéf. | 20% jusqu'à 700 000 EUR, puis 31,25% |
+| Art. 757 B | Primes versées (hors gains) au-delà de l'abattement global | 30 500 EUR global (tous bénéficiaires) | Droits de succession selon le lien |
+
+**Sous l'art. 757 B, les gains (intérêts et PV) sont exonérés** — seules les primes sont taxées.
+
+### PV latentes et gains non réalisés au décès
+
+**Le décès n'est pas un fait générateur de l'IR ni des prélèvements sociaux (PS).** Les gains latents ne sont jamais soumis à la fiscalité des rachats.
+
+| Support | Sort des gains latents au décès |
+|---------|----------------------------------|
+| Unités de compte (UC) | PV latentes définitivement exonérées d'IR et de PS — elles "s'effacent" fiscalement |
+| Fonds en euros | PS déjà prélevés annuellement (au fil de l'eau) ; IR jamais dû (pas de rachat) |
+
+**Conséquence pratique** : une AV avec 500 000 EUR de PV latentes en UC transmet ces PV sans IR ni PS aux bénéficiaires. La seule fiscalité applicable est successorale (990 I ou 757 B), qui s'applique sur la valeur totale du capital (incluant les gains latents) mais à des taux et abattements spécifiques, sans rapport avec la fiscalité des rachats de vivant (PFU 30% ou barème).
+
+**Avantage décisif de l'AV pour la transmission** : cumul de l'abattement 152 500 EUR/bénéficiaire ET de l'effacement des PV latentes sur UC.
+
+### Autres points clés
+
+- Clause bénéficiaire : vérifier sa rédaction (acceptation, démembrement possible pour optimiser la transmission)
 - Contrats non dénoués au décès du conjoint : régime spécifique selon le régime matrimonial
+- Primes manifestement excessives : risque de réintégration dans la succession (art. L132-13 Code des assurances)
 
 ## Options du Conjoint Survivant
 

--- a/notaire/references/succession.md
+++ b/notaire/references/succession.md
@@ -162,15 +162,17 @@ L'assurance-vie est **hors succession** (art. L132-12 Code des assurances). Les 
 
 | Contrat souscrit | Âge à la date du versement | Date du versement | Régime |
 |------------------|:--------------------------:|-------------------|--------|
-| Avant le 20/11/1991 | < 70 ans | Peu importe | **Art. 990 I** : abattement 152 500 EUR/bénéf. |
-| Avant le 20/11/1991 | ≥ 70 ans | Avant le 13/10/1998 | **Art. 990 I** : abattement 152 500 EUR/bénéf. |
-| Avant le 20/11/1991 | ≥ 70 ans | À partir du 13/10/1998 | **Art. 990 I** : abattement 152 500 EUR/bénéf. (régime dérogatoire — contrat pré-1991 prime) |
-| Après le 20/11/1991 | < 70 ans | Peu importe | **Art. 990 I** : abattement 152 500 EUR/bénéf. |
+| Avant le 20/11/1991 | Peu importe | Avant le 13/10/1998 | **Exonération totale** : ni 990 I ni droits de succession |
+| Avant le 20/11/1991 | Peu importe | À partir du 13/10/1998 | **Art. 990 I** : abattement 152 500 EUR/bénéf. (régime dérogatoire — contrat pré-1991) |
+| Après le 20/11/1991 | < 70 ans | Avant le 13/10/1998 | **Exonération totale** : ni 990 I ni droits de succession |
+| Après le 20/11/1991 | < 70 ans | À partir du 13/10/1998 | **Art. 990 I** : abattement 152 500 EUR/bénéf. |
 | Après le 20/11/1991 | ≥ 70 ans | Peu importe | **Art. 757 B** : abattement global 30 500 EUR, puis droits de succession sur les primes |
 
-**Le seul cas défavorable** (757 B / plafond 30 500 EUR global) : contrat souscrit **après** le 20/11/1991 **ET** primes versées **après** 70 ans — **quelle que soit la date de versement**. Le seuil du 13/10/1998 ne joue que pour les primes versées **avant** 70 ans (art. 990 I à partir de cette date).
+**Le vrai cas d'exonération totale** : les primes versées **avant le 13/10/1998** échappent à toute imposition (ni 990 I ni droits), que le contrat soit pré- ou post-20/11/1991 (pour un contrat post-1991, à condition d'un versement avant 70 ans). C'est le seuil du 13/10/1998 — et non l'âge — qui bascule ces primes anciennes vers l'art. 990 I.
 
-**Règle clé pour les contrats pré-1991** : même des primes versées après 70 ans et après le 13/10/1998 relèvent de l'art. 990 I (abattement de 152 500 EUR par bénéficiaire) — le régime dérogatoire favorable s'applique dès lors que le contrat a été souscrit avant le 20/11/1991. Ne pas fermer ces contrats anciens.
+**Le seul cas défavorable** (757 B / plafond 30 500 EUR global) : contrat souscrit **après** le 20/11/1991 **ET** primes versées **après** 70 ans — **quelle que soit la date de versement**. Le seuil du 13/10/1998 ne joue que pour les primes versées **avant** 70 ans (exonération totale avant cette date, art. 990 I à partir).
+
+**Règle clé pour les contrats pré-1991** : primes versées **avant le 13/10/1998** = exonération totale ; primes versées **à partir du 13/10/1998**, même après 70 ans, relèvent de l'art. 990 I (abattement de 152 500 EUR par bénéficiaire) — le régime dérogatoire favorable s'applique dès lors que le contrat a été souscrit avant le 20/11/1991, et l'art. 757 B ne s'y applique jamais. Ne pas fermer ces contrats anciens.
 
 **Attention — l'art. 757 B ne dépend pas du 13/10/1998** : pour un contrat souscrit **après** le 20/11/1991, les primes versées **après 70 ans** relèvent de l'art. 757 B (abattement global 30 500 EUR) quelle que soit leur date de versement, y compris avant le 13/10/1998. L'art. 757 B ne s'applique jamais aux contrats souscrits avant le 20/11/1991.
 

--- a/notaire/references/succession.md
+++ b/notaire/references/succession.md
@@ -166,12 +166,13 @@ L'assurance-vie est **hors succession** (art. L132-12 Code des assurances). Les 
 | Avant le 20/11/1991 | ≥ 70 ans | Avant le 13/10/1998 | **Art. 990 I** : abattement 152 500 EUR/bénéf. |
 | Avant le 20/11/1991 | ≥ 70 ans | À partir du 13/10/1998 | **Art. 990 I** : abattement 152 500 EUR/bénéf. (régime dérogatoire — contrat pré-1991 prime) |
 | Après le 20/11/1991 | < 70 ans | Peu importe | **Art. 990 I** : abattement 152 500 EUR/bénéf. |
-| Après le 20/11/1991 | ≥ 70 ans | Avant le 13/10/1998 | **Art. 990 I** : abattement 152 500 EUR/bénéf. |
-| Après le 20/11/1991 | ≥ 70 ans | À partir du 13/10/1998 | **Art. 757 B** : abattement global 30 500 EUR, puis droits de succession sur les primes |
+| Après le 20/11/1991 | ≥ 70 ans | Peu importe | **Art. 757 B** : abattement global 30 500 EUR, puis droits de succession sur les primes |
 
-**Le seul cas défavorable** (757 B / plafond 30 500 EUR global) : contrat souscrit **après** le 20/11/1991 **ET** primes versées **après** 70 ans **ET** versements effectués **à partir** du 13/10/1998.
+**Le seul cas défavorable** (757 B / plafond 30 500 EUR global) : contrat souscrit **après** le 20/11/1991 **ET** primes versées **après** 70 ans — **quelle que soit la date de versement**. Le seuil du 13/10/1998 ne joue que pour les primes versées **avant** 70 ans (art. 990 I à partir de cette date).
 
 **Règle clé pour les contrats pré-1991** : même des primes versées après 70 ans et après le 13/10/1998 relèvent de l'art. 990 I (abattement de 152 500 EUR par bénéficiaire) — le régime dérogatoire favorable s'applique dès lors que le contrat a été souscrit avant le 20/11/1991. Ne pas fermer ces contrats anciens.
+
+**Attention — l'art. 757 B ne dépend pas du 13/10/1998** : pour un contrat souscrit **après** le 20/11/1991, les primes versées **après 70 ans** relèvent de l'art. 757 B (abattement global 30 500 EUR) quelle que soit leur date de versement, y compris avant le 13/10/1998. L'art. 757 B ne s'applique jamais aux contrats souscrits avant le 20/11/1991.
 
 ### Barèmes 990 I et 757 B
 
@@ -184,16 +185,18 @@ L'assurance-vie est **hors succession** (art. L132-12 Code des assurances). Les 
 
 ### PV latentes et gains non réalisés au décès
 
-**Le décès n'est pas un fait générateur de l'IR ni des prélèvements sociaux (PS).** Les gains latents ne sont jamais soumis à la fiscalité des rachats.
+**Le décès n'est pas un fait générateur de l'IR.** Les gains latents ne sont jamais soumis à la fiscalité des rachats au titre de l'IR. **En revanche, les prélèvements sociaux (PS) restent dus sur les gains latents en UC au décès** — ce n'est que l'IR qui est définitivement évité.
 
 | Support | Sort des gains latents au décès |
 |---------|----------------------------------|
-| Unités de compte (UC) | PV latentes définitivement exonérées d'IR et de PS — elles "s'effacent" fiscalement |
+| Unités de compte (UC) | **IR** définitivement exonéré — mais **PS dus** sur les gains constatés au dénouement, nets des PS déjà acquittés le cas échéant |
 | Fonds en euros | PS déjà prélevés annuellement (au fil de l'eau) ; IR jamais dû (pas de rachat) |
 
-**Conséquence pratique** : une AV avec 500 000 EUR de PV latentes en UC transmet ces PV sans IR ni PS aux bénéficiaires. La seule fiscalité applicable est successorale (990 I ou 757 B), qui s'applique sur la valeur totale du capital (incluant les gains latents) mais à des taux et abattements spécifiques, sans rapport avec la fiscalité des rachats de vivant (PFU 30% ou barème).
+**Attention, piège fréquent** : contrairement à une idée reçue, les PV latentes en UC ne sont **pas** exonérées de PS au décès. Depuis la LFSS 2010 (art. L136-7 II 3° CSS), l'assureur prélève les PS sur les gains UC constatés au dénouement par décès et les déduit du capital avant versement aux bénéficiaires. Le Conseil d'État a validé ce mécanisme (CE 18/02/2026, n° 504077). Ce point diffère du régime des cryptoactifs au décès (où IR et PS sont tous deux purgés) — les deux régimes ne doivent pas être confondus.
 
-**Avantage décisif de l'AV pour la transmission** : cumul de l'abattement 152 500 EUR/bénéficiaire ET de l'effacement des PV latentes sur UC.
+**Conséquence pratique** : une AV avec 500 000 EUR de PV latentes en UC transmet ces PV sans IR aux bénéficiaires, mais l'assureur prélève environ 86 000 EUR de PS (17,2%) avant versement. La fiscalité successorale (990 I ou 757 B) s'applique ensuite sur le capital net de ces PS, à des taux et abattements spécifiques, sans rapport avec la fiscalité des rachats de vivant (PFU 30% ou barème).
+
+**Avantage de l'AV pour la transmission** : cumul de l'abattement 152 500 EUR/bénéficiaire ET de la purge définitive de l'IR sur les PV latentes en UC — mais **les PS restent dus** sur ces mêmes PV, contrairement à ce qui est parfois avancé.
 
 ### Autres points clés
 


### PR DESCRIPTION
Plu value latentes au décès, clarification abattement option barème

Intègre les modifications des PR #34 et #36 du repo upstream :

PR #36 — Matrice complète 3 variables pour la fiscalité AV au décès :
- Date souscription contrat (avant/après 20/11/1991)
- Âge à la date du versement (avant/après 70 ans)
- Date du versement (avant/après 13/10/1998)
- Seul cas défavorable (757 B / 30 500 EUR global) : contrat post-1991 + primes post-70 ans + versements post-13/10/1998
- Contrats pré-1991 : régime dérogatoire favorable (990 I, 152 500 EUR/bénéf.) même pour primes après 70 ans et après 13/10/1998

PR #34 — Clarification option barème AV (2OP) :
- L'abattement annuel (4 600 EUR / 9 200 EUR) s'applique aussi bien au PFU qu'au barème
- Ce n'est pas un avantage propre à l'option barème

Ajout : fiscalité des PV latentes au décès :
- Le décès n'est pas un fait générateur de l'IR ni des PS
- UC : PV latentes définitivement exonérées d'IR et de PS
- Fonds € : PS prélevés au fil de l'eau ; IR jamais dû
- Mise à jour du JSON de données avec la section assurance_vie_deces
