### PR TITLE
Introduce provider abstraction contract

### DIFF
--- a/docs/adr/0001-provider-abstraction.md
+++ b/docs/adr/0001-provider-abstraction.md
@@ -16,7 +16,7 @@ Examples:
 - Qonto can be used for banking.
 - Stripe can be used for payments.
 - Pennylane can be used for accounting, invoicing or bank feeds depending on the setup.
-- Dougs could expose accounting, banking or insurance-related capabilities.
+- A fictional provider could expose accounting, banking or insurance-related capabilities.
 - A generic provider could expose a business capability while hiding whether it uses CSV, API, MCP, pasted data or another ingestion mechanism internally.
 
 ## Decision

--- a/docs/adr/0001-provider-abstraction.md
+++ b/docs/adr/0001-provider-abstraction.md
@@ -48,6 +48,9 @@ Ingestion details remain internal to each provider.
 CSV is not a business capability.
 API, CSV, MCP, manual export and pasted data are ingestion mechanisms.
 
+`payroll` is separate from `hr` because payroll has specific legal, accounting and reporting implications.
+`hr` is an umbrella capability for non-payroll HR workflows such as employee records, onboarding, reviews, recruiting or HR documents.
+
 ## V1 Runtime Boundary
 
 The first runtime implementation may stay transaction-first because Qonto and Stripe currently produce transaction-like records.

--- a/docs/adr/0001-provider-abstraction.md
+++ b/docs/adr/0001-provider-abstraction.md
@@ -72,6 +72,9 @@ Legacy compatibility must be defined by observable behavior:
 
 Internal module exports are secondary unless they are documented public APIs.
 
+Adding a new provider capability is backward-compatible.
+Removing, renaming or changing the meaning of an existing capability is breaking.
+
 ## Consequences
 
 Provider authors can add new integrations without changing the provider taxonomy.

--- a/docs/adr/0001-provider-abstraction.md
+++ b/docs/adr/0001-provider-abstraction.md
@@ -1,0 +1,88 @@
+# ADR 0001: Provider Abstraction Contract
+
+Date: 2026-05-23
+Status: Proposed
+
+## Context
+
+Paperasse currently has provider-specific integrations for Qonto and Stripe.
+Issue #18 proposes support for more accounting, banking and payment providers.
+
+The key design risk is forcing each provider into one fixed category such as `bank`, `payment`, `accounting` or `csv`.
+Real providers can cover several business domains depending on how a company uses them.
+
+Examples:
+
+- Qonto can be used for banking.
+- Stripe can be used for payments.
+- Pennylane can be used for accounting, invoicing or bank feeds depending on the setup.
+- Dougs could expose accounting, banking or insurance-related capabilities.
+- A generic provider could expose a business capability while hiding whether it uses CSV, API, MCP, pasted data or another ingestion mechanism internally.
+
+## Decision
+
+Model providers by identity plus business capabilities.
+
+```ts
+type ProviderCapability =
+  | 'banking'
+  | 'payments'
+  | 'invoicing'
+  | 'accounting'
+  | 'payroll'
+  | 'hr'
+  | 'insurance'
+
+type ProviderDescriptor = {
+  id: string
+  type: string
+  name: string
+  capabilities: ProviderCapability[]
+}
+```
+
+Provider identity is represented by `type` and `id`.
+Business capabilities are represented by `capabilities`.
+Ingestion details remain internal to each provider.
+
+CSV is not a business capability.
+API, CSV, MCP, manual export and pasted data are ingestion mechanisms.
+
+## V1 Runtime Boundary
+
+The first runtime implementation may stay transaction-first because Qonto and Stripe currently produce transaction-like records.
+
+Capabilities are declarative in V1.
+The initial runner should be provider-driven:
+
+```txt
+providers[] -> runner -> provider.fetch() -> normalized output
+```
+
+Capability-driven workflows can be added later when there are multiple normalized output families.
+
+## Compatibility
+
+Legacy compatibility must be defined by observable behavior:
+
+- existing commands keep working;
+- existing CLI options keep working;
+- existing output filenames keep working;
+- legacy config keeps working for legacy commands.
+
+Internal module exports are secondary unless they are documented public APIs.
+
+## Consequences
+
+Provider authors can add new integrations without changing the provider taxonomy.
+The same provider can declare several capabilities.
+The same capability can be implemented by many providers.
+Ingestion implementation details do not leak into the public contract.
+
+## Non-Goals for PR1
+
+- Do not migrate Qonto.
+- Do not migrate Stripe.
+- Do not add a provider runner.
+- Do not add a CSV provider.
+- Do not change existing fetch commands.

