### PR TITLE
feat(comptable): parseur CII + formats PA

### DIFF
--- a/comptable/references/facturation/plateformes-agreees.md
+++ b/comptable/references/facturation/plateformes-agreees.md
@@ -95,6 +95,38 @@ Pour recommander une PA, demander :
 | E-reporting | Transmet les données de facturation, transaction et paiement au PPF |
 | Conservation | Archive les factures 6 ans minimum |
 
+## Formats selon le réseau d'échange
+
+Trois formats sont définis par la norme européenne EN 16931. Toute PA immatriculée doit être capable d'émettre et de recevoir au moins l'un d'entre eux.
+
+| Format | Standard | Cas d'usage |
+|--------|----------|-------------|
+| **Factur-X** | PDF/A-3 + XML CII embarqué (EN 16931) | Format hybride : lisible par l'humain (PDF) et par la machine (XML CII embarqué). Recommandé pour les échanges entre PA françaises et pour les envois aux clients qui n'ont pas encore de PA. |
+| **CII pur** | Cross-Industry Invoice — UN/CEFACT (EN 16931) | Fichier XML seul, sans PDF. Même structure que le XML embarqué dans Factur-X. Utilisé pour les échanges machine-to-machine entre PA. |
+| **UBL** | Universal Business Language — OASIS (EN 16931) | Format natif du réseau Peppol. Requis pour les échanges avec des partenaires dont la PA est connectée au réseau Peppol (notamment les entreprises européennes hors France). |
+
+**Annuaire PPF** : registre central tenu par l'État qui associe chaque SIREN/SIRET à sa PA. Toutes les PA doivent l'interroger pour savoir où router une facture. L'annuaire ne dicte pas le format : c'est la PA destinataire qui déclare les formats qu'elle accepte.
+
+**Réseau Peppol** : réseau d'échange européen (transport AS4 + annuaire SML) utilisé par certaines PA pour acheminer les factures — y compris parfois entre PA françaises — et obligatoirement pour les échanges intra-UE avec des partenaires Peppol.
+
+**Conséquence sur le choix de PA** : si vous avez des clients dans l'UE déjà sur Peppol, choisissez une PA connectée au réseau Peppol (Indy, Dext, ou toute PA immatriculée avec cette capacité). Vérifiez dans le contrat de votre PA si elle prend en charge la conversion CII/Factur-X → UBL en sortie : cette conversion n'est pas imposée par la réglementation, elle est propre à chaque PA.
+
+Sources : [Spécification Factur-X (FNFE-MPE)](https://fnfe-mpe.org/factur-x/) · [Peppol BIS Billing 3.0](https://docs.peppol.eu/poacc/billing/3.0/) · [DGFiP — Facturation électronique](https://www.impots.gouv.fr/professionnel/je-passe-la-facturation-electronique)
+
+## PDPs pour éditeurs de logiciels et opérateurs
+
+Certaines PDPs immatriculées (ou en cours d'immatriculation) ciblent non pas les entreprises directement, mais les **éditeurs de logiciels** et les **Opérateurs de Dématérialisation (OD)** qui souhaitent intégrer la facturation électronique dans leurs propres produits via API.
+
+### Iopole
+
+- **Statut DGFiP** : immatriculation en cours — rapport d'audit de conformité attendu (source : [liste officielle DGFiP](https://www.impots.gouv.fr/je-consulte-la-liste-des-plateformes-agreees))
+- **Peppol** : oui
+- **Formats** : Factur-X, CII, UBL
+- **Cible** : éditeurs de logiciels et opérateurs (accès via API)
+- **Site** : https://www.iopole.com
+- **Siège** : 145 Impasse John Locke, 34470 Pérols
+- **Intérêt** : PDP française avec réseau Peppol, adaptée aux intégrateurs qui veulent embarquer la facturation électronique dans leur produit
+
 ## Devenir PA
 
 **Non recommandé pour les TPE/PME.** Conditions : ISO 27001, SecNumCloud (si hébergement tiers), audit de conformité, tests d'interopérabilité PPF, système d'information dans l'UE. Coût et complexité réservés aux éditeurs de logiciels et plateformes financières.

--- a/comptable/references/facturation/plateformes-agreees.md
+++ b/comptable/references/facturation/plateformes-agreees.md
@@ -95,37 +95,6 @@ Pour recommander une PA, demander :
 | E-reporting | Transmet les données de facturation, transaction et paiement au PPF |
 | Conservation | Archive les factures 6 ans minimum |
 
-## Formats selon le réseau d'échange
-
-Trois formats sont définis par la norme européenne EN 16931. Toute PA doit pouvoir émettre au moins l'un d'entre eux, mais doit être capable de recevoir les trois (socle complet Factur-X + CII + UBL).
-
-| Format | Standard | Cas d'usage |
-|--------|----------|-------------|
-| **Factur-X** | PDF/A-3 + XML CII embarqué (EN 16931) | Format hybride : lisible par l'humain (PDF) et par la machine (XML CII embarqué). Recommandé pour les échanges entre PA françaises et pour les envois aux clients qui n'ont pas encore de PA. |
-| **CII pur** | Cross-Industry Invoice — UN/CEFACT (EN 16931) | Fichier XML seul, sans PDF. Même structure que le XML embarqué dans Factur-X. Utilisé pour les échanges machine-to-machine entre PA. |
-| **UBL** | Universal Business Language — OASIS (EN 16931) | Format natif du réseau Peppol. Requis pour les échanges avec des partenaires dont la PA est connectée au réseau Peppol (notamment les entreprises européennes hors France). |
-
-**Annuaire PPF** : registre central tenu par l'État qui associe chaque SIREN/SIRET à sa PA. Toutes les PA doivent l'interroger pour savoir où router une facture. L'annuaire ne dicte pas le format : c'est la PA destinataire qui déclare les formats qu'elle accepte.
-
-**Réseau Peppol** : réseau d'échange européen (transport AS4 + annuaire SML) utilisé par certaines PA pour acheminer les factures — y compris parfois entre PA françaises — et obligatoirement pour les échanges intra-UE avec des partenaires Peppol.
-
-**Conséquence sur le choix de PA** : si vous avez des clients dans l'UE déjà sur Peppol, choisissez une PA connectée au réseau Peppol (Indy, Dext, ou toute PA immatriculée avec cette capacité). Vérifiez dans le contrat de votre PA si elle prend en charge la conversion CII/Factur-X → UBL en sortie : cette conversion n'est pas imposée par la réglementation, elle est propre à chaque PA.
-
-Sources : [Spécification Factur-X (FNFE-MPE)](https://fnfe-mpe.org/factur-x/) · [Peppol BIS Billing 3.0](https://docs.peppol.eu/poacc/billing/3.0/) · [DGFiP — Facturation électronique](https://www.impots.gouv.fr/professionnel/je-passe-la-facturation-electronique)
-
-## PA pour éditeurs de logiciels et opérateurs
-
-Certaines Plateformes Agréées (PA) ciblent non pas les entreprises directement, mais les **éditeurs de logiciels** et les **Opérateurs de Dématérialisation (OD)** qui souhaitent intégrer la facturation électronique dans leurs propres produits via API.
-
-### Iopole
-
-- **Statut DGFiP** : immatriculée définitivement (n° 0018) depuis le 11 décembre 2025 (source : [liste officielle DGFiP](https://www.impots.gouv.fr/je-consulte-la-liste-des-plateformes-agreees))
-- **Peppol** : oui
-- **Formats** : Factur-X, CII, UBL
-- **Cible** : éditeurs de logiciels et opérateurs (accès via API)
-- **Site** : https://www.iopole.com
-- **Intérêt** : PA française avec réseau Peppol, adaptée aux intégrateurs qui veulent embarquer la facturation électronique dans leur produit
-
 ## Devenir PA
 
 **Non recommandé pour les TPE/PME.** Conditions : ISO 27001, SecNumCloud (si hébergement tiers), audit de conformité, tests d'interopérabilité PPF, système d'information dans l'UE. Coût et complexité réservés aux éditeurs de logiciels et plateformes financières.

--- a/comptable/references/facturation/plateformes-agreees.md
+++ b/comptable/references/facturation/plateformes-agreees.md
@@ -97,7 +97,7 @@ Pour recommander une PA, demander :
 
 ## Formats selon le réseau d'échange
 
-Trois formats sont définis par la norme européenne EN 16931. Toute PA immatriculée doit être capable d'émettre et de recevoir au moins l'un d'entre eux.
+Trois formats sont définis par la norme européenne EN 16931. Toute PA doit pouvoir émettre au moins l'un d'entre eux, mais doit être capable de recevoir les trois (socle complet Factur-X + CII + UBL).
 
 | Format | Standard | Cas d'usage |
 |--------|----------|-------------|
@@ -113,19 +113,18 @@ Trois formats sont définis par la norme européenne EN 16931. Toute PA immatric
 
 Sources : [Spécification Factur-X (FNFE-MPE)](https://fnfe-mpe.org/factur-x/) · [Peppol BIS Billing 3.0](https://docs.peppol.eu/poacc/billing/3.0/) · [DGFiP — Facturation électronique](https://www.impots.gouv.fr/professionnel/je-passe-la-facturation-electronique)
 
-## PDPs pour éditeurs de logiciels et opérateurs
+## PA pour éditeurs de logiciels et opérateurs
 
-Certaines PDPs immatriculées (ou en cours d'immatriculation) ciblent non pas les entreprises directement, mais les **éditeurs de logiciels** et les **Opérateurs de Dématérialisation (OD)** qui souhaitent intégrer la facturation électronique dans leurs propres produits via API.
+Certaines Plateformes Agréées (PA) ciblent non pas les entreprises directement, mais les **éditeurs de logiciels** et les **Opérateurs de Dématérialisation (OD)** qui souhaitent intégrer la facturation électronique dans leurs propres produits via API.
 
 ### Iopole
 
-- **Statut DGFiP** : immatriculation en cours — rapport d'audit de conformité attendu (source : [liste officielle DGFiP](https://www.impots.gouv.fr/je-consulte-la-liste-des-plateformes-agreees))
+- **Statut DGFiP** : immatriculée définitivement (n° 0018) depuis le 11 décembre 2025 (source : [liste officielle DGFiP](https://www.impots.gouv.fr/je-consulte-la-liste-des-plateformes-agreees))
 - **Peppol** : oui
 - **Formats** : Factur-X, CII, UBL
 - **Cible** : éditeurs de logiciels et opérateurs (accès via API)
 - **Site** : https://www.iopole.com
-- **Siège** : 145 Impasse John Locke, 34470 Pérols
-- **Intérêt** : PDP française avec réseau Peppol, adaptée aux intégrateurs qui veulent embarquer la facturation électronique dans leur produit
+- **Intérêt** : PA française avec réseau Peppol, adaptée aux intégrateurs qui veulent embarquer la facturation électronique dans leur produit
 
 ## Devenir PA
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "facture": "node scripts/generate-facturx.js",
     "validate:facture": "node scripts/validate-facture.js",
     "parse:facture": "node scripts/parse-einvoice.js",
+    "test:parse": "node scripts/test-parse-einvoice.js",
     "fetch": "node integrations/stripe/fetch.js; node integrations/qonto/fetch.js",
     "fetch:qonto": "node integrations/qonto/fetch.js",
     "fetch:stripe": "node integrations/stripe/fetch.js"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "closing": "node scripts/generate-fec.js && node scripts/generate-statements.js && node scripts/generate-pdfs.js",
     "facture": "node scripts/generate-facturx.js",
     "validate:facture": "node scripts/validate-facture.js",
+    "parse:facture": "node scripts/parse-einvoice.js",
     "fetch": "node integrations/stripe/fetch.js; node integrations/qonto/fetch.js",
     "fetch:qonto": "node integrations/qonto/fetch.js",
     "fetch:stripe": "node integrations/stripe/fetch.js"

--- a/scripts/parse-einvoice.js
+++ b/scripts/parse-einvoice.js
@@ -231,7 +231,12 @@ function parseCII(xml) {
     const unitMatch = lineXml.match(/ram:BilledQuantity[^>]*unitCode="([^"]+)"/);
     const unitCode = unitMatch ? unitMatch[1] : null;
 
-    const unitPrice = parseAmount(tag(lineXml, 'ram:ChargeAmount')) ?? 0;
+    // Le prix unitaire est le prix NET (après remise). Sur une ligne avec
+    // remise, GrossPriceProductTradePrice (prix catalogue) précède
+    // NetPriceProductTradePrice — cibler le bloc net, pas le premier
+    // ChargeAmount du document. Repli sur la ligne entière si absent.
+    const netPriceBlock = block(lineXml, 'ram:NetPriceProductTradePrice');
+    const unitPrice = parseAmount(tag(netPriceBlock || lineXml, 'ram:ChargeAmount')) ?? 0;
     const lineTotal = parseAmount(tag(lineXml, 'ram:LineTotalAmount')) ?? 0;
 
     return {

--- a/scripts/parse-einvoice.js
+++ b/scripts/parse-einvoice.js
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+
+/**
+ * Lecture de factures électroniques au format CII (Factur-X / EN 16931)
+ *
+ * Extrait les données structurées d'une facture reçue au format CII
+ * et les retourne dans le même format JSON qu'attend generate-facturx.js,
+ * avec en plus le détail de la ventilation TVA (tax_breakdown).
+ *
+ * Usage :
+ *   node scripts/parse-einvoice.js --invoice output/F-2026-001.xml
+ *   node scripts/parse-einvoice.js --invoice output/F-2026-001.xml --json
+ *
+ * Formats supportés :
+ *   - XML CII (Cross-Industry Invoice, EN 16931 / Factur-X)
+ *
+ * Format UBL (réseau Peppol) : non encore supporté.
+ *
+ * Pour extraire le XML embarqué d'un Factur-X PDF, utilisez pdfdetach
+ * (fourni par le paquet poppler-utils) :
+ *   pdfdetach -savefile factur-x.xml votre-facture.pdf
+ *   node scripts/parse-einvoice.js --invoice factur-x.xml
+ *
+ * Hypothèses du parseur :
+ *   - Les noms d'éléments CII ne sont pas auto-imbriqués (ex : pas de
+ *     <ram:SellerTradeParty> dans un <ram:SellerTradeParty>).
+ *   - Le séparateur décimal est le point (.) — requis par la norme EN 16931.
+ *   - Pour un usage en production sur des CII arbitraires, préférer un
+ *     parseur XML dédié (ex : fast-xml-parser).
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Helpers d'extraction XML
+// Ciblés sur le schéma CII EN 16931 — pas un parseur XML générique.
+// ---------------------------------------------------------------------------
+
+// Contenu texte de la première occurrence d'un tag (avec ou sans attributs).
+function tag(xml, name) {
+  const m = xml.match(new RegExp(`<${name}[^>]*>([^<]*)<\\/${name}>`));
+  return m ? unescapeXml(m[1].trim()) : null;
+}
+
+// Contenu texte d'un tag portant un attribut précis (ex: schemeID="0002").
+// Gère les guillemets simples et doubles.
+function tagAttr(xml, name, attr, value) {
+  const re = new RegExp(`<${name}[^>]*${attr}=["']${value}["'][^>]*>([^<]*)<\\/${name}>`);
+  const m = xml.match(re);
+  return m ? unescapeXml(m[1].trim()) : null;
+}
+
+// Premier sous-bloc délimité par un tag (avec attributs éventuels).
+// Suppose que le tag n'est pas auto-imbriqué (voir en-tête).
+function block(xml, name) {
+  const re = new RegExp(`<${name}[\\s>][\\s\\S]*?<\\/${name}>`);
+  const m = xml ? xml.match(re) : null;
+  return m ? m[0] : null;
+}
+
+// Toutes les occurrences non-chevauchantes d'un bloc délimité par un tag.
+function allBlocks(xml, name) {
+  const blocks = [];
+  const re = new RegExp(`<${name}[\\s>][\\s\\S]*?<\\/${name}>`, 'g');
+  let m;
+  while ((m = re.exec(xml)) !== null) blocks.push(m[0]);
+  return blocks;
+}
+
+// Convertit une date au format CII 102 (YYYYMMDD) en ISO (YYYY-MM-DD).
+function parseDate102(raw) {
+  if (!raw || raw.length !== 8) return raw || null;
+  return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`;
+}
+
+// Parse un montant en virgule fixe. Retourne null si la valeur est absente
+// ou non numérique (EN 16931 impose le point comme séparateur décimal).
+function parseAmount(raw) {
+  if (!raw) return null;
+  const n = parseFloat(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+function unescapeXml(str) {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+}
+
+// ---------------------------------------------------------------------------
+// Détection du format à partir de l'espace de noms XML
+// ---------------------------------------------------------------------------
+
+function detectFormat(xml) {
+  if (xml.includes('CrossIndustryInvoice')) return 'cii';
+  if (xml.includes('urn:oasis:names:specification:ubl:schema:xsd:Invoice')) return 'ubl';
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing CII — Cross-Industry Invoice (EN 16931 / Factur-X)
+//
+// Structure de référence :
+//   rsm:CrossIndustryInvoice
+//     rsm:ExchangedDocumentContext   → profil (EN 16931)
+//     rsm:ExchangedDocument          → numéro, type, date, notes
+//     rsm:SupplyChainTradeTransaction
+//       ram:ApplicableHeaderTradeAgreement
+//         ram:SellerTradeParty       → vendeur
+//         ram:BuyerTradeParty        → acheteur
+//       ram:ApplicableHeaderTradeDelivery
+//       ram:ApplicableHeaderTradeSettlement
+//         ram:InvoiceCurrencyCode
+//         ram:ApplicableTradeTax     → ventilation TVA (N blocs, un par taux)
+//         ram:SpecifiedTradePaymentTerms → échéance, conditions
+//         ram:SpecifiedTradeSettlementHeaderMonetarySummation → totaux
+//       ram:IncludedSupplyChainTradeLineItem (N lignes)
+// ---------------------------------------------------------------------------
+
+function parseCII(xml) {
+  // --- Document ---
+  const exchangedDoc = block(xml, 'rsm:ExchangedDocument') || '';
+  const number = tag(exchangedDoc, 'ram:ID');
+  const typeCode = tag(exchangedDoc, 'ram:TypeCode');
+  const type = typeCode === '381' ? 'credit_note' : 'invoice';
+  const rawDate = tag(exchangedDoc, 'udt:DateTimeString');
+  const date = parseDate102(rawDate);
+
+  // La catégorie d'opération (biens/services/mixte) est stockée dans une note
+  // identifiée par SubjectCode AAK — obligation 2026, art. 242 nonies A CGI.
+  let category = null;
+  for (const noteXml of allBlocks(exchangedDoc, 'ram:IncludedNote')) {
+    if (noteXml.includes('AAK')) {
+      const content = tag(noteXml, 'ram:Content');
+      if (content === 'Livraison de biens') category = 'goods';
+      else if (content === 'Prestation de services') category = 'services';
+      else if (content === 'Mixte') category = 'mixed';
+    }
+  }
+
+  // --- Transaction ---
+  const tradeTransaction = block(xml, 'rsm:SupplyChainTradeTransaction') || '';
+  const agreement = block(tradeTransaction, 'ram:ApplicableHeaderTradeAgreement') || '';
+  const settlement = block(tradeTransaction, 'ram:ApplicableHeaderTradeSettlement') || '';
+
+  // --- Vendeur (SellerTradeParty) ---
+  const sellerBlock = block(agreement, 'ram:SellerTradeParty') || '';
+  const sellerName = tag(sellerBlock, 'ram:Name');
+  // Le SIRET (ICD 0002, ISO 6523) est porté par SpecifiedLegalOrganization.
+  const sellerLegalOrg = block(sellerBlock, 'ram:SpecifiedLegalOrganization') || '';
+  const sellerSiret = tagAttr(sellerLegalOrg, 'ram:ID', 'schemeID', '0002');
+  const sellerAddressBlock = block(sellerBlock, 'ram:PostalTradeAddress') || '';
+  const sellerAddress = tag(sellerAddressBlock, 'ram:LineOne');
+  const sellerPostcode = tag(sellerAddressBlock, 'ram:PostcodeCode');
+  const sellerCity = tag(sellerAddressBlock, 'ram:CityName');
+  // N° TVA intracommunautaire : SpecifiedTaxRegistration/ID[@schemeID="VA"]
+  const sellerTaxReg = block(sellerBlock, 'ram:SpecifiedTaxRegistration') || '';
+  const sellerTva = tagAttr(sellerTaxReg, 'ram:ID', 'schemeID', 'VA');
+
+  // --- Acheteur (BuyerTradeParty) ---
+  const buyerBlock = block(agreement, 'ram:BuyerTradeParty') || '';
+  const buyerName = tag(buyerBlock, 'ram:Name');
+  const buyerLegalOrg = block(buyerBlock, 'ram:SpecifiedLegalOrganization') || '';
+  const buyerIdRaw = tagAttr(buyerLegalOrg, 'ram:ID', 'schemeID', '0002');
+  // ICD 0002 = SIRET (14 chiffres). Le SIREN est les 9 premiers chiffres.
+  const buyerSiret = buyerIdRaw && buyerIdRaw.length === 14 ? buyerIdRaw : null;
+  const buyerSiren = buyerIdRaw && buyerIdRaw.length >= 9 ? buyerIdRaw.slice(0, 9) : null;
+  const buyerAddressBlock = block(buyerBlock, 'ram:PostalTradeAddress') || '';
+  const buyerAddress = tag(buyerAddressBlock, 'ram:LineOne');
+  const buyerTaxReg = block(buyerBlock, 'ram:SpecifiedTaxRegistration') || '';
+  const buyerTva = tagAttr(buyerTaxReg, 'ram:ID', 'schemeID', 'VA');
+
+  // --- Règlement ---
+  const currency = tag(settlement, 'ram:InvoiceCurrencyCode') || 'EUR';
+  const paymentTermsBlock = block(settlement, 'ram:SpecifiedTradePaymentTerms') || '';
+  const paymentTermsDesc = tag(paymentTermsBlock, 'ram:Description');
+  const rawDueDate = tag(paymentTermsBlock, 'udt:DateTimeString');
+  const dueDate = parseDate102(rawDueDate);
+
+  // --- Ventilation TVA (N blocs, un par taux ou par catégorie) ---
+  // Les codes catégorie sont définis dans UNCL5305 (UN/EDIFACT).
+  // Exemples courants : S = standard, E = exonéré, K = intracom, Z = taux zéro.
+  const taxBlocks = allBlocks(settlement, 'ram:ApplicableTradeTax');
+  const taxBreakdown = taxBlocks.map(tb => {
+    const rateRaw = tag(tb, 'ram:RateApplicablePercent');
+    const rate = rateRaw !== null ? (parseAmount(rateRaw) ?? 0) / 100 : null;
+    const entry = {
+      category_code: tag(tb, 'ram:CategoryCode'),
+      rate,
+      basis_amount: parseAmount(tag(tb, 'ram:BasisAmount')),
+      tax_amount: parseAmount(tag(tb, 'ram:CalculatedAmount')),
+    };
+    const reasonCode = tag(tb, 'ram:ExemptionReasonCode');
+    const reason = tag(tb, 'ram:ExemptionReason');
+    if (reasonCode) entry.exemption_reason_code = reasonCode;
+    if (reason) entry.exemption_reason = reason;
+    return entry;
+  });
+
+  // Taux unique : renseigné seulement si toutes les lignes imposables (S)
+  // partagent le même taux — sinon null (voir tax_breakdown).
+  const standardRows = taxBreakdown.filter(r => r.category_code === 'S');
+  const uniqueRates = [...new Set(standardRows.map(r => r.rate))];
+  const tvaRate = uniqueRates.length === 1 ? uniqueRates[0] : null;
+
+  // Présence d'une exonération (catégories autres que S).
+  // Ne pas confondre avec la franchise en base art. 293 B CGI, qui utilise
+  // ExemptionReasonCode = "VATEX-FR-FRANCHISE" — vérifier tax_breakdown.
+  const tvaExempt = taxBreakdown.some(r => r.category_code !== 'S');
+
+  // --- Totaux ---
+  const summation = block(settlement, 'ram:SpecifiedTradeSettlementHeaderMonetarySummation') || '';
+  const totalHT = parseAmount(tag(summation, 'ram:TaxBasisTotalAmount')) ?? 0;
+  const totalTVA = parseAmount(tag(summation, 'ram:TaxTotalAmount')) ?? 0;
+  const totalTTC = parseAmount(tag(summation, 'ram:GrandTotalAmount')) ?? 0;
+
+  // --- Lignes ---
+  const lineBlocks = allBlocks(tradeTransaction, 'ram:IncludedSupplyChainTradeLineItem');
+  const lines = lineBlocks.map(lineXml => {
+    const description = tag(lineXml, 'ram:Name');
+    const quantity = parseAmount(tag(lineXml, 'ram:BilledQuantity')) ?? 0;
+
+    // L'unité est dans l'attribut unitCode de BilledQuantity.
+    // C62 = "pièce" (unité générique UN/ECE Rec 20) — omis dans la sortie.
+    const unitMatch = lineXml.match(/ram:BilledQuantity[^>]*unitCode="([^"]+)"/);
+    const unitCode = unitMatch ? unitMatch[1] : null;
+
+    const unitPrice = parseAmount(tag(lineXml, 'ram:ChargeAmount')) ?? 0;
+    const lineTotal = parseAmount(tag(lineXml, 'ram:LineTotalAmount')) ?? 0;
+
+    return {
+      description,
+      quantity,
+      ...(unitCode && unitCode !== 'C62' ? { unit: unitCode } : {}),
+      unit_price: unitPrice,
+      total: lineTotal,
+    };
+  });
+
+  // --- Résultat ---
+  // Format identique à l'entrée de generate-facturx.js, avec en plus :
+  //   seller    → émetteur de la facture reçue
+  //   tax_breakdown → ventilation TVA détaillée (multi-taux)
+  return {
+    number,
+    date,
+    due_date: dueDate,
+    type,
+    ...(category ? { category } : {}),
+    seller: {
+      name: sellerName,
+      ...(sellerSiret ? { siret: sellerSiret } : {}),
+      ...(sellerAddress ? { address: sellerAddress } : {}),
+      ...(sellerPostcode ? { postcode: sellerPostcode } : {}),
+      ...(sellerCity ? { city: sellerCity } : {}),
+      ...(sellerTva ? { tva_intracom: sellerTva } : {}),
+    },
+    client: {
+      name: buyerName,
+      ...(buyerSiren ? { siren: buyerSiren } : {}),
+      ...(buyerSiret ? { siret: buyerSiret } : {}),
+      ...(buyerAddress ? { address: buyerAddress } : {}),
+      ...(buyerTva ? { tva_intracom: buyerTva } : {}),
+    },
+    currency,
+    totals: {
+      ht: totalHT,
+      tva: totalTVA,
+      ttc: totalTTC,
+      ...(tvaRate !== null ? { tva_rate: tvaRate } : {}),
+      tva_exempt: tvaExempt,
+    },
+    tax_breakdown: taxBreakdown,
+    lines,
+    ...(paymentTermsDesc ? { payment: { terms: paymentTermsDesc } } : {}),
+    _format: 'cii-en16931',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Affichage humain
+// ---------------------------------------------------------------------------
+
+// Formate un taux TVA en pourcentage sans zéro inutile (ex : 0.021 → "2.1%").
+function formatRate(rate) {
+  const pct = rate * 100;
+  return `${parseFloat(pct.toFixed(4))}%`;
+}
+
+function printHuman(invoice) {
+  const eur = (n) => (n !== null && n !== undefined ? n.toFixed(2) + ' EUR' : '-');
+  const categoryLabels = { goods: 'Livraison de biens', services: 'Prestation de services', mixed: 'Mixte' };
+
+  console.log('\n━━━ Facture parsée ━━━\n');
+  console.log(`  Numéro      : ${invoice.number}`);
+  console.log(`  Type        : ${invoice.type === 'credit_note' ? 'Avoir (TypeCode 381)' : 'Facture (TypeCode 380)'}`);
+  console.log(`  Date        : ${invoice.date}`);
+  console.log(`  Échéance    : ${invoice.due_date || '-'}`);
+  if (invoice.category) console.log(`  Catégorie   : ${categoryLabels[invoice.category] || invoice.category}`);
+  console.log(`  Format      : ${invoice._format}`);
+
+  console.log('\n  Vendeur');
+  console.log(`    Nom       : ${invoice.seller.name || '-'}`);
+  console.log(`    SIRET     : ${invoice.seller.siret || '-'}`);
+  if (invoice.seller.address) console.log(`    Adresse   : ${invoice.seller.address}`);
+  if (invoice.seller.tva_intracom) console.log(`    N° TVA    : ${invoice.seller.tva_intracom}`);
+
+  console.log('\n  Acheteur');
+  console.log(`    Nom       : ${invoice.client.name || '-'}`);
+  console.log(`    SIREN     : ${invoice.client.siren || '-'}`);
+  if (invoice.client.address) console.log(`    Adresse   : ${invoice.client.address}`);
+  if (invoice.client.tva_intracom) console.log(`    N° TVA    : ${invoice.client.tva_intracom}`);
+
+  console.log('\n  Montants');
+  console.log(`    Total HT  : ${eur(invoice.totals.ht)}`);
+  if (invoice.tax_breakdown.length > 0) {
+    invoice.tax_breakdown.forEach(tb => {
+      const label = tb.category_code === 'S'
+        ? `TVA ${formatRate(tb.rate)}`
+        : `TVA (${tb.category_code}${tb.exemption_reason ? ' — ' + tb.exemption_reason : ''})`;
+      console.log(`    ${label.padEnd(18)}: base ${eur(tb.basis_amount)}, TVA ${eur(tb.tax_amount)}`);
+    });
+  }
+  console.log(`    Total TTC : ${eur(invoice.totals.ttc)}`);
+
+  if (invoice.lines && invoice.lines.length > 0) {
+    console.log(`\n  Lignes (${invoice.lines.length})`);
+    invoice.lines.forEach((l, i) => {
+      const unit = l.unit ? ` ${l.unit}` : '';
+      console.log(`    ${i + 1}. ${l.description} — ${l.quantity}${unit} × ${l.unit_price.toFixed(2)} EUR = ${l.total.toFixed(2)} EUR`);
+    });
+  }
+
+  if (invoice.payment && invoice.payment.terms) {
+    console.log(`\n  Paiement    : ${invoice.payment.terms}`);
+  }
+
+  console.log('');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = process.argv.slice(2);
+  const invoiceIdx = args.indexOf('--invoice');
+  const jsonOutput = args.includes('--json');
+
+  if (invoiceIdx === -1 || !args[invoiceIdx + 1]) {
+    console.error('Usage: node scripts/parse-einvoice.js --invoice <fichier.xml>');
+    console.error('Options:');
+    console.error('  --json   Sortie JSON uniquement (pour intégration CI/agent)');
+    process.exit(1);
+  }
+
+  const filePath = args[invoiceIdx + 1];
+  if (!fs.existsSync(filePath)) {
+    console.error(`Fichier introuvable : ${filePath}`);
+    process.exit(1);
+  }
+
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.pdf') {
+    console.error('Les fichiers PDF ne sont pas supportés directement.');
+    console.error("Extrayez d'abord le XML embarqué avec pdfdetach (poppler-utils) :");
+    console.error('  pdfdetach -savefile factur-x.xml ' + path.basename(filePath));
+    console.error('  node scripts/parse-einvoice.js --invoice factur-x.xml');
+    process.exit(1);
+  }
+
+  const xml = fs.readFileSync(filePath, 'utf8');
+  if (!xml.trim()) {
+    console.error('Fichier vide.');
+    process.exit(1);
+  }
+
+  const format = detectFormat(xml);
+  if (!format) {
+    console.error('Format non reconnu : ni CII ni UBL détecté.');
+    console.error('Vérifiez que le fichier est bien une facture électronique EN 16931.');
+    process.exit(1);
+  }
+
+  if (format === 'ubl') {
+    console.error('Format UBL non encore supporté (utilisé sur le réseau Peppol).');
+    console.error('Ce parser traite les factures CII (Factur-X, échanges domestiques FR).');
+    process.exit(1);
+  }
+
+  const invoice = parseCII(xml);
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(invoice, null, 2));
+  } else {
+    printHuman(invoice);
+  }
+}
+
+main();

--- a/scripts/parse-einvoice.js
+++ b/scripts/parse-einvoice.js
@@ -1,11 +1,48 @@
 #!/usr/bin/env node
 
 /**
- * Lecture de factures électroniques au format CII (Factur-X / EN 16931)
+ * Lecture stricte de factures électroniques au format CII (Factur-X / EN 16931)
  *
- * Extrait les données structurées d'une facture reçue au format CII
- * et les retourne dans le même format JSON qu'attend generate-facturx.js,
- * avec en plus le détail de la ventilation TVA (tax_breakdown).
+ * Extrait les données structurées d'une facture reçue au format CII et les
+ * retourne dans le même format JSON qu'attend generate-facturx.js, avec en plus
+ * le détail de la ventilation TVA (tax_breakdown).
+ *
+ * Contrat de sortie
+ *   - Toute anomalie est une ERREUR BLOQUANTE : le script imprime la liste des
+ *     erreurs et sort en code 1, sans émettre de facture.
+ *   - Aucune valeur n'est inventée : ni null ni 0 de repli sur un champ
+ *     obligatoire absent, illisible ou incohérent.
+ *   - Code de sortie 0 = les contrôles ci-dessous sont passés. C'est la seule
+ *     condition dans laquelle la sortie peut alimenter un import comptable.
+ *
+ * Contrôles effectués
+ *   1. Profil : BT-24 doit commencer par « urn:cen.eu:en16931:2017 ». Les
+ *      profils Factur-X MINIMUM et BASIC WL sont refusés : ils ne portent
+ *      aucune ligne de facture (et, pour MINIMUM, pas de ventilation TVA).
+ *   2. Champs obligatoires EN 16931 : BT-1, BT-2, BT-3, BT-5, BT-24, BT-27,
+ *      BT-44, identité du vendeur (SIREN, SIRET ou n° de TVA), au moins une
+ *      ligne, au moins une ventilation TVA, et pour chaque ligne BT-129,
+ *      BT-146, BT-131, BT-153.
+ *      BT-3 est restreint aux types que ce script sait classer (380, 381, 384,
+ *      386, 389) : un code inconnu est refusé, jamais rangé en facture.
+ *   3. Types : dates au format 102 (AAAAMMJJ) et existantes au calendrier ;
+ *      montants au format décimal EN 16931 (point décimal, pas de texte).
+ *   4. Rapprochement arithmétique, tolérance 1 centime : BR-CO-10, BR-CO-13,
+ *      BR-CO-14, BR-CO-15, BR-CO-16, plus le contrôle du montant de TVA par
+ *      catégorie (BR-S-09 pour la catégorie S, TVA nulle imposée par BR-E-09,
+ *      BR-Z-09, BR-AE-09, BR-IC-09, BR-G-09 et BR-O-09 pour les autres) et la
+ *      couverture de la base HT totale par les bases de la ventilation.
+ *
+ * Limites connues (assumées, jamais compensées par une valeur devinée)
+ *   - Pas de validation XSD, pas de Schematron : aucune dépendance XML dans ce
+ *     dépôt. Les contrôles sont ceux listés ci-dessus, pas la totalité des
+ *     règles EN 16931 ; un document non conforme au schéma peut donc passer ces
+ *     contrôles métier. Pour une conformité complète, passer par un validateur
+ *     dédié ou par une plateforme agréée.
+ *   - Les sous-lignes du profil EXTENDED (lignes imbriquées) ne sont pas lues :
+ *     le découpage des lignes est alors faux et les rapprochements de totaux
+ *     rejettent la facture (constaté sur un exemplaire réel).
+ *   - Format UBL non supporté.
  *
  * Usage :
  *   node scripts/parse-einvoice.js --invoice output/F-2026-001.xml
@@ -14,7 +51,7 @@
  * Formats supportés :
  *   - XML CII (Cross-Industry Invoice, EN 16931 / Factur-X)
  *
- * Format UBL (réseau Peppol) : non encore supporté.
+ * Format UBL (réseau Peppol) : non supporté.
  *
  * Pour extraire le XML embarqué d'un Factur-X PDF, utilisez pdfdetach
  * (fourni par le paquet poppler-utils) :
@@ -39,16 +76,27 @@ const path = require('path');
 // Ciblés sur le schéma CII EN 16931 — pas un parseur XML générique.
 // ---------------------------------------------------------------------------
 
+// Les préfixes de namespace ne sont pas normatifs : un même élément s'écrit
+// <rsm:ExchangedDocument> chez un émetteur et <ExchangedDocument> chez un autre
+// qui déclare un namespace par défaut. Les deux formes sont acceptées.
+function nsPattern(name) {
+  const separator = name.indexOf(':');
+  if (separator === -1) return name;
+  return `(?:${name.slice(0, separator)}:)?${name.slice(separator + 1)}`;
+}
+
 // Contenu texte de la première occurrence d'un tag (avec ou sans attributs).
 function tag(xml, name) {
-  const m = xml.match(new RegExp(`<${name}[^>]*>([^<]*)<\\/${name}>`));
+  const n = nsPattern(name);
+  const m = xml.match(new RegExp(`<${n}[^>]*>([^<]*)<\\/${n}>`));
   return m ? unescapeXml(m[1].trim()) : null;
 }
 
 // Contenu texte d'un tag portant un attribut précis (ex: schemeID="0002").
 // Gère les guillemets simples et doubles.
 function tagAttr(xml, name, attr, value) {
-  const re = new RegExp(`<${name}[^>]*${attr}=["']${value}["'][^>]*>([^<]*)<\\/${name}>`);
+  const n = nsPattern(name);
+  const re = new RegExp(`<${n}[^>]*${attr}=["']${value}["'][^>]*>([^<]*)<\\/${n}>`);
   const m = xml.match(re);
   return m ? unescapeXml(m[1].trim()) : null;
 }
@@ -56,7 +104,8 @@ function tagAttr(xml, name, attr, value) {
 // Premier sous-bloc délimité par un tag (avec attributs éventuels).
 // Suppose que le tag n'est pas auto-imbriqué (voir en-tête).
 function block(xml, name) {
-  const re = new RegExp(`<${name}[\\s>][\\s\\S]*?<\\/${name}>`);
+  const n = nsPattern(name);
+  const re = new RegExp(`<${n}[\\s>][\\s\\S]*?<\\/${n}>`);
   const m = xml ? xml.match(re) : null;
   return m ? m[0] : null;
 }
@@ -64,33 +113,75 @@ function block(xml, name) {
 // Toutes les occurrences non-chevauchantes d'un bloc délimité par un tag.
 function allBlocks(xml, name) {
   const blocks = [];
-  const re = new RegExp(`<${name}[\\s>][\\s\\S]*?<\\/${name}>`, 'g');
+  const n = nsPattern(name);
+  const re = new RegExp(`<${n}[\\s>][\\s\\S]*?<\\/${n}>`, 'g');
   let m;
   while ((m = re.exec(xml)) !== null) blocks.push(m[0]);
   return blocks;
 }
 
-// Convertit une date au format CII 102 (YYYYMMDD) en ISO (YYYY-MM-DD).
-function parseDate102(raw) {
-  if (!raw || raw.length !== 8) return raw || null;
-  return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`;
-}
-
-// Parse un montant en virgule fixe. Retourne null si la valeur est absente
-// ou non numérique (EN 16931 impose le point comme séparateur décimal).
-function parseAmount(raw) {
-  if (!raw) return null;
-  const n = parseFloat(raw);
-  return Number.isFinite(n) ? n : null;
-}
-
+// &amp; est décodé en DERNIER : sinon « &amp;lt; » donnerait « < » (double
+// décodage) au lieu de « &lt; ».
 function unescapeXml(str) {
   return str
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'");
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+// ---------------------------------------------------------------------------
+// Lecture stricte des valeurs
+//
+// Chaque helper reçoit un descriptif de champ { id, label, required } et pousse
+// une erreur dans `errors` plutôt que de fabriquer une valeur de repli.
+// ---------------------------------------------------------------------------
+
+function missing(field, errors) {
+  if (field.required) {
+    errors.push({ id: `${field.id}_MISSING`, message: `${field.label} : absent` });
+  }
+  return null;
+}
+
+// Texte obligatoire (ou optionnel si required n'est pas positionné).
+function readText(value, field, errors) {
+  if (value === null || value === undefined || value === '') return missing(field, errors);
+  return value;
+}
+
+// Date CII au format 102 (AAAAMMJJ) vers ISO (AAAA-MM-JJ).
+// Refuse toute autre longueur, tout caractère non numérique, et toute date
+// inexistante au calendrier (ex : 20260231).
+function parseDate102(raw, field, errors) {
+  if (!raw) return missing(field, errors);
+  if (!/^\d{8}$/.test(raw)) {
+    errors.push({ id: `${field.id}_INVALID`, message: `${field.label} : format 102 (AAAAMMJJ) attendu, reçu « ${raw} »` });
+    return null;
+  }
+  const year = Number(raw.slice(0, 4));
+  const month = Number(raw.slice(4, 6));
+  const day = Number(raw.slice(6, 8));
+  const dt = new Date(Date.UTC(year, month - 1, day));
+  if (dt.getUTCFullYear() !== year || dt.getUTCMonth() !== month - 1 || dt.getUTCDate() !== day) {
+    errors.push({ id: `${field.id}_INVALID`, message: `${field.label} : date inexistante au calendrier (${raw})` });
+    return null;
+  }
+  return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`;
+}
+
+// Montant ou quantité en virgule fixe. EN 16931 impose le point décimal :
+// « 12abc », « 1,5 » ou « 1e5 » sont des erreurs, pas des valeurs à corriger.
+// Le signe est accepté car xs:decimal l'autorise.
+function parseDecimal(raw, field, errors) {
+  if (raw === null || raw === undefined || raw === '') return missing(field, errors);
+  const value = String(raw).trim();
+  if (!/^[-+]?\d+(\.\d+)?$/.test(value)) {
+    errors.push({ id: `${field.id}_INVALID`, message: `${field.label} : valeur décimale invalide « ${raw} »` });
+    return null;
+  }
+  return Number(value);
 }
 
 // ---------------------------------------------------------------------------
@@ -104,13 +195,42 @@ function detectFormat(xml) {
 }
 
 // ---------------------------------------------------------------------------
+// Contrôle du profil (BT-24)
+//
+// Les profils EN 16931 portent l'identifiant CEN. Les profils Factur-X
+// MINIMUM (urn:factur-x.eu:1p0:minimum) et BASIC WL (…:1p0:basicwl) ne le
+// portent pas : ce sont des jeux de données comptables partiels, sans aucune
+// ligne de facture, hors norme EN 16931.
+// ---------------------------------------------------------------------------
+
+const EN16931_PROFILE_PREFIX = 'urn:cen.eu:en16931:2017';
+
+function checkProfile(xml, errors) {
+  const context = block(xml, 'rsm:ExchangedDocumentContext') || '';
+  const guideline = block(context, 'ram:GuidelineSpecifiedDocumentContextParameter') || '';
+  const profileId = tag(guideline, 'ram:ID');
+
+  if (!profileId) {
+    errors.push({ id: 'BT-24_MISSING', message: 'Profil (BT-24) absent : conformité EN 16931 invérifiable' });
+    return;
+  }
+  if (!profileId.startsWith(EN16931_PROFILE_PREFIX)) {
+    errors.push({
+      id: 'BT-24_PROFILE',
+      message: `Profil non EN 16931 : « ${profileId} ». Les profils Factur-X MINIMUM et BASIC WL ne portent aucune ligne de facture : inexploitables pour une écriture comptable.`,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Parsing CII — Cross-Industry Invoice (EN 16931 / Factur-X)
 //
 // Structure de référence :
 //   rsm:CrossIndustryInvoice
-//     rsm:ExchangedDocumentContext   → profil (EN 16931)
+//     rsm:ExchangedDocumentContext   → profil (BT-24)
 //     rsm:ExchangedDocument          → numéro, type, date, notes
 //     rsm:SupplyChainTradeTransaction
+//       ram:IncludedSupplyChainTradeLineItem (N lignes)
 //       ram:ApplicableHeaderTradeAgreement
 //         ram:SellerTradeParty       → vendeur
 //         ram:BuyerTradeParty        → acheteur
@@ -120,17 +240,46 @@ function detectFormat(xml) {
 //         ram:ApplicableTradeTax     → ventilation TVA (N blocs, un par taux)
 //         ram:SpecifiedTradePaymentTerms → échéance, conditions
 //         ram:SpecifiedTradeSettlementHeaderMonetarySummation → totaux
-//       ram:IncludedSupplyChainTradeLineItem (N lignes)
+//
+// L'ordre des blocs n'est pas supposé : chaque bloc est cherché par son nom.
 // ---------------------------------------------------------------------------
 
-function parseCII(xml) {
-  // --- Document ---
+// N° TVA intracommunautaire : le tiers peut porter plusieurs
+// SpecifiedTaxRegistration (VA, FC…) — chercher celui de schemeID « VA » dans
+// tous les blocs, pas seulement dans le premier.
+function findVatNumber(partyBlock) {
+  for (const registration of allBlocks(partyBlock, 'ram:SpecifiedTaxRegistration')) {
+    const vat = tagAttr(registration, 'ram:ID', 'schemeID', 'VA');
+    if (vat) return vat;
+  }
+  return null;
+}
+
+// Types de document (BT-3, UNTDID 1001) que ce script sait classer pour une
+// écriture. EN 16931 en autorise d'autres : ils sont refusés plutôt que
+// devinés, un code inconnu ne doit pas devenir une facture ordinaire.
+const SUPPORTED_TYPE_CODES = {
+  380: 'invoice', // facture
+  381: 'credit_note', // avoir
+  384: 'invoice', // facture rectificative
+  386: 'invoice', // facture d'acompte
+  389: 'invoice', // facture auto-facturée
+};
+
+function parseDocument(xml, errors) {
   const exchangedDoc = block(xml, 'rsm:ExchangedDocument') || '';
-  const number = tag(exchangedDoc, 'ram:ID');
-  const typeCode = tag(exchangedDoc, 'ram:TypeCode');
-  const type = typeCode === '381' ? 'credit_note' : 'invoice';
-  const rawDate = tag(exchangedDoc, 'udt:DateTimeString');
-  const date = parseDate102(rawDate);
+  const number = readText(tag(exchangedDoc, 'ram:ID'), { id: 'BT-1', label: 'Numéro de facture (BT-1)', required: true }, errors);
+  const typeCode = readText(tag(exchangedDoc, 'ram:TypeCode'), { id: 'BT-3', label: 'Type de document (BT-3)', required: true }, errors);
+  // hasOwn plutôt qu'un accès direct : un TypeCode valant « constructor »
+  // remonterait sinon une propriété héritée d'Object.
+  const type = typeCode !== null && Object.hasOwn(SUPPORTED_TYPE_CODES, typeCode) ? SUPPORTED_TYPE_CODES[typeCode] : null;
+  if (typeCode !== null && type === null) {
+    errors.push({
+      id: 'BT-3_UNSUPPORTED',
+      message: `Type de document (BT-3) « ${typeCode} » non pris en charge : codes UNTDID 1001 acceptés ${Object.keys(SUPPORTED_TYPE_CODES).join(', ')}`,
+    });
+  }
+  const date = parseDate102(tag(exchangedDoc, 'udt:DateTimeString'), { id: 'BT-2', label: "Date d'émission (BT-2)", required: true }, errors);
 
   // La catégorie d'opération (biens/services/mixte) est stockée dans une note
   // identifiée par SubjectCode AAK — obligation 2026, art. 242 nonies A CGI.
@@ -144,57 +293,97 @@ function parseCII(xml) {
     }
   }
 
-  // --- Transaction ---
-  const tradeTransaction = block(xml, 'rsm:SupplyChainTradeTransaction') || '';
-  const agreement = block(tradeTransaction, 'ram:ApplicableHeaderTradeAgreement') || '';
-  const settlement = block(tradeTransaction, 'ram:ApplicableHeaderTradeSettlement') || '';
+  return { number, type, typeCode, date, category };
+}
 
-  // --- Vendeur (SellerTradeParty) ---
+// Identifiant légal français porté par SpecifiedLegalOrganization/ID sous
+// l'ICD 0002 (ISO 6523) : SIRET sur 14 chiffres, SIREN sur 9. L'identifiant est
+// facultatif dans EN 16931, mais s'il est présent il doit être exploitable :
+// une valeur tronquée ou alphanumérique est une erreur, pas une donnée à
+// réinterpréter, et un SIREN n'est jamais restitué comme un SIRET.
+function parseLegalId(partyBlock, field, errors) {
+  const legalOrg = block(partyBlock, 'ram:SpecifiedLegalOrganization') || '';
+  const rawId = tagAttr(legalOrg, 'ram:ID', 'schemeID', '0002');
+  if (rawId === null) return { siret: null, siren: null };
+  if (/^\d{14}$/.test(rawId)) return { siret: rawId, siren: rawId.slice(0, 9) };
+  if (/^\d{9}$/.test(rawId)) return { siret: null, siren: rawId };
+
+  errors.push({
+    id: `${field.id}_INVALID`,
+    message: `${field.label} : SIREN (9 chiffres) ou SIRET (14 chiffres) attendu, reçu « ${rawId} »`,
+  });
+  return { siret: null, siren: null };
+}
+
+function parseSeller(agreement, errors) {
   const sellerBlock = block(agreement, 'ram:SellerTradeParty') || '';
-  const sellerName = tag(sellerBlock, 'ram:Name');
-  // Le SIRET (ICD 0002, ISO 6523) est porté par SpecifiedLegalOrganization.
-  const sellerLegalOrg = block(sellerBlock, 'ram:SpecifiedLegalOrganization') || '';
-  const sellerSiret = tagAttr(sellerLegalOrg, 'ram:ID', 'schemeID', '0002');
-  const sellerAddressBlock = block(sellerBlock, 'ram:PostalTradeAddress') || '';
-  const sellerAddress = tag(sellerAddressBlock, 'ram:LineOne');
-  const sellerPostcode = tag(sellerAddressBlock, 'ram:PostcodeCode');
-  const sellerCity = tag(sellerAddressBlock, 'ram:CityName');
-  // N° TVA intracommunautaire : SpecifiedTaxRegistration/ID[@schemeID="VA"]
-  const sellerTaxReg = block(sellerBlock, 'ram:SpecifiedTaxRegistration') || '';
-  const sellerTva = tagAttr(sellerTaxReg, 'ram:ID', 'schemeID', 'VA');
+  const name = readText(tag(sellerBlock, 'ram:Name'), { id: 'BT-27', label: 'Nom du vendeur (BT-27)', required: true }, errors);
+  const { siret, siren } = parseLegalId(sellerBlock, { id: 'BT-30', label: 'Identifiant légal du vendeur (BT-30, schemeID 0002)' }, errors);
+  const vat = findVatNumber(sellerBlock);
 
-  // --- Acheteur (BuyerTradeParty) ---
+  // Le vendeur doit être identifiable. BR-CO-26 accepte aussi l'identifiant
+  // vendeur BT-29, que ce script ne lit pas : le contrôle est donc plus strict
+  // que la règle, d'où un identifiant propre plutôt que le numéro BR-CO-26.
+  if (!siret && !siren && !vat) {
+    errors.push({
+      id: 'VENDEUR_NON_IDENTIFIABLE',
+      message: 'Vendeur non identifiable : ni SIREN/SIRET (schemeID 0002) ni n° de TVA intracommunautaire',
+    });
+  }
+
+  const addressBlock = block(sellerBlock, 'ram:PostalTradeAddress') || '';
+  return {
+    name,
+    siret,
+    siren,
+    vat,
+    address: tag(addressBlock, 'ram:LineOne'),
+    postcode: tag(addressBlock, 'ram:PostcodeCode'),
+    city: tag(addressBlock, 'ram:CityName'),
+  };
+}
+
+function parseBuyer(agreement, errors) {
   const buyerBlock = block(agreement, 'ram:BuyerTradeParty') || '';
-  const buyerName = tag(buyerBlock, 'ram:Name');
-  const buyerLegalOrg = block(buyerBlock, 'ram:SpecifiedLegalOrganization') || '';
-  const buyerIdRaw = tagAttr(buyerLegalOrg, 'ram:ID', 'schemeID', '0002');
-  // ICD 0002 = SIRET (14 chiffres). Le SIREN est les 9 premiers chiffres.
-  const buyerSiret = buyerIdRaw && buyerIdRaw.length === 14 ? buyerIdRaw : null;
-  const buyerSiren = buyerIdRaw && buyerIdRaw.length >= 9 ? buyerIdRaw.slice(0, 9) : null;
-  const buyerAddressBlock = block(buyerBlock, 'ram:PostalTradeAddress') || '';
-  const buyerAddress = tag(buyerAddressBlock, 'ram:LineOne');
-  const buyerTaxReg = block(buyerBlock, 'ram:SpecifiedTaxRegistration') || '';
-  const buyerTva = tagAttr(buyerTaxReg, 'ram:ID', 'schemeID', 'VA');
+  const name = readText(tag(buyerBlock, 'ram:Name'), { id: 'BT-44', label: "Nom de l'acheteur (BT-44)", required: true }, errors);
+  const { siret, siren } = parseLegalId(buyerBlock, { id: 'BT-47', label: "Identifiant légal de l'acheteur (BT-47, schemeID 0002)" }, errors);
+  const addressBlock = block(buyerBlock, 'ram:PostalTradeAddress') || '';
 
-  // --- Règlement ---
-  const currency = tag(settlement, 'ram:InvoiceCurrencyCode') || 'EUR';
-  const paymentTermsBlock = block(settlement, 'ram:SpecifiedTradePaymentTerms') || '';
-  const paymentTermsDesc = tag(paymentTermsBlock, 'ram:Description');
-  const rawDueDate = tag(paymentTermsBlock, 'udt:DateTimeString');
-  const dueDate = parseDate102(rawDueDate);
+  return { name, siret, siren, address: tag(addressBlock, 'ram:LineOne'), vat: findVatNumber(buyerBlock) };
+}
 
-  // --- Ventilation TVA (N blocs, un par taux ou par catégorie) ---
-  // Les codes catégorie sont définis dans UNCL5305 (UN/EDIFACT).
-  // Exemples courants : S = standard, E = exonéré, K = intracom, Z = taux zéro.
+// Seule la catégorie S est taxée dans EN 16931 : son montant de TVA se calcule
+// depuis un taux (BR-S-09). Pour toutes les autres (E exonéré, Z taux zéro,
+// AE autoliquidation, K intracommunautaire, G export, O hors champ), les règles
+// BR-E-09, BR-Z-09, BR-AE-09, BR-IC-09, BR-G-09 et BR-O-09 imposent un montant
+// de TVA nul.
+const RATED_VAT_CATEGORIES = ['S'];
+
+// Ventilation TVA (N blocs, un par taux ou par catégorie).
+// Les codes catégorie sont définis dans UNCL5305 (UN/EDIFACT).
+// Exemples courants : S = standard, E = exonéré, K = intracom, Z = taux zéro.
+function parseTaxBreakdown(settlement, errors) {
   const taxBlocks = allBlocks(settlement, 'ram:ApplicableTradeTax');
-  const taxBreakdown = taxBlocks.map(tb => {
+  if (taxBlocks.length === 0) {
+    errors.push({ id: 'BG-23_MISSING', message: 'Aucune ventilation TVA (BG-23) : ventilation obligatoire' });
+    return [];
+  }
+
+  return taxBlocks.map((tb, i) => {
+    const position = `Ventilation TVA ${i + 1}`;
+    const categoryCode = readText(tag(tb, 'ram:CategoryCode'), { id: `BT-118_${i + 1}`, label: `${position} : catégorie (BT-118)`, required: true }, errors);
+    // Le taux est obligatoire pour les catégories taxées ; pour les autres il
+    // peut être absent (exonération, autoliquidation…).
     const rateRaw = tag(tb, 'ram:RateApplicablePercent');
-    const rate = rateRaw !== null ? (parseAmount(rateRaw) ?? 0) / 100 : null;
+    const rate = rateRaw === null && !RATED_VAT_CATEGORIES.includes(categoryCode)
+      ? null
+      : parseDecimal(rateRaw, { id: `BT-119_${i + 1}`, label: `${position} : taux (BT-119)`, required: true }, errors);
+
     const entry = {
-      category_code: tag(tb, 'ram:CategoryCode'),
-      rate,
-      basis_amount: parseAmount(tag(tb, 'ram:BasisAmount')),
-      tax_amount: parseAmount(tag(tb, 'ram:CalculatedAmount')),
+      category_code: categoryCode,
+      rate: rate === null ? null : rate / 100,
+      basis_amount: parseDecimal(tag(tb, 'ram:BasisAmount'), { id: `BT-116_${i + 1}`, label: `${position} : base (BT-116)`, required: true }, errors),
+      tax_amount: parseDecimal(tag(tb, 'ram:CalculatedAmount'), { id: `BT-117_${i + 1}`, label: `${position} : montant (BT-117)`, required: true }, errors),
     };
     const reasonCode = tag(tb, 'ram:ExemptionReasonCode');
     const reason = tag(tb, 'ram:ExemptionReason');
@@ -202,6 +391,139 @@ function parseCII(xml) {
     if (reason) entry.exemption_reason = reason;
     return entry;
   });
+}
+
+function parseLines(tradeTransaction, errors) {
+  const lineBlocks = allBlocks(tradeTransaction, 'ram:IncludedSupplyChainTradeLineItem');
+  if (lineBlocks.length === 0) {
+    errors.push({ id: 'BG-25_MISSING', message: 'Aucune ligne de facture (BG-25) : au moins une ligne est obligatoire' });
+    return [];
+  }
+
+  return lineBlocks.map((lineXml, i) => {
+    const position = `Ligne ${i + 1}`;
+    const description = readText(tag(lineXml, 'ram:Name'), { id: `BT-153_${i + 1}`, label: `${position} : désignation (BT-153)`, required: true }, errors);
+    const quantity = parseDecimal(tag(lineXml, 'ram:BilledQuantity'), { id: `BT-129_${i + 1}`, label: `${position} : quantité (BT-129)`, required: true }, errors);
+
+    // L'unité est dans l'attribut unitCode de BilledQuantity.
+    // C62 = "pièce" (unité générique UN/ECE Rec 20) — omis dans la sortie.
+    const unitMatch = lineXml.match(new RegExp(`<${nsPattern('ram:BilledQuantity')}[^>]*unitCode="([^"]+)"`));
+    const unitCode = unitMatch ? unitMatch[1] : null;
+
+    // Le prix unitaire est le prix NET (après remise). Sur une ligne avec
+    // remise, GrossPriceProductTradePrice (prix catalogue) précède
+    // NetPriceProductTradePrice — cibler le bloc net. Aucun repli sur la ligne
+    // entière : sans prix net (BT-146), la ligne est refusée.
+    const netPriceBlock = block(lineXml, 'ram:NetPriceProductTradePrice');
+    const unitPrice = parseDecimal(netPriceBlock && tag(netPriceBlock, 'ram:ChargeAmount'), { id: `BT-146_${i + 1}`, label: `${position} : prix unitaire net (BT-146)`, required: true }, errors);
+    const total = parseDecimal(tag(lineXml, 'ram:LineTotalAmount'), { id: `BT-131_${i + 1}`, label: `${position} : total HT (BT-131)`, required: true }, errors);
+
+    return {
+      description,
+      quantity,
+      ...(unitCode && unitCode !== 'C62' ? { unit: unitCode } : {}),
+      unit_price: unitPrice,
+      total,
+    };
+  });
+}
+
+function parseTotals(settlement, currency, errors) {
+  const summation = block(settlement, 'ram:SpecifiedTradeSettlementHeaderMonetarySummation') || '';
+  const required = (id, label) => ({ id, label, required: true });
+  const optional = (id, label) => ({ id, label, required: false });
+
+  // BT-110 (devise de facturation) peut coexister avec BT-111 (devise de
+  // déclaration TVA) : cibler celui qui porte la devise de la facture.
+  const taxTotalRaw = tagAttr(summation, 'ram:TaxTotalAmount', 'currencyID', currency) ?? tag(summation, 'ram:TaxTotalAmount');
+
+  return {
+    lineTotal: parseDecimal(tag(summation, 'ram:LineTotalAmount'), required('BT-106', 'Somme des lignes (BT-106)'), errors),
+    allowanceTotal: parseDecimal(tag(summation, 'ram:AllowanceTotalAmount'), optional('BT-107', 'Total des remises (BT-107)'), errors) ?? 0,
+    chargeTotal: parseDecimal(tag(summation, 'ram:ChargeTotalAmount'), optional('BT-108', 'Total des frais (BT-108)'), errors) ?? 0,
+    taxBasisTotal: parseDecimal(tag(summation, 'ram:TaxBasisTotalAmount'), required('BT-109', 'Base HT totale (BT-109)'), errors),
+    taxTotal: parseDecimal(taxTotalRaw, required('BT-110', 'Total TVA (BT-110)'), errors),
+    grandTotal: parseDecimal(tag(summation, 'ram:GrandTotalAmount'), required('BT-112', 'Total TTC (BT-112)'), errors),
+    prepaid: parseDecimal(tag(summation, 'ram:TotalPrepaidAmount'), optional('BT-113', 'Acomptes versés (BT-113)'), errors) ?? 0,
+    rounding: parseDecimal(tag(summation, 'ram:RoundingAmount'), optional('BT-114', "Écart d'arrondi (BT-114)"), errors) ?? 0,
+    duePayable: parseDecimal(tag(summation, 'ram:DuePayableAmount'), required('BT-115', 'Montant à payer (BT-115)'), errors),
+  };
+}
+
+// Contrôle de la ventilation TVA : c'est ici qu'une facture arithmétiquement
+// fausse mais cohérente de bout en bout est attrapée (base 200 à 20 % annoncée
+// avec 30 EUR de TVA, totaux alignés sur 30).
+function checkVatBreakdown(taxBreakdown, taxBasisTotal, errors) {
+  const cents = (n) => Math.round(n * 100);
+
+  taxBreakdown.forEach((entry, i) => {
+    const position = `Ventilation TVA ${i + 1}`;
+    if (entry.basis_amount === null || entry.tax_amount === null) return;
+
+    if (RATED_VAT_CATEGORIES.includes(entry.category_code)) {
+      if (entry.rate === null) return; // absence déjà signalée
+      const expected = entry.basis_amount * entry.rate;
+      if (Math.abs(cents(entry.tax_amount) - cents(expected)) > 1) {
+        errors.push({
+          id: `BR-S-09_${i + 1}`,
+          message: `${position} : TVA de ${entry.tax_amount.toFixed(2)} pour une base de ${entry.basis_amount.toFixed(2)} au taux de ${(entry.rate * 100).toFixed(2)}% (attendu ${expected.toFixed(2)})`,
+        });
+      }
+      return;
+    }
+
+    if (cents(entry.tax_amount) !== 0) {
+      errors.push({
+        id: `BR-CAT-09_${i + 1}`,
+        message: `${position} : montant de TVA non nul (${entry.tax_amount.toFixed(2)}) pour la catégorie « ${entry.category_code} », qui impose une TVA à 0`,
+      });
+    }
+  });
+
+  // Contrôle de cohérence : les bases déclarées par catégorie doivent couvrir
+  // exactement la base HT totale. Agrégat plus faible que BR-S-08 et ses
+  // équivalents par catégorie, qui rapprochent base par base et taux par taux.
+  if (taxBasisTotal === null || taxBreakdown.some(e => e.basis_amount === null)) return;
+  const sumOfBases = taxBreakdown.reduce((acc, e) => acc + e.basis_amount, 0);
+  if (Math.abs(cents(sumOfBases) - cents(taxBasisTotal)) > 1) {
+    errors.push({
+      id: 'COHERENCE_BASES',
+      message: `Somme des bases de la ventilation TVA (BT-116) : ${sumOfBases.toFixed(2)} au lieu de la base HT totale (BT-109) ${taxBasisTotal.toFixed(2)}`,
+    });
+  }
+}
+
+// Rapprochement arithmétique EN 16931, tolérance 1 centime.
+// Les montants déjà signalés comme absents ou invalides (null) sont ignorés :
+// l'erreur correspondante est déjà dans la liste.
+function reconcile(totals, lines, taxBreakdown, errors) {
+  const cents = (n) => Math.round(n * 100);
+  const check = (id, label, left, right) => {
+    if (left === null || right === null) return;
+    if (Math.abs(cents(left) - cents(right)) > 1) {
+      errors.push({ id, message: `${label} : ${left.toFixed(2)} au lieu de ${right.toFixed(2)}` });
+    }
+  };
+  const sum = (values) => (values.some(v => v === null) ? null : values.reduce((acc, v) => acc + v, 0));
+
+  check('BR-CO-10', 'Somme des lignes (BT-106) incohérente avec le total des lignes', totals.lineTotal, sum(lines.map(l => l.total)));
+  check('BR-CO-14', 'Total TVA (BT-110) incohérent avec la ventilation TVA', totals.taxTotal, sum(taxBreakdown.map(t => t.tax_amount)));
+  check('BR-CO-13', 'Base HT totale (BT-109) incohérente avec BT-106 - BT-107 + BT-108', totals.taxBasisTotal,
+    totals.lineTotal === null ? null : totals.lineTotal - totals.allowanceTotal + totals.chargeTotal);
+  check('BR-CO-15', 'Total TTC (BT-112) incohérent avec BT-109 + BT-110', totals.grandTotal,
+    totals.taxBasisTotal === null || totals.taxTotal === null ? null : totals.taxBasisTotal + totals.taxTotal);
+  check('BR-CO-16', 'Montant à payer (BT-115) incohérent avec BT-112 - BT-113 + BT-114', totals.duePayable,
+    totals.grandTotal === null ? null : totals.grandTotal - totals.prepaid + totals.rounding);
+
+  checkVatBreakdown(taxBreakdown, totals.taxBasisTotal, errors);
+}
+
+// Assemble la sortie JSON. Format identique à l'entrée de generate-facturx.js,
+// avec en plus :
+//   seller        → émetteur de la facture reçue
+//   tax_breakdown → ventilation TVA détaillée (multi-taux)
+function buildInvoice(parts) {
+  const { doc, seller, buyer, currency, dueDate, paymentTerms, taxBreakdown, lines, totals } = parts;
 
   // Taux unique : renseigné seulement si toutes les lignes imposables (S)
   // partagent le même taux — sinon null (voir tax_breakdown).
@@ -209,83 +531,85 @@ function parseCII(xml) {
   const uniqueRates = [...new Set(standardRows.map(r => r.rate))];
   const tvaRate = uniqueRates.length === 1 ? uniqueRates[0] : null;
 
-  // Présence d'une exonération (catégories autres que S).
+  // Présence d'une catégorie non taxée (exonération, autoliquidation, export…).
   // Ne pas confondre avec la franchise en base art. 293 B CGI, qui utilise
   // ExemptionReasonCode = "VATEX-FR-FRANCHISE" — vérifier tax_breakdown.
-  const tvaExempt = taxBreakdown.some(r => r.category_code !== 'S');
+  const tvaExempt = taxBreakdown.some(r => !RATED_VAT_CATEGORIES.includes(r.category_code));
 
-  // --- Totaux ---
-  const summation = block(settlement, 'ram:SpecifiedTradeSettlementHeaderMonetarySummation') || '';
-  const totalHT = parseAmount(tag(summation, 'ram:TaxBasisTotalAmount')) ?? 0;
-  const totalTVA = parseAmount(tag(summation, 'ram:TaxTotalAmount')) ?? 0;
-  const totalTTC = parseAmount(tag(summation, 'ram:GrandTotalAmount')) ?? 0;
-
-  // --- Lignes ---
-  const lineBlocks = allBlocks(tradeTransaction, 'ram:IncludedSupplyChainTradeLineItem');
-  const lines = lineBlocks.map(lineXml => {
-    const description = tag(lineXml, 'ram:Name');
-    const quantity = parseAmount(tag(lineXml, 'ram:BilledQuantity')) ?? 0;
-
-    // L'unité est dans l'attribut unitCode de BilledQuantity.
-    // C62 = "pièce" (unité générique UN/ECE Rec 20) — omis dans la sortie.
-    const unitMatch = lineXml.match(/ram:BilledQuantity[^>]*unitCode="([^"]+)"/);
-    const unitCode = unitMatch ? unitMatch[1] : null;
-
-    // Le prix unitaire est le prix NET (après remise). Sur une ligne avec
-    // remise, GrossPriceProductTradePrice (prix catalogue) précède
-    // NetPriceProductTradePrice — cibler le bloc net, pas le premier
-    // ChargeAmount du document. Repli sur la ligne entière si absent.
-    const netPriceBlock = block(lineXml, 'ram:NetPriceProductTradePrice');
-    const unitPrice = parseAmount(tag(netPriceBlock || lineXml, 'ram:ChargeAmount')) ?? 0;
-    const lineTotal = parseAmount(tag(lineXml, 'ram:LineTotalAmount')) ?? 0;
-
-    return {
-      description,
-      quantity,
-      ...(unitCode && unitCode !== 'C62' ? { unit: unitCode } : {}),
-      unit_price: unitPrice,
-      total: lineTotal,
-    };
-  });
-
-  // --- Résultat ---
-  // Format identique à l'entrée de generate-facturx.js, avec en plus :
-  //   seller    → émetteur de la facture reçue
-  //   tax_breakdown → ventilation TVA détaillée (multi-taux)
   return {
-    number,
-    date,
+    number: doc.number,
+    date: doc.date,
     due_date: dueDate,
-    type,
-    ...(category ? { category } : {}),
+    type: doc.type,
+    type_code: doc.typeCode,
+    ...(doc.category ? { category: doc.category } : {}),
     seller: {
-      name: sellerName,
-      ...(sellerSiret ? { siret: sellerSiret } : {}),
-      ...(sellerAddress ? { address: sellerAddress } : {}),
-      ...(sellerPostcode ? { postcode: sellerPostcode } : {}),
-      ...(sellerCity ? { city: sellerCity } : {}),
-      ...(sellerTva ? { tva_intracom: sellerTva } : {}),
+      name: seller.name,
+      ...(seller.siren ? { siren: seller.siren } : {}),
+      ...(seller.siret ? { siret: seller.siret } : {}),
+      ...(seller.address ? { address: seller.address } : {}),
+      ...(seller.postcode ? { postcode: seller.postcode } : {}),
+      ...(seller.city ? { city: seller.city } : {}),
+      ...(seller.vat ? { tva_intracom: seller.vat } : {}),
     },
     client: {
-      name: buyerName,
-      ...(buyerSiren ? { siren: buyerSiren } : {}),
-      ...(buyerSiret ? { siret: buyerSiret } : {}),
-      ...(buyerAddress ? { address: buyerAddress } : {}),
-      ...(buyerTva ? { tva_intracom: buyerTva } : {}),
+      name: buyer.name,
+      ...(buyer.siren ? { siren: buyer.siren } : {}),
+      ...(buyer.siret ? { siret: buyer.siret } : {}),
+      ...(buyer.address ? { address: buyer.address } : {}),
+      ...(buyer.vat ? { tva_intracom: buyer.vat } : {}),
     },
     currency,
     totals: {
-      ht: totalHT,
-      tva: totalTVA,
-      ttc: totalTTC,
+      ht: totals.taxBasisTotal,
+      tva: totals.taxTotal,
+      ttc: totals.grandTotal,
+      due_payable: totals.duePayable,
       ...(tvaRate !== null ? { tva_rate: tvaRate } : {}),
       tva_exempt: tvaExempt,
     },
     tax_breakdown: taxBreakdown,
     lines,
-    ...(paymentTermsDesc ? { payment: { terms: paymentTermsDesc } } : {}),
+    ...(paymentTerms ? { payment: { terms: paymentTerms } } : {}),
     _format: 'cii-en16931',
   };
+}
+
+function parseCII(xml) {
+  const errors = [];
+
+  checkProfile(xml, errors);
+  const doc = parseDocument(xml, errors);
+
+  const tradeTransaction = block(xml, 'rsm:SupplyChainTradeTransaction') || '';
+  const agreement = block(tradeTransaction, 'ram:ApplicableHeaderTradeAgreement') || '';
+  const settlement = block(tradeTransaction, 'ram:ApplicableHeaderTradeSettlement') || '';
+
+  const seller = parseSeller(agreement, errors);
+  const buyer = parseBuyer(agreement, errors);
+
+  const currency = readText(tag(settlement, 'ram:InvoiceCurrencyCode'), { id: 'BT-5', label: 'Devise de facturation (BT-5)', required: true }, errors);
+  const paymentTermsBlock = block(settlement, 'ram:SpecifiedTradePaymentTerms') || '';
+  const dueDate = parseDate102(tag(paymentTermsBlock, 'udt:DateTimeString'), { id: 'BT-9', label: "Date d'échéance (BT-9)", required: false }, errors);
+
+  const taxBreakdown = parseTaxBreakdown(settlement, errors);
+  const lines = parseLines(tradeTransaction, errors);
+  const totals = parseTotals(settlement, currency, errors);
+  reconcile(totals, lines, taxBreakdown, errors);
+
+  const invoice = buildInvoice({
+    doc,
+    seller,
+    buyer,
+    currency,
+    dueDate,
+    paymentTerms: tag(paymentTermsBlock, 'ram:Description'),
+    taxBreakdown,
+    lines,
+    totals,
+  });
+
+  return { invoice, errors };
 }
 
 // ---------------------------------------------------------------------------
@@ -299,48 +623,46 @@ function formatRate(rate) {
 }
 
 function printHuman(invoice) {
-  const eur = (n) => (n !== null && n !== undefined ? n.toFixed(2) + ' EUR' : '-');
+  const amount = (n) => (n !== null && n !== undefined ? `${n.toFixed(2)} ${invoice.currency}` : '-');
   const categoryLabels = { goods: 'Livraison de biens', services: 'Prestation de services', mixed: 'Mixte' };
 
   console.log('\n━━━ Facture parsée ━━━\n');
   console.log(`  Numéro      : ${invoice.number}`);
-  console.log(`  Type        : ${invoice.type === 'credit_note' ? 'Avoir (TypeCode 381)' : 'Facture (TypeCode 380)'}`);
+  console.log(`  Type        : ${invoice.type === 'credit_note' ? 'Avoir' : 'Facture'} (TypeCode ${invoice.type_code})`);
   console.log(`  Date        : ${invoice.date}`);
   console.log(`  Échéance    : ${invoice.due_date || '-'}`);
   if (invoice.category) console.log(`  Catégorie   : ${categoryLabels[invoice.category] || invoice.category}`);
   console.log(`  Format      : ${invoice._format}`);
 
   console.log('\n  Vendeur');
-  console.log(`    Nom       : ${invoice.seller.name || '-'}`);
+  console.log(`    Nom       : ${invoice.seller.name}`);
+  console.log(`    SIREN     : ${invoice.seller.siren || '-'}`);
   console.log(`    SIRET     : ${invoice.seller.siret || '-'}`);
   if (invoice.seller.address) console.log(`    Adresse   : ${invoice.seller.address}`);
   if (invoice.seller.tva_intracom) console.log(`    N° TVA    : ${invoice.seller.tva_intracom}`);
 
   console.log('\n  Acheteur');
-  console.log(`    Nom       : ${invoice.client.name || '-'}`);
+  console.log(`    Nom       : ${invoice.client.name}`);
   console.log(`    SIREN     : ${invoice.client.siren || '-'}`);
   if (invoice.client.address) console.log(`    Adresse   : ${invoice.client.address}`);
   if (invoice.client.tva_intracom) console.log(`    N° TVA    : ${invoice.client.tva_intracom}`);
 
   console.log('\n  Montants');
-  console.log(`    Total HT  : ${eur(invoice.totals.ht)}`);
-  if (invoice.tax_breakdown.length > 0) {
-    invoice.tax_breakdown.forEach(tb => {
-      const label = tb.category_code === 'S'
-        ? `TVA ${formatRate(tb.rate)}`
-        : `TVA (${tb.category_code}${tb.exemption_reason ? ' — ' + tb.exemption_reason : ''})`;
-      console.log(`    ${label.padEnd(18)}: base ${eur(tb.basis_amount)}, TVA ${eur(tb.tax_amount)}`);
-    });
-  }
-  console.log(`    Total TTC : ${eur(invoice.totals.ttc)}`);
+  console.log(`    Total HT  : ${amount(invoice.totals.ht)}`);
+  invoice.tax_breakdown.forEach(tb => {
+    const label = tb.category_code === 'S'
+      ? `TVA ${formatRate(tb.rate)}`
+      : `TVA (${tb.category_code}${tb.exemption_reason ? ' — ' + tb.exemption_reason : ''})`;
+    console.log(`    ${label.padEnd(18)}: base ${amount(tb.basis_amount)}, TVA ${amount(tb.tax_amount)}`);
+  });
+  console.log(`    Total TTC : ${amount(invoice.totals.ttc)}`);
+  console.log(`    À payer   : ${amount(invoice.totals.due_payable)}`);
 
-  if (invoice.lines && invoice.lines.length > 0) {
-    console.log(`\n  Lignes (${invoice.lines.length})`);
-    invoice.lines.forEach((l, i) => {
-      const unit = l.unit ? ` ${l.unit}` : '';
-      console.log(`    ${i + 1}. ${l.description} — ${l.quantity}${unit} × ${l.unit_price.toFixed(2)} EUR = ${l.total.toFixed(2)} EUR`);
-    });
-  }
+  console.log(`\n  Lignes (${invoice.lines.length})`);
+  invoice.lines.forEach((l, i) => {
+    const unit = l.unit ? ` ${l.unit}` : '';
+    console.log(`    ${i + 1}. ${l.description} — ${l.quantity}${unit} × ${l.unit_price.toFixed(2)} = ${l.total.toFixed(2)} ${invoice.currency}`);
+  });
 
   if (invoice.payment && invoice.payment.terms) {
     console.log(`\n  Paiement    : ${invoice.payment.terms}`);
@@ -349,23 +671,19 @@ function printHuman(invoice) {
   console.log('');
 }
 
+function printErrors(errors) {
+  console.error(`\n❌ Facture refusée — ${errors.length} erreur(s) :\n`);
+  errors.forEach(e => console.error(`   [${e.id}] ${e.message}`));
+  console.error('\nAucune donnée n\'est émise : cette facture ne doit pas alimenter un import comptable.\n');
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
-function main() {
-  const args = process.argv.slice(2);
-  const invoiceIdx = args.indexOf('--invoice');
-  const jsonOutput = args.includes('--json');
-
-  if (invoiceIdx === -1 || !args[invoiceIdx + 1]) {
-    console.error('Usage: node scripts/parse-einvoice.js --invoice <fichier.xml>');
-    console.error('Options:');
-    console.error('  --json   Sortie JSON uniquement (pour intégration CI/agent)');
-    process.exit(1);
-  }
-
-  const filePath = args[invoiceIdx + 1];
+// Lit le fichier et s'assure qu'il s'agit bien d'un CII exploitable.
+// Sort en code 1 avec un message explicite sinon.
+function readCiiFile(filePath) {
   if (!fs.existsSync(filePath)) {
     console.error(`Fichier introuvable : ${filePath}`);
     process.exit(1);
@@ -394,12 +712,33 @@ function main() {
   }
 
   if (format === 'ubl') {
-    console.error('Format UBL non encore supporté (utilisé sur le réseau Peppol).');
+    console.error('Format UBL non supporté (utilisé sur le réseau Peppol).');
     console.error('Ce parser traite les factures CII (Factur-X, échanges domestiques FR).');
     process.exit(1);
   }
 
-  const invoice = parseCII(xml);
+  return xml;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const invoiceIdx = args.indexOf('--invoice');
+  const jsonOutput = args.includes('--json');
+
+  if (invoiceIdx === -1 || !args[invoiceIdx + 1]) {
+    console.error('Usage: node scripts/parse-einvoice.js --invoice <fichier.xml>');
+    console.error('Options:');
+    console.error('  --json   Sortie JSON uniquement (pour intégration CI/agent)');
+    process.exit(1);
+  }
+
+  const { invoice, errors } = parseCII(readCiiFile(args[invoiceIdx + 1]));
+
+  if (errors.length > 0) {
+    if (jsonOutput) console.log(JSON.stringify({ ok: false, errors }, null, 2));
+    else printErrors(errors);
+    process.exit(1);
+  }
 
   if (jsonOutput) {
     console.log(JSON.stringify(invoice, null, 2));

--- a/scripts/test-parse-einvoice.js
+++ b/scripts/test-parse-einvoice.js
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+/**
+ * Tests de parse-einvoice.js
+ *
+ * 1. Round-trip : une facture generee par generate-facturx.js (--xml-only)
+ *    est relue par parse-einvoice.js — les donnees doivent correspondre.
+ *    Couvre les deux regimes : TVA 20% (S) et franchise en base (E).
+ * 2. Fixture avec remise : une ligne CII portant GrossPriceProductTradePrice
+ *    (prix catalogue) AVANT NetPriceProductTradePrice (prix net) — le parseur
+ *    doit retourner le prix net, pas le brut.
+ *
+ * Usage : npm run test:parse
+ */
+
+"use strict";
+
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const ROOT = path.join(__dirname, "..");
+const GENERATE_SCRIPT = path.join(ROOT, "scripts", "generate-facturx.js");
+const PARSE_SCRIPT = path.join(ROOT, "scripts", "parse-einvoice.js");
+
+function parseInvoice(xmlPath) {
+  const output = execFileSync(process.execPath, [PARSE_SCRIPT, "--invoice", xmlPath, "--json"], {
+    encoding: "utf8",
+  });
+  return JSON.parse(output);
+}
+
+// Dossiers temporaires crees par les tests — supprimes en fin de run.
+const TMP_DIRS = [];
+
+function mkTmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paperasse-test-"));
+  TMP_DIRS.push(dir);
+  return dir;
+}
+
+// Genere le XML CII dans un dossier temporaire contenant son propre
+// company.json (generate-facturx.js cherche company.json dans le CWD d'abord).
+function generateXml(company, invoice) {
+  const tmpDir = mkTmpDir();
+  fs.writeFileSync(path.join(tmpDir, "company.json"), JSON.stringify(company, null, 2));
+  const invoicePath = path.join(tmpDir, `${invoice.number}.json`);
+  fs.writeFileSync(invoicePath, JSON.stringify(invoice, null, 2));
+  execFileSync(
+    process.execPath,
+    [GENERATE_SCRIPT, "--invoice", invoicePath, "--xml-only", "--output", tmpDir],
+    { cwd: tmpDir, encoding: "utf8" }
+  );
+  return path.join(tmpDir, `${invoice.number}.xml`);
+}
+
+const baseCompany = {
+  name: "TEST COMPANY SASU",
+  legal_form: "SASU",
+  siren: "123456789",
+  siret: "12345678900014",
+  address: "1 Rue de la Paix, 75001 Paris",
+  city: "Paris",
+  tva_intracom: "FR32123456789",
+  tax: { regime_tva: "reel_simplifie", tva_rate: 0.2 },
+};
+
+const baseInvoice = {
+  number: "F-TEST-001",
+  date: "2026-01-15",
+  due_date: "2026-02-14",
+  type: "invoice",
+  category: "services",
+  client: {
+    name: "CLIENT EXEMPLE SARL",
+    address: "10 rue Example, 75001 Paris",
+    country: "FR",
+    siren: "987654321",
+  },
+  lines: [
+    { description: "Developpement", quantity: 3, unit: "DAY", unit_price: 500 },
+    { description: "Licence logicielle", quantity: 2, unit_price: 120 },
+  ],
+  payment: { terms: "30 jours date de facture", method: "virement" },
+};
+
+function testRoundTripTva20() {
+  const xmlPath = generateXml(baseCompany, baseInvoice);
+  const parsed = parseInvoice(xmlPath);
+
+  assert.strictEqual(parsed.number, "F-TEST-001");
+  assert.strictEqual(parsed.date, "2026-01-15");
+  assert.strictEqual(parsed.due_date, "2026-02-14");
+  assert.strictEqual(parsed.type, "invoice");
+  assert.strictEqual(parsed.category, "services");
+
+  assert.strictEqual(parsed.seller.name, "TEST COMPANY SASU");
+  assert.strictEqual(parsed.seller.siret, "12345678900014");
+  assert.strictEqual(parsed.seller.tva_intracom, "FR32123456789");
+
+  assert.strictEqual(parsed.client.name, "CLIENT EXEMPLE SARL");
+  assert.strictEqual(parsed.client.siren, "987654321");
+  assert.strictEqual(parsed.client.siret, undefined);
+
+  // HT = 3 x 500 + 2 x 120 = 1740 ; TVA 20% = 348 ; TTC = 2088
+  assert.strictEqual(parsed.totals.ht, 1740);
+  assert.strictEqual(parsed.totals.tva, 348);
+  assert.strictEqual(parsed.totals.ttc, 2088);
+  assert.strictEqual(parsed.totals.tva_rate, 0.2);
+  assert.strictEqual(parsed.totals.tva_exempt, false);
+
+  assert.strictEqual(parsed.tax_breakdown.length, 1);
+  assert.strictEqual(parsed.tax_breakdown[0].category_code, "S");
+  assert.strictEqual(parsed.tax_breakdown[0].rate, 0.2);
+  assert.strictEqual(parsed.tax_breakdown[0].basis_amount, 1740);
+  assert.strictEqual(parsed.tax_breakdown[0].tax_amount, 348);
+
+  assert.strictEqual(parsed.lines.length, 2);
+  assert.strictEqual(parsed.lines[0].description, "Developpement");
+  assert.strictEqual(parsed.lines[0].quantity, 3);
+  assert.strictEqual(parsed.lines[0].unit, "DAY");
+  assert.strictEqual(parsed.lines[0].unit_price, 500);
+  assert.strictEqual(parsed.lines[0].total, 1500);
+  assert.strictEqual(parsed.lines[1].description, "Licence logicielle");
+  assert.strictEqual(parsed.lines[1].unit, undefined); // C62 omis
+  assert.strictEqual(parsed.lines[1].unit_price, 120);
+  assert.strictEqual(parsed.lines[1].total, 240);
+
+  assert.strictEqual(parsed.payment.terms, "30 jours date de facture");
+}
+
+function testRoundTripFranchise() {
+  const company = { ...baseCompany, tax: { regime_tva: "franchise" } };
+  const invoice = { ...baseInvoice, number: "F-TEST-002" };
+  const xmlPath = generateXml(company, invoice);
+  const parsed = parseInvoice(xmlPath);
+
+  assert.strictEqual(parsed.totals.ht, 1740);
+  assert.strictEqual(parsed.totals.tva, 0);
+  assert.strictEqual(parsed.totals.ttc, 1740);
+  assert.strictEqual(parsed.totals.tva_exempt, true);
+  assert.strictEqual("tva_rate" in parsed.totals, false); // aucune ligne S
+
+  assert.strictEqual(parsed.tax_breakdown.length, 1);
+  assert.strictEqual(parsed.tax_breakdown[0].category_code, "E");
+  assert.match(parsed.tax_breakdown[0].exemption_reason, /article 293 B/);
+}
+
+// Ligne avec remise : le prix brut (GrossPriceProductTradePrice, 120.00)
+// precede le prix net (NetPriceProductTradePrice, 100.00) comme dans les
+// Factur-X reels. Le parseur doit retourner le net.
+const FIXTURE_DISCOUNT_LINE = `<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice
+  xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+  xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+  xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocument>
+    <ram:ID>F-REMISE-001</ram:ID>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">20260115</udt:DateTimeString>
+    </ram:IssueDateTime>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:SellerTradeParty>
+        <ram:Name>VENDEUR SAS</ram:Name>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:Name>ACHETEUR SARL</ram:Name>
+      </ram:BuyerTradeParty>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>40.00</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>200.00</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:TaxBasisTotalAmount>200.00</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount currencyID="EUR">40.00</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>240.00</ram:GrandTotalAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>Prestation avec remise</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>120.00</ram:ChargeAmount>
+          <ram:AppliedTradeAllowanceCharge>
+            <ram:ChargeIndicator><udt:Indicator>false</udt:Indicator></ram:ChargeIndicator>
+            <ram:ActualAmount>20.00</ram:ActualAmount>
+          </ram:AppliedTradeAllowanceCharge>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>100.00</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">2</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>200.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>
+`;
+
+function testUnitPriceIsNetNotGross() {
+  const tmpDir = mkTmpDir();
+  const xmlPath = path.join(tmpDir, "F-REMISE-001.xml");
+  fs.writeFileSync(xmlPath, FIXTURE_DISCOUNT_LINE);
+  const parsed = parseInvoice(xmlPath);
+
+  assert.strictEqual(parsed.lines.length, 1);
+  assert.strictEqual(parsed.lines[0].unit_price, 100); // net, pas le brut 120
+  assert.strictEqual(parsed.lines[0].quantity, 2);
+  assert.strictEqual(parsed.lines[0].total, 200);
+  assert.strictEqual(parsed.totals.ttc, 240);
+}
+
+function main() {
+  try {
+    testRoundTripTva20();
+    testRoundTripFranchise();
+    testUnitPriceIsNetNotGross();
+  } finally {
+    TMP_DIRS.forEach((dir) => fs.rmSync(dir, { recursive: true, force: true }));
+  }
+  console.log("parse-einvoice tests passed.");
+}
+
+main();

--- a/scripts/test-parse-einvoice.js
+++ b/scripts/test-parse-einvoice.js
@@ -6,9 +6,12 @@
  * 1. Round-trip : une facture generee par generate-facturx.js (--xml-only)
  *    est relue par parse-einvoice.js — les donnees doivent correspondre.
  *    Couvre les deux regimes : TVA 20% (S) et franchise en base (E).
- * 2. Fixture avec remise : une ligne CII portant GrossPriceProductTradePrice
- *    (prix catalogue) AVANT NetPriceProductTradePrice (prix net) — le parseur
- *    doit retourner le prix net, pas le brut.
+ * 2. Lecture d'une fixture CII conforme EN 16931 (lignes en premier, comme
+ *    dans le schema reel) : prix net et non prix brut, n° de TVA cherche dans
+ *    tous les blocs SpecifiedTaxRegistration, decodage XML.
+ * 3. Refus : chaque controle bloquant du parseur a un test qui le declenche
+ *    (profil, date, decimal, rapprochements, champ obligatoire absent).
+ *    Ces tests assertent le code de sortie non nul ET l'identifiant d'erreur.
  *
  * Usage : npm run test:parse
  */
@@ -25,11 +28,30 @@ const ROOT = path.join(__dirname, "..");
 const GENERATE_SCRIPT = path.join(ROOT, "scripts", "generate-facturx.js");
 const PARSE_SCRIPT = path.join(ROOT, "scripts", "parse-einvoice.js");
 
+// Parse une facture attendue conforme. Leve si le parseur la refuse.
 function parseInvoice(xmlPath) {
   const output = execFileSync(process.execPath, [PARSE_SCRIPT, "--invoice", xmlPath, "--json"], {
     encoding: "utf8",
   });
   return JSON.parse(output);
+}
+
+// Parse une facture attendue non conforme. Retourne la liste des erreurs.
+function parseExpectingErrors(xmlPath) {
+  try {
+    execFileSync(process.execPath, [PARSE_SCRIPT, "--invoice", xmlPath, "--json"], { encoding: "utf8" });
+  } catch (err) {
+    assert.strictEqual(err.status, 1, "le parseur doit sortir en code 1");
+    const payload = JSON.parse(err.stdout);
+    assert.strictEqual(payload.ok, false);
+    return payload.errors;
+  }
+  throw new assert.AssertionError({ message: `${path.basename(xmlPath)} aurait du etre refusee` });
+}
+
+function assertHasError(errors, id) {
+  const ids = errors.map((e) => e.id);
+  assert.ok(ids.includes(id), `erreur ${id} attendue, recu : ${ids.join(", ") || "aucune"}`);
 }
 
 // Dossiers temporaires crees par les tests — supprimes en fin de run.
@@ -39,6 +61,12 @@ function mkTmpDir() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paperasse-test-"));
   TMP_DIRS.push(dir);
   return dir;
+}
+
+function writeFixture(name, xml) {
+  const xmlPath = path.join(mkTmpDir(), `${name}.xml`);
+  fs.writeFileSync(xmlPath, xml);
+  return xmlPath;
 }
 
 // Genere le XML CII dans un dossier temporaire contenant son propre
@@ -108,6 +136,7 @@ function testRoundTripTva20() {
   assert.strictEqual(parsed.totals.ht, 1740);
   assert.strictEqual(parsed.totals.tva, 348);
   assert.strictEqual(parsed.totals.ttc, 2088);
+  assert.strictEqual(parsed.totals.due_payable, 2088);
   assert.strictEqual(parsed.totals.tva_rate, 0.2);
   assert.strictEqual(parsed.totals.tva_exempt, false);
 
@@ -140,6 +169,7 @@ function testRoundTripFranchise() {
   assert.strictEqual(parsed.totals.ht, 1740);
   assert.strictEqual(parsed.totals.tva, 0);
   assert.strictEqual(parsed.totals.ttc, 1740);
+  assert.strictEqual(parsed.totals.due_payable, 1740);
   assert.strictEqual(parsed.totals.tva_exempt, true);
   assert.strictEqual("tva_rate" in parsed.totals, false); // aucune ligne S
 
@@ -148,14 +178,22 @@ function testRoundTripFranchise() {
   assert.match(parsed.tax_breakdown[0].exemption_reason, /article 293 B/);
 }
 
-// Ligne avec remise : le prix brut (GrossPriceProductTradePrice, 120.00)
-// precede le prix net (NetPriceProductTradePrice, 100.00) comme dans les
-// Factur-X reels. Le parseur doit retourner le net.
-const FIXTURE_DISCOUNT_LINE = `<?xml version="1.0" encoding="UTF-8"?>
+// Fixture CII conforme EN 16931, dans l'ordre du schema reel (lignes AVANT
+// l'accord et le reglement, contrairement a ce que produit generate-facturx.js).
+// Elle porte volontairement :
+//   - une ligne avec remise : prix brut 120.00 puis prix net 100.00 ;
+//   - deux SpecifiedTaxRegistration cote vendeur, le bloc "VA" en second.
+// Totaux : 2 x 100 = 200 HT, TVA 20% = 40, TTC = 240, a payer = 240.
+const VALID_CII = `<?xml version="1.0" encoding="UTF-8"?>
 <rsm:CrossIndustryInvoice
   xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
   xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
   xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:en16931</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
   <rsm:ExchangedDocument>
     <ram:ID>F-REMISE-001</ram:ID>
     <ram:TypeCode>380</ram:TypeCode>
@@ -164,30 +202,10 @@ const FIXTURE_DISCOUNT_LINE = `<?xml version="1.0" encoding="UTF-8"?>
     </ram:IssueDateTime>
   </rsm:ExchangedDocument>
   <rsm:SupplyChainTradeTransaction>
-    <ram:ApplicableHeaderTradeAgreement>
-      <ram:SellerTradeParty>
-        <ram:Name>VENDEUR SAS</ram:Name>
-      </ram:SellerTradeParty>
-      <ram:BuyerTradeParty>
-        <ram:Name>ACHETEUR SARL</ram:Name>
-      </ram:BuyerTradeParty>
-    </ram:ApplicableHeaderTradeAgreement>
-    <ram:ApplicableHeaderTradeSettlement>
-      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
-      <ram:ApplicableTradeTax>
-        <ram:CalculatedAmount>40.00</ram:CalculatedAmount>
-        <ram:TypeCode>VAT</ram:TypeCode>
-        <ram:BasisAmount>200.00</ram:BasisAmount>
-        <ram:CategoryCode>S</ram:CategoryCode>
-        <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
-      </ram:ApplicableTradeTax>
-      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
-        <ram:TaxBasisTotalAmount>200.00</ram:TaxBasisTotalAmount>
-        <ram:TaxTotalAmount currencyID="EUR">40.00</ram:TaxTotalAmount>
-        <ram:GrandTotalAmount>240.00</ram:GrandTotalAmount>
-      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
-    </ram:ApplicableHeaderTradeSettlement>
     <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
       <ram:SpecifiedTradeProduct>
         <ram:Name>Prestation avec remise</ram:Name>
       </ram:SpecifiedTradeProduct>
@@ -207,37 +225,307 @@ const FIXTURE_DISCOUNT_LINE = `<?xml version="1.0" encoding="UTF-8"?>
         <ram:BilledQuantity unitCode="C62">2</ram:BilledQuantity>
       </ram:SpecifiedLineTradeDelivery>
       <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
         <ram:SpecifiedTradeSettlementLineMonetarySummation>
           <ram:LineTotalAmount>200.00</ram:LineTotalAmount>
         </ram:SpecifiedTradeSettlementLineMonetarySummation>
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:SellerTradeParty>
+        <ram:Name>VENDEUR SAS</ram:Name>
+        <ram:SpecifiedLegalOrganization>
+          <ram:ID schemeID="0002">12345678900014</ram:ID>
+        </ram:SpecifiedLegalOrganization>
+        <ram:PostalTradeAddress>
+          <ram:LineOne>1 Rue de la Paix</ram:LineOne>
+          <ram:PostcodeCode>75001</ram:PostcodeCode>
+          <ram:CityName>Paris</ram:CityName>
+          <ram:CountryID>FR</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="FC">7501234567</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">FR32123456789</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:Name>ACHETEUR SARL</ram:Name>
+        <ram:SpecifiedLegalOrganization>
+          <ram:ID schemeID="0002">987654321</ram:ID>
+        </ram:SpecifiedLegalOrganization>
+        <ram:PostalTradeAddress>
+          <ram:LineOne>10 rue Example</ram:LineOne>
+          <ram:CountryID>FR</ram:CountryID>
+        </ram:PostalTradeAddress>
+      </ram:BuyerTradeParty>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery/>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>40.00</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>200.00</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>200.00</ram:LineTotalAmount>
+        <ram:TaxBasisTotalAmount>200.00</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount currencyID="EUR">40.00</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>240.00</ram:GrandTotalAmount>
+        <ram:DuePayableAmount>240.00</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
   </rsm:SupplyChainTradeTransaction>
 </rsm:CrossIndustryInvoice>
 `;
 
-function testUnitPriceIsNetNotGross() {
-  const tmpDir = mkTmpDir();
-  const xmlPath = path.join(tmpDir, "F-REMISE-001.xml");
-  fs.writeFileSync(xmlPath, FIXTURE_DISCOUNT_LINE);
-  const parsed = parseInvoice(xmlPath);
+// Remplace un ou plusieurs fragments de la fixture conforme, en verifiant que
+// chaque fragment existait : sans ce garde-fou, un test de refus pourrait
+// passer alors qu'il n'a rien mute.
+function mutate(...replacements) {
+  return replacements.reduce((xml, [search, replacement]) => {
+    assert.ok(xml.includes(search), `fragment absent de la fixture : ${search}`);
+    return xml.replace(search, replacement);
+  }, VALID_CII);
+}
 
+function testValidFixtureIsAccepted() {
+  const parsed = parseInvoice(writeFixture("F-REMISE-001", VALID_CII));
+
+  assert.strictEqual(parsed.number, "F-REMISE-001");
+  assert.strictEqual(parsed.date, "2026-01-15");
   assert.strictEqual(parsed.lines.length, 1);
   assert.strictEqual(parsed.lines[0].unit_price, 100); // net, pas le brut 120
   assert.strictEqual(parsed.lines[0].quantity, 2);
   assert.strictEqual(parsed.lines[0].total, 200);
   assert.strictEqual(parsed.totals.ttc, 240);
+  assert.strictEqual(parsed.totals.due_payable, 240);
+  assert.strictEqual(parsed.client.siren, "987654321");
+  // Le bloc VA est le second : il doit quand meme etre trouve.
+  assert.strictEqual(parsed.seller.tva_intracom, "FR32123456789");
 }
+
+// Les prefixes de namespace ne sont pas normatifs : certains emetteurs
+// declarent CrossIndustryInvoice dans le namespace par defaut et n'ecrivent
+// donc pas le prefixe rsm:. Le meme document doit se lire a l'identique.
+function testDefaultNamespaceIsAccepted() {
+  const xml = VALID_CII.replace("xmlns:rsm=", "xmlns=").replace(/rsm:/g, "");
+  const parsed = parseInvoice(writeFixture("F-NS-DEFAUT", xml));
+
+  assert.strictEqual(parsed.number, "F-REMISE-001");
+  assert.strictEqual(parsed.lines.length, 1);
+  assert.strictEqual(parsed.lines[0].unit_price, 100);
+  assert.strictEqual(parsed.totals.ttc, 240);
+  assert.strictEqual(parsed.totals.due_payable, 240);
+}
+
+function testPriceFallsBackToNothingWithoutNetPrice() {
+  const xml = mutate([
+    `        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>100.00</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+`,
+    "",
+  ]);
+  // Sans prix net, le parseur doit refuser la ligne et surtout ne pas retomber
+  // sur le prix brut (120.00) du bloc GrossPriceProductTradePrice.
+  assertHasError(parseExpectingErrors(writeFixture("F-SANS-PRIX-NET", xml)), "BT-146_1_MISSING");
+}
+
+function testXmlEntitiesAreDecodedOnce() {
+  const xml = mutate(["<ram:Name>VENDEUR SAS</ram:Name>", "<ram:Name>DUPONT &amp;lt;FILS&amp;gt;</ram:Name>"]);
+  const parsed = parseInvoice(writeFixture("F-ENTITES", xml));
+  // &amp;lt; se decode en &lt; — pas en < (double decodage).
+  assert.strictEqual(parsed.seller.name, "DUPONT &lt;FILS&gt;");
+}
+
+function testProfileBasicWlIsRejected() {
+  const xml = mutate([
+    "urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:en16931",
+    "urn:factur-x.eu:1p0:basicwl",
+  ]);
+  assertHasError(parseExpectingErrors(writeFixture("F-BASICWL", xml)), "BT-24_PROFILE");
+}
+
+function testImpossibleCalendarDateIsRejected() {
+  const xml = mutate([">20260115<", ">20260231<"]); // 31 fevrier
+  assertHasError(parseExpectingErrors(writeFixture("F-DATE-KO", xml)), "BT-2_INVALID");
+}
+
+// Date tronquee : les 8 chiffres du format 102 ne sont pas la, mais un decoupage
+// naif y verrait quand meme une date valide (2026-01-1).
+function testTruncatedDateIsRejected() {
+  const xml = mutate([">20260115<", ">2026011<"]);
+  assertHasError(parseExpectingErrors(writeFixture("F-DATE-COURTE", xml)), "BT-2_INVALID");
+}
+
+function testMalformedDecimalIsRejected() {
+  const xml = mutate([
+    "<ram:GrandTotalAmount>240.00</ram:GrandTotalAmount>",
+    "<ram:GrandTotalAmount>12abc</ram:GrandTotalAmount>",
+  ]);
+  assertHasError(parseExpectingErrors(writeFixture("F-DECIMAL-KO", xml)), "BT-112_INVALID");
+}
+
+function testTotalsMismatchIsRejected() {
+  const xml = mutate([
+    "<ram:GrandTotalAmount>240.00</ram:GrandTotalAmount>",
+    "<ram:GrandTotalAmount>999.00</ram:GrandTotalAmount>",
+  ]);
+  // 200 HT + 40 TVA ne font pas 999 TTC.
+  assertHasError(parseExpectingErrors(writeFixture("F-TOTAUX-KO", xml)), "BR-CO-15");
+}
+
+function testLineSumMismatchIsRejected() {
+  const xml = mutate([
+    "<ram:LineTotalAmount>200.00</ram:LineTotalAmount>\n        <ram:TaxBasisTotalAmount>",
+    "<ram:LineTotalAmount>150.00</ram:LineTotalAmount>\n        <ram:TaxBasisTotalAmount>",
+  ]);
+  // La somme des lignes vaut 200, pas 150.
+  assertHasError(parseExpectingErrors(writeFixture("F-LIGNES-KO", xml)), "BR-CO-10");
+}
+
+// Facture interieurement coherente (tous les totaux s'additionnent) mais dont
+// la TVA ne correspond pas au taux annonce : 200 a 20% font 40, pas 30.
+// C'est le cas « ecriture plausible mais fausse ».
+function testVatAmountNotMatchingRateIsRejected() {
+  const xml = mutate(
+    ["<ram:CalculatedAmount>40.00</ram:CalculatedAmount>", "<ram:CalculatedAmount>30.00</ram:CalculatedAmount>"],
+    ['<ram:TaxTotalAmount currencyID="EUR">40.00</ram:TaxTotalAmount>', '<ram:TaxTotalAmount currencyID="EUR">30.00</ram:TaxTotalAmount>'],
+    ["<ram:GrandTotalAmount>240.00</ram:GrandTotalAmount>", "<ram:GrandTotalAmount>230.00</ram:GrandTotalAmount>"],
+    ["<ram:DuePayableAmount>240.00</ram:DuePayableAmount>", "<ram:DuePayableAmount>230.00</ram:DuePayableAmount>"]
+  );
+  assertHasError(parseExpectingErrors(writeFixture("F-TVA-KO", xml)), "BR-S-09_1");
+}
+
+// La base declaree dans la ventilation TVA (150) ne couvre pas la base HT
+// totale (200) : une partie du chiffre d'affaires echappe a la TVA.
+function testVatBasisNotCoveringTaxBasisTotalIsRejected() {
+  const xml = mutate(
+    ["<ram:BasisAmount>200.00</ram:BasisAmount>", "<ram:BasisAmount>150.00</ram:BasisAmount>"],
+    ["<ram:CalculatedAmount>40.00</ram:CalculatedAmount>", "<ram:CalculatedAmount>30.00</ram:CalculatedAmount>"],
+    ['<ram:TaxTotalAmount currencyID="EUR">40.00</ram:TaxTotalAmount>', '<ram:TaxTotalAmount currencyID="EUR">30.00</ram:TaxTotalAmount>'],
+    ["<ram:GrandTotalAmount>240.00</ram:GrandTotalAmount>", "<ram:GrandTotalAmount>230.00</ram:GrandTotalAmount>"],
+    ["<ram:DuePayableAmount>240.00</ram:DuePayableAmount>", "<ram:DuePayableAmount>230.00</ram:DuePayableAmount>"]
+  );
+  assertHasError(parseExpectingErrors(writeFixture("F-BASES-KO", xml)), "COHERENCE_BASES");
+}
+
+// Un code type inconnu ne doit pas retomber silencieusement sur « facture ».
+function testUnsupportedTypeCodeIsRejected() {
+  const xml = mutate(["<ram:TypeCode>380</ram:TypeCode>", "<ram:TypeCode>FactureCommerciale</ram:TypeCode>"]);
+  assertHasError(parseExpectingErrors(writeFixture("F-TYPE-KO", xml)), "BT-3_UNSUPPORTED");
+}
+
+// Une facture rectificative (384) reste une facture, mais son code doit
+// rester lisible dans la sortie pour l'ecriture comptable.
+function testCorrectiveTypeCodeIsExposed() {
+  const xml = mutate(["<ram:TypeCode>380</ram:TypeCode>", "<ram:TypeCode>384</ram:TypeCode>"]);
+  const parsed = parseInvoice(writeFixture("F-TYPE-384", xml));
+  assert.strictEqual(parsed.type, "invoice");
+  assert.strictEqual(parsed.type_code, "384");
+}
+
+// Un TypeCode heritant d'Object ne doit pas passer pour un type connu.
+function testPrototypeTypeCodeIsRejected() {
+  const xml = mutate(["<ram:TypeCode>380</ram:TypeCode>", "<ram:TypeCode>constructor</ram:TypeCode>"]);
+  assertHasError(parseExpectingErrors(writeFixture("F-TYPE-PROTO", xml)), "BT-3_UNSUPPORTED");
+}
+
+// Un SIREN de 9 chiffres ne doit pas etre restitue dans le champ siret.
+function testSellerSirenIsNotLabelledSiret() {
+  const xml = mutate(['schemeID="0002">12345678900014<', 'schemeID="0002">123456789<']);
+  const parsed = parseInvoice(writeFixture("F-SIREN", xml));
+
+  assert.strictEqual(parsed.seller.siren, "123456789");
+  assert.strictEqual(parsed.seller.siret, undefined);
+}
+
+function testMalformedSellerLegalIdIsRejected() {
+  const xml = mutate(['schemeID="0002">12345678900014<', 'schemeID="0002">1234ABC<']);
+  assertHasError(parseExpectingErrors(writeFixture("F-SIRET-KO", xml)), "BT-30_INVALID");
+}
+
+// Categorie S : le taux est obligatoire, son absence ne doit pas desactiver
+// silencieusement le controle du montant de TVA.
+function testStandardCategoryWithoutRateIsRejected() {
+  const xml = mutate(["\n        <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>", ""]);
+  assertHasError(parseExpectingErrors(writeFixture("F-TAUX-ABSENT", xml)), "BT-119_1_MISSING");
+}
+
+// Categories non taxees : BR-E-09 et ses equivalents imposent une TVA a zero.
+function testExemptCategoryWithVatIsRejected() {
+  // Cibler la ventilation d'en-tete : le bloc de la ligne porte lui aussi une
+  // categorie S, et il apparait en premier dans la fixture.
+  const xml = mutate([
+    "<ram:BasisAmount>200.00</ram:BasisAmount>\n        <ram:CategoryCode>S</ram:CategoryCode>",
+    "<ram:BasisAmount>200.00</ram:BasisAmount>\n        <ram:CategoryCode>E</ram:CategoryCode>",
+  ]);
+  assertHasError(parseExpectingErrors(writeFixture("F-EXO-TVA", xml)), "BR-CAT-09_1");
+}
+
+// xs:decimal autorise le signe : +240.00 est une valeur valide, pas un rejet.
+function testSignedDecimalIsAccepted() {
+  const xml = mutate(["<ram:GrandTotalAmount>240.00<", "<ram:GrandTotalAmount>+240.00<"]);
+  const parsed = parseInvoice(writeFixture("F-SIGNE", xml));
+  assert.strictEqual(parsed.totals.ttc, 240);
+}
+
+function testMissingDuePayableIsRejected() {
+  const xml = mutate(["        <ram:DuePayableAmount>240.00</ram:DuePayableAmount>\n", ""]);
+  assertHasError(parseExpectingErrors(writeFixture("F-SANS-BT115", xml)), "BT-115_MISSING");
+}
+
+function testMissingSellerNameIsRejected() {
+  const xml = mutate(["<ram:Name>VENDEUR SAS</ram:Name>", ""]);
+  assertHasError(parseExpectingErrors(writeFixture("F-SANS-VENDEUR", xml)), "BT-27_MISSING");
+}
+
+const TESTS = [
+  testRoundTripTva20,
+  testRoundTripFranchise,
+  testValidFixtureIsAccepted,
+  testDefaultNamespaceIsAccepted,
+  testPriceFallsBackToNothingWithoutNetPrice,
+  testXmlEntitiesAreDecodedOnce,
+  testProfileBasicWlIsRejected,
+  testImpossibleCalendarDateIsRejected,
+  testTruncatedDateIsRejected,
+  testMalformedDecimalIsRejected,
+  testTotalsMismatchIsRejected,
+  testLineSumMismatchIsRejected,
+  testVatAmountNotMatchingRateIsRejected,
+  testVatBasisNotCoveringTaxBasisTotalIsRejected,
+  testUnsupportedTypeCodeIsRejected,
+  testCorrectiveTypeCodeIsExposed,
+  testPrototypeTypeCodeIsRejected,
+  testSellerSirenIsNotLabelledSiret,
+  testMalformedSellerLegalIdIsRejected,
+  testStandardCategoryWithoutRateIsRejected,
+  testExemptCategoryWithVatIsRejected,
+  testSignedDecimalIsAccepted,
+  testMissingDuePayableIsRejected,
+  testMissingSellerNameIsRejected,
+];
 
 function main() {
   try {
-    testRoundTripTva20();
-    testRoundTripFranchise();
-    testUnitPriceIsNetNotGross();
+    TESTS.forEach((test) => {
+      test();
+      console.log(`  ok ${test.name}`);
+    });
   } finally {
     TMP_DIRS.forEach((dir) => fs.rmSync(dir, { recursive: true, force: true }));
   }
-  console.log("parse-einvoice tests passed.");
+  console.log(`\nparse-einvoice : ${TESTS.length} tests passed.`);
 }
 
 main();


### PR DESCRIPTION
## Ce que fait cette PR

### `scripts/parse-einvoice.js`

Complément de `generate-facturx.js` : lit un XML CII (Factur-X inclus) et retourne les données structurées en JSON.

Points d'attention à l'implémentation :
- ventilation TVA multi-taux (`tax_breakdown[]`) : les vraies factures ont souvent plusieurs taux et exemptions dans le même document
- SIRET lu dans `SpecifiedLegalOrganization` (ICD 0002), conformément à EN 16931
- aucune dépendance supplémentaire

```
node scripts/parse-einvoice.js --invoice factur-x.xml
node scripts/parse-einvoice.js --invoice factur-x.xml --json
```

### `comptable/references/facturation/plateformes-agreees.md`

- Ajout d'un tableau sur les trois formats EN 16931 (Factur-X, CII, UBL) avec leurs cas d'usage, et une note sur la distinction Annuaire PPF / réseau Peppol
- Nouvelle section pour les PDPs qui ciblent les éditeurs et OD (plutôt que les entreprises directement), avec une entrée Iopole issue de la liste DGFiP

Sources : FNFE-MPE · Peppol BIS Billing 3.0 · DGFiP