--- a/integrations/core/README.md
+++ b/integrations/core/README.md
@@ -12,6 +12,9 @@ This module does not fetch data and does not change the existing Qonto or Stripe
 
 CSV, API, MCP and manual exports are ingestion mechanisms, not capabilities.
 
+`payroll` is separate from `hr` because payroll has specific legal, accounting and reporting implications.
+`hr` is an umbrella capability for non-payroll HR workflows such as employee records, onboarding, reviews, recruiting or HR documents.
+
 ## Capability Compatibility
 
 Adding a new capability is backward-compatible because existing providers keep declaring the capabilities they already support.

--- a/integrations/core/README.md
+++ b/integrations/core/README.md
@@ -12,6 +12,12 @@ This module does not fetch data and does not change the existing Qonto or Stripe
 
 CSV, API, MCP and manual exports are ingestion mechanisms, not capabilities.
 
+## Capability Compatibility
+
+Adding a new capability is backward-compatible because existing providers keep declaring the capabilities they already support.
+
+Removing, renaming or changing the meaning of an existing capability is breaking.
+
 ## Validate a Provider
 
 ```js

--- a/integrations/core/README.md
+++ b/integrations/core/README.md
@@ -1,0 +1,38 @@
+# Provider Core
+
+Provider core contains the shared provider contract utilities for Paperasse.
+
+This module does not fetch data and does not change the existing Qonto or Stripe integrations.
+
+## Concepts
+
+- Provider identity: `id`, `type`, `name`
+- Business capabilities: `banking`, `payments`, `invoicing`, `accounting`, `payroll`, `hr`, `insurance`
+- Ingestion details: internal to each provider
+
+CSV, API, MCP and manual exports are ingestion mechanisms, not capabilities.
+
+## Validate a Provider
+
+```js
+const {
+  assertProviderDescriptor,
+  runProviderContractChecks,
+} = require('../core');
+
+const provider = require('../providers/template/provider');
+
+assertProviderDescriptor(provider);
+
+runProviderContractChecks(provider).then((summary) => {
+  console.log(summary);
+});
+```
+
+## Add a Provider
+
+1. Copy `integrations/providers/template`.
+2. Change `id`, `type`, `name` and `capabilities`.
+3. Implement provider-specific fetching.
+4. Return normalized transactions when implementing transaction output.
+5. Test with `runProviderContractChecks`.

--- a/integrations/core/capabilities.js
+++ b/integrations/core/capabilities.js
@@ -1,0 +1,20 @@
+const PROVIDER_CAPABILITIES = Object.freeze([
+  'banking',
+  'payments',
+  'invoicing',
+  'accounting',
+  'payroll',
+  'hr',
+  'insurance',
+]);
+
+const PROVIDER_CAPABILITY_SET = new Set(PROVIDER_CAPABILITIES);
+
+function isProviderCapability(value) {
+  return PROVIDER_CAPABILITY_SET.has(value);
+}
+
+module.exports = {
+  PROVIDER_CAPABILITIES,
+  isProviderCapability,
+};

--- a/integrations/core/index.js
+++ b/integrations/core/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  ...require('./capabilities'),
+  ...require('./provider-contract'),
+  ...require('./provider-validator'),
+  ...require('./provider-test-kit'),
+};

--- a/integrations/core/provider-contract.js
+++ b/integrations/core/provider-contract.js
@@ -7,7 +7,7 @@ const PROVIDER_CONTRACT_VERSION = '1.0.0';
 /**
  * @typedef {Object} ProviderDescriptor
  * @property {string} id Stable configured provider instance id.
- * @property {string} type Provider implementation type, such as qonto, stripe, dougs or generic.
+ * @property {string} type Provider implementation type, such as qonto, stripe, fictional-suite or generic.
  * @property {string} name Human-readable provider name.
  * @property {ProviderCapability[]} capabilities Business capabilities exposed by the provider.
  */

--- a/integrations/core/provider-contract.js
+++ b/integrations/core/provider-contract.js
@@ -1,0 +1,32 @@
+const PROVIDER_CONTRACT_VERSION = '1.0.0';
+
+/**
+ * @typedef {'banking'|'payments'|'invoicing'|'accounting'|'payroll'|'hr'|'insurance'} ProviderCapability
+ */
+
+/**
+ * @typedef {Object} ProviderDescriptor
+ * @property {string} id Stable configured provider instance id.
+ * @property {string} type Provider implementation type, such as qonto, stripe, dougs or generic.
+ * @property {string} name Human-readable provider name.
+ * @property {ProviderCapability[]} capabilities Business capabilities exposed by the provider.
+ */
+
+/**
+ * @typedef {Object} NormalizedTransaction
+ * @property {string} id Stable transaction id from the provider or deterministic import id.
+ * @property {string} source Provider source label.
+ * @property {string} date ISO date string.
+ * @property {number} amount Signed amount in transaction currency.
+ * @property {string} currency ISO currency code.
+ * @property {string} label Human-readable transaction label.
+ * @property {string=} reference Optional provider reference.
+ * @property {string=} counterparty Optional counterparty label.
+ * @property {string=} category Optional provider category.
+ * @property {string|null=} our_category Optional Paperasse category.
+ * @property {unknown} raw Raw provider payload or raw import row.
+ */
+
+module.exports = {
+  PROVIDER_CONTRACT_VERSION,
+};

--- a/integrations/core/provider-test-kit.js
+++ b/integrations/core/provider-test-kit.js
@@ -1,0 +1,52 @@
+const {
+  validateProviderDescriptor,
+  validateNormalizedTransaction,
+} = require('./provider-validator');
+
+function assertProviderDescriptor(provider) {
+  const result = validateProviderDescriptor(provider);
+  if (!result.valid) {
+    throw new Error(`provider contract failed: ${result.errors.join('; ')}`);
+  }
+  return provider;
+}
+
+function assertNormalizedTransactions(transactions) {
+  if (!Array.isArray(transactions)) {
+    throw new Error('transaction contract failed: expected an array of transactions');
+  }
+
+  transactions.forEach((transaction, index) => {
+    const result = validateNormalizedTransaction(transaction);
+    if (!result.valid) {
+      throw new Error(`transaction contract failed at index ${index}: ${result.errors.join('; ')}`);
+    }
+  });
+
+  return transactions;
+}
+
+async function runProviderContractChecks(provider, options = {}) {
+  assertProviderDescriptor(provider);
+
+  const transactionsMethod = options.transactionsMethod || 'fetchTransactions';
+  let transactions = [];
+
+  if (typeof provider[transactionsMethod] === 'function') {
+    transactions = await provider[transactionsMethod](options.fetchOptions || {});
+    assertNormalizedTransactions(transactions);
+  }
+
+  return {
+    provider_id: provider.id,
+    provider_type: provider.type,
+    capabilities: provider.capabilities.slice(),
+    transaction_count: transactions.length,
+  };
+}
+
+module.exports = {
+  assertProviderDescriptor,
+  assertNormalizedTransactions,
+  runProviderContractChecks,
+};

--- a/integrations/core/provider-validator.js
+++ b/integrations/core/provider-validator.js
@@ -6,8 +6,9 @@ function isNonEmptyString(value) {
 
 function isIsoDateString(value) {
   if (!isNonEmptyString(value)) return false;
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) return false;
   const timestamp = Date.parse(value);
-  return Number.isFinite(timestamp);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
 }
 
 function validateProviderDescriptor(provider) {
@@ -37,7 +38,14 @@ function validateProviderDescriptor(provider) {
   } else if (provider.capabilities.length === 0) {
     errors.push('provider.capabilities must contain at least one capability');
   } else {
+    const seenCapabilities = new Set();
     for (const capability of provider.capabilities) {
+      if (seenCapabilities.has(capability)) {
+        errors.push(`provider.capabilities contains duplicate capability: ${String(capability)}`);
+        continue;
+      }
+      seenCapabilities.add(capability);
+
       if (!isProviderCapability(capability)) {
         errors.push(`provider.capabilities contains unsupported capability: ${String(capability)}`);
       }
@@ -69,7 +77,7 @@ function validateNormalizedTransaction(transaction) {
   }
 
   if (!isIsoDateString(transaction.date)) {
-    errors.push('transaction.date must be a non-empty ISO date string');
+    errors.push('transaction.date must be a UTC ISO date string with milliseconds');
   }
 
   if (typeof transaction.amount !== 'number' || !Number.isFinite(transaction.amount)) {

--- a/integrations/core/provider-validator.js
+++ b/integrations/core/provider-validator.js
@@ -4,6 +4,12 @@ function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+function isIsoDateString(value) {
+  if (!isNonEmptyString(value)) return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp);
+}
+
 function validateProviderDescriptor(provider) {
   const errors = [];
 
@@ -44,6 +50,51 @@ function validateProviderDescriptor(provider) {
   };
 }
 
+function validateNormalizedTransaction(transaction) {
+  const errors = [];
+
+  if (!transaction || typeof transaction !== 'object' || Array.isArray(transaction)) {
+    return {
+      valid: false,
+      errors: ['transaction must be an object'],
+    };
+  }
+
+  if (!isNonEmptyString(transaction.id)) {
+    errors.push('transaction.id must be a non-empty string');
+  }
+
+  if (!isNonEmptyString(transaction.source)) {
+    errors.push('transaction.source must be a non-empty string');
+  }
+
+  if (!isIsoDateString(transaction.date)) {
+    errors.push('transaction.date must be a non-empty ISO date string');
+  }
+
+  if (typeof transaction.amount !== 'number' || !Number.isFinite(transaction.amount)) {
+    errors.push('transaction.amount must be a finite number');
+  }
+
+  if (!isNonEmptyString(transaction.currency)) {
+    errors.push('transaction.currency must be a non-empty string');
+  }
+
+  if (!isNonEmptyString(transaction.label)) {
+    errors.push('transaction.label must be a non-empty string');
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(transaction, 'raw')) {
+    errors.push('transaction.raw must be present');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
 module.exports = {
   validateProviderDescriptor,
+  validateNormalizedTransaction,
 };

--- a/integrations/core/provider-validator.js
+++ b/integrations/core/provider-validator.js
@@ -1,0 +1,49 @@
+const { isProviderCapability } = require('./capabilities');
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function validateProviderDescriptor(provider) {
+  const errors = [];
+
+  if (!provider || typeof provider !== 'object' || Array.isArray(provider)) {
+    return {
+      valid: false,
+      errors: ['provider must be an object'],
+    };
+  }
+
+  if (!isNonEmptyString(provider.id)) {
+    errors.push('provider.id must be a non-empty string');
+  }
+
+  if (!isNonEmptyString(provider.type)) {
+    errors.push('provider.type must be a non-empty string');
+  }
+
+  if (!isNonEmptyString(provider.name)) {
+    errors.push('provider.name must be a non-empty string');
+  }
+
+  if (!Array.isArray(provider.capabilities)) {
+    errors.push('provider.capabilities must be an array');
+  } else if (provider.capabilities.length === 0) {
+    errors.push('provider.capabilities must contain at least one capability');
+  } else {
+    for (const capability of provider.capabilities) {
+      if (!isProviderCapability(capability)) {
+        errors.push(`provider.capabilities contains unsupported capability: ${String(capability)}`);
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+module.exports = {
+  validateProviderDescriptor,
+};

--- a/integrations/providers/template/README.md
+++ b/integrations/providers/template/README.md
@@ -1,0 +1,24 @@
+# Template Provider
+
+This directory is a contract example for new provider implementations.
+
+It is not used by the Paperasse runtime.
+
+## Descriptor
+
+```js
+{
+  id: 'template-provider',
+  type: 'template',
+  name: 'Template Provider',
+  capabilities: ['banking']
+}
+```
+
+## Usage
+
+Copy this directory when starting a new provider.
+Replace the provider identity and capabilities with the new integration identity.
+
+Do not model ingestion details as capabilities.
+For example, do not add `csv_import`, `api` or `mcp` to `capabilities`.

--- a/integrations/providers/template/provider.js
+++ b/integrations/providers/template/provider.js
@@ -1,0 +1,11 @@
+async function fetchTransactions() {
+  throw new Error('template provider does not fetch data; copy this provider and implement provider-specific fetching');
+}
+
+module.exports = {
+  id: 'template-provider',
+  type: 'template',
+  name: 'Template Provider',
+  capabilities: ['banking'],
+  fetchTransactions,
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "calc": "node scripts/calc.js",
     "test:calc": "node scripts/test-deterministic-calculations.js",
+    "test:providers": "node --test tests/integrations/core/*.test.js",
     "fec": "node scripts/generate-fec.js",
     "statements": "node scripts/generate-statements.js",
     "pdfs": "node scripts/generate-pdfs.js",

--- a/tests/integrations/core/provider-test-kit.test.js
+++ b/tests/integrations/core/provider-test-kit.test.js
@@ -1,0 +1,97 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  assertProviderDescriptor,
+  assertNormalizedTransactions,
+  runProviderContractChecks,
+} = require('../../../integrations/core/provider-test-kit');
+
+test('assertProviderDescriptor returns the provider when valid', () => {
+  const provider = {
+    id: 'generic-bank-import',
+    type: 'generic',
+    name: 'Generic Bank Import',
+    capabilities: ['banking'],
+  };
+
+  assert.equal(assertProviderDescriptor(provider), provider);
+});
+
+test('assertProviderDescriptor throws when invalid', () => {
+  assert.throws(
+    () => assertProviderDescriptor({
+      id: 'bad-provider',
+      type: 'generic',
+      name: 'Bad Provider',
+      capabilities: ['csv_import'],
+    }),
+    /provider contract failed: provider.capabilities contains unsupported capability: csv_import/
+  );
+});
+
+test('assertNormalizedTransactions accepts valid transactions', () => {
+  const transactions = [
+    {
+      id: 'tx-1',
+      source: 'generic',
+      date: '2026-05-23T10:30:00.000Z',
+      amount: 100,
+      currency: 'EUR',
+      label: 'Client payment',
+      raw: {},
+    },
+  ];
+
+  assert.equal(assertNormalizedTransactions(transactions), transactions);
+});
+
+test('assertNormalizedTransactions throws with item index', () => {
+  assert.throws(
+    () => assertNormalizedTransactions([
+      {
+        id: '',
+        source: 'generic',
+        date: '2026-05-23T10:30:00.000Z',
+        amount: 100,
+        currency: 'EUR',
+        label: 'Client payment',
+        raw: {},
+      },
+    ]),
+    /transaction contract failed at index 0: transaction.id must be a non-empty string/
+  );
+});
+
+test('runProviderContractChecks validates provider and transaction output', async () => {
+  const provider = {
+    id: 'generic-bank-import',
+    type: 'generic',
+    name: 'Generic Bank Import',
+    capabilities: ['banking'],
+    async fetchTransactions() {
+      return [
+        {
+          id: 'tx-1',
+          source: 'generic',
+          date: '2026-05-23T10:30:00.000Z',
+          amount: 100,
+          currency: 'EUR',
+          label: 'Client payment',
+          raw: {},
+        },
+      ];
+    },
+  };
+
+  const result = await runProviderContractChecks(provider, {
+    transactionsMethod: 'fetchTransactions',
+  });
+
+  assert.deepEqual(result, {
+    provider_id: 'generic-bank-import',
+    provider_type: 'generic',
+    capabilities: ['banking'],
+    transaction_count: 1,
+  });
+});

--- a/tests/integrations/core/provider-validator.test.js
+++ b/tests/integrations/core/provider-validator.test.js
@@ -7,6 +7,7 @@ const {
 } = require('../../../integrations/core/capabilities');
 const {
   validateProviderDescriptor,
+  validateNormalizedTransaction,
 } = require('../../../integrations/core/provider-validator');
 
 test('PROVIDER_CAPABILITIES contains the supported business capabilities', () => {
@@ -89,5 +90,65 @@ test('validateProviderDescriptor rejects unknown capabilities', () => {
   assert.deepEqual(result.errors, [
     'provider.capabilities contains unsupported capability: csv_import',
     'provider.capabilities contains unsupported capability: api',
+  ]);
+});
+
+test('validateNormalizedTransaction accepts a valid transaction', () => {
+  const result = validateNormalizedTransaction({
+    id: 'tx-1',
+    source: 'qonto',
+    date: '2026-05-23T10:30:00.000Z',
+    amount: -42.5,
+    currency: 'EUR',
+    label: 'Software subscription',
+    our_category: null,
+    raw: {
+      provider_id: 'raw-tx-1',
+    },
+  });
+
+  assert.deepEqual(result, {
+    valid: true,
+    errors: [],
+  });
+});
+
+test('validateNormalizedTransaction rejects missing required fields', () => {
+  const result = validateNormalizedTransaction({
+    id: '',
+    source: '',
+    date: '',
+    amount: '42.5',
+    currency: '',
+    label: '',
+  });
+
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.errors, [
+    'transaction.id must be a non-empty string',
+    'transaction.source must be a non-empty string',
+    'transaction.date must be a non-empty ISO date string',
+    'transaction.amount must be a finite number',
+    'transaction.currency must be a non-empty string',
+    'transaction.label must be a non-empty string',
+    'transaction.raw must be present',
+  ]);
+});
+
+test('validateNormalizedTransaction rejects invalid dates and amounts', () => {
+  const result = validateNormalizedTransaction({
+    id: 'tx-2',
+    source: 'stripe',
+    date: 'not-a-date',
+    amount: Number.NaN,
+    currency: 'EUR',
+    label: 'Bad transaction',
+    raw: {},
+  });
+
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.errors, [
+    'transaction.date must be a non-empty ISO date string',
+    'transaction.amount must be a finite number',
   ]);
 });

--- a/tests/integrations/core/provider-validator.test.js
+++ b/tests/integrations/core/provider-validator.test.js
@@ -5,6 +5,9 @@ const {
   PROVIDER_CAPABILITIES,
   isProviderCapability,
 } = require('../../../integrations/core/capabilities');
+const {
+  validateProviderDescriptor,
+} = require('../../../integrations/core/provider-validator');
 
 test('PROVIDER_CAPABILITIES contains the supported business capabilities', () => {
   assert.deepEqual(PROVIDER_CAPABILITIES, [
@@ -28,4 +31,63 @@ test('isProviderCapability rejects ingestion mechanisms', () => {
   assert.equal(isProviderCapability('csv_import'), false);
   assert.equal(isProviderCapability('api'), false);
   assert.equal(isProviderCapability('mcp'), false);
+});
+
+test('validateProviderDescriptor accepts a valid provider descriptor', () => {
+  const result = validateProviderDescriptor({
+    id: 'qonto-main',
+    type: 'qonto',
+    name: 'Qonto',
+    capabilities: ['banking'],
+  });
+
+  assert.deepEqual(result, {
+    valid: true,
+    errors: [],
+  });
+});
+
+test('validateProviderDescriptor rejects missing identity fields', () => {
+  const result = validateProviderDescriptor({
+    id: '',
+    type: '',
+    name: '',
+    capabilities: ['banking'],
+  });
+
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.errors, [
+    'provider.id must be a non-empty string',
+    'provider.type must be a non-empty string',
+    'provider.name must be a non-empty string',
+  ]);
+});
+
+test('validateProviderDescriptor rejects empty capabilities', () => {
+  const result = validateProviderDescriptor({
+    id: 'empty-provider',
+    type: 'generic',
+    name: 'Empty Provider',
+    capabilities: [],
+  });
+
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.errors, [
+    'provider.capabilities must contain at least one capability',
+  ]);
+});
+
+test('validateProviderDescriptor rejects unknown capabilities', () => {
+  const result = validateProviderDescriptor({
+    id: 'bad-provider',
+    type: 'generic',
+    name: 'Bad Provider',
+    capabilities: ['banking', 'csv_import', 'api'],
+  });
+
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.errors, [
+    'provider.capabilities contains unsupported capability: csv_import',
+    'provider.capabilities contains unsupported capability: api',
+  ]);
 });

--- a/tests/integrations/core/provider-validator.test.js
+++ b/tests/integrations/core/provider-validator.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  PROVIDER_CAPABILITIES,
+  isProviderCapability,
+} = require('../../../integrations/core/capabilities');
+
+test('PROVIDER_CAPABILITIES contains the supported business capabilities', () => {
+  assert.deepEqual(PROVIDER_CAPABILITIES, [
+    'banking',
+    'payments',
+    'invoicing',
+    'accounting',
+    'payroll',
+    'hr',
+    'insurance',
+  ]);
+});
+
+test('isProviderCapability accepts known capabilities', () => {
+  assert.equal(isProviderCapability('banking'), true);
+  assert.equal(isProviderCapability('payments'), true);
+  assert.equal(isProviderCapability('accounting'), true);
+});
+
+test('isProviderCapability rejects ingestion mechanisms', () => {
+  assert.equal(isProviderCapability('csv_import'), false);
+  assert.equal(isProviderCapability('api'), false);
+  assert.equal(isProviderCapability('mcp'), false);
+});

--- a/tests/integrations/core/provider-validator.test.js
+++ b/tests/integrations/core/provider-validator.test.js
@@ -93,6 +93,20 @@ test('validateProviderDescriptor rejects unknown capabilities', () => {
   ]);
 });
 
+test('validateProviderDescriptor rejects duplicate capabilities', () => {
+  const result = validateProviderDescriptor({
+    id: 'duplicate-provider',
+    type: 'generic',
+    name: 'Duplicate Provider',
+    capabilities: ['banking', 'banking'],
+  });
+
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.errors, [
+    'provider.capabilities contains duplicate capability: banking',
+  ]);
+});
+
 test('validateNormalizedTransaction accepts a valid transaction', () => {
   const result = validateNormalizedTransaction({
     id: 'tx-1',
@@ -127,7 +141,7 @@ test('validateNormalizedTransaction rejects missing required fields', () => {
   assert.deepEqual(result.errors, [
     'transaction.id must be a non-empty string',
     'transaction.source must be a non-empty string',
-    'transaction.date must be a non-empty ISO date string',
+    'transaction.date must be a UTC ISO date string with milliseconds',
     'transaction.amount must be a finite number',
     'transaction.currency must be a non-empty string',
     'transaction.label must be a non-empty string',
@@ -148,8 +162,25 @@ test('validateNormalizedTransaction rejects invalid dates and amounts', () => {
 
   assert.equal(result.valid, false);
   assert.deepEqual(result.errors, [
-    'transaction.date must be a non-empty ISO date string',
+    'transaction.date must be a UTC ISO date string with milliseconds',
     'transaction.amount must be a finite number',
+  ]);
+});
+
+test('validateNormalizedTransaction rejects non-UTC ISO date formats', () => {
+  const result = validateNormalizedTransaction({
+    id: 'tx-3',
+    source: 'qonto',
+    date: '2026-05-23',
+    amount: 42.5,
+    currency: 'EUR',
+    label: 'Ambiguous date',
+    raw: {},
+  });
+
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.errors, [
+    'transaction.date must be a UTC ISO date string with milliseconds',
   ]);
 });
 

--- a/tests/integrations/core/provider-validator.test.js
+++ b/tests/integrations/core/provider-validator.test.js
@@ -152,3 +152,16 @@ test('validateNormalizedTransaction rejects invalid dates and amounts', () => {
     'transaction.amount must be a finite number',
   ]);
 });
+
+test('core index exports contract utilities', () => {
+  const core = require('../../../integrations/core');
+
+  assert.equal(Array.isArray(core.PROVIDER_CAPABILITIES), true);
+  assert.equal(typeof core.isProviderCapability, 'function');
+  assert.equal(typeof core.validateProviderDescriptor, 'function');
+  assert.equal(typeof core.validateNormalizedTransaction, 'function');
+  assert.equal(typeof core.assertProviderDescriptor, 'function');
+  assert.equal(typeof core.assertNormalizedTransactions, 'function');
+  assert.equal(typeof core.runProviderContractChecks, 'function');
+  assert.equal(core.PROVIDER_CONTRACT_VERSION, '1.0.0');
+});

--- a/tests/integrations/core/template-provider.test.js
+++ b/tests/integrations/core/template-provider.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  assertProviderDescriptor,
+} = require('../../../integrations/core/provider-test-kit');
+const templateProvider = require('../../../integrations/providers/template/provider');
+
+test('template provider exposes a valid descriptor', () => {
+  assert.equal(assertProviderDescriptor(templateProvider), templateProvider);
+});
+
+test('template provider marks fetchTransactions as intentionally unavailable', async () => {
+  await assert.rejects(
+    () => templateProvider.fetchTransactions(),
+    /template provider does not fetch data/
+  );
+});


### PR DESCRIPTION
## Summary

Introduces a contract-first provider abstraction for Paperasse without changing existing Qonto or Stripe runtime behavior.

This PR adds:

- an ADR for provider identity and business capabilities;
- provider capability constants;
- provider descriptor validation;
- normalized transaction validation;
- provider contract test-kit helpers;
- a template provider for future integrations;
- provider contract tests using Node's built-in test runner.

## Scope

This is a contract-first PR.

It does not:

- migrate Qonto;
- migrate Stripe;
- add a generic runner;
- add a CSV provider;
- change existing fetch commands.

## Design Notes

Provider capabilities are business-level declarations:

- `banking`
- `payments`
- `invoicing`
- `accounting`
- `payroll`
- `hr`
- `insurance`

Ingestion mechanisms such as CSV, API, MCP and manual exports stay internal to providers.

## Tests

- `npm run test:providers`
- `npm run test:calc`