### PR TITLE
fix(fiscaliste): l'ARE bénéficie de l'abattement de 10 % (doc + calc_ir.py)

### DIFF
--- a/fiscaliste/SKILL.md
+++ b/fiscaliste/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: fiscaliste
 metadata:
-  last_updated: 2026-04-19
+  last_updated: 2026-05-30
 includes:
   - data/**
   - references/**
@@ -88,7 +88,7 @@ Dernière MAJ: [date] — Vérifier les barèmes de la dernière loi de finances
 |--------|-----------|------------|
 | Salaires | 1AJ/1BJ | 10 % (min 509 €, max 14 555 €) ou frais réels |
 | Pensions / retraites | 1AS/1BS | 10 % (min 450 €, max 4 446 €) par foyer |
-| **Chômage (ARE)** | 1AP/1BP | **Aucun** (piège classique : ne jamais mettre en 1AJ) |
+| **Chômage (ARE)** | 1AP/1BP | **10 %** — l'ARE est un revenu de remplacement imposé selon les règles des traitements et salaires (BOI-RSA-BASE-30-50-20) ; l'abattement de 10 % s'applique sur le total salaires + ARE. Se déclare en 1AP/1BP (pas en 1AJ), mais bénéficie bien de l'abattement. |
 | Dividendes (option barème) | 2DC | 40 % |
 | Dividendes (PFU) | 2DC | Aucun |
 | Micro-BNC | 5TE | 34 % (plafond 77 700 €) |

--- a/fiscaliste/data/bareme-ir-2025.json
+++ b/fiscaliste/data/bareme-ir-2025.json
@@ -41,7 +41,7 @@
     "taux": 0.10,
     "minimum": 509,
     "maximum": 14555,
-    "description": "Abattement forfaitaire automatique sur traitements et salaires (case 1AJ). ATTENTION terminologie : 1AJ = salaire net imposable du bulletin, AVANT cet abattement. Le RNI = 1AJ × 0.9 (dans la plage standard)."
+    "description": "Abattement forfaitaire automatique sur traitements et salaires (case 1AJ) ET sur les allocations chômage / ARE (case 1AP), qui sont des revenus de remplacement imposés selon les règles des traitements et salaires (BOI-RSA-BASE-30-50-20). Plancher/plafond communs au total salaires + ARE par membre du foyer. ATTENTION terminologie : 1AJ = salaire net imposable du bulletin, AVANT cet abattement. Le RNI = 1AJ × 0.9 (dans la plage standard)."
   },
 
   "abattement_pensions_10pct": {

--- a/fiscaliste/evals/evals.json
+++ b/fiscaliste/evals/evals.json
@@ -273,6 +273,21 @@
         "Le skill conclut correctement sur le respect du plafond (5 750 € < 10 000 €)",
         "Le skill rappelle que l'excédent au-delà du plafond serait perdu (non reportable)"
       ]
+    },
+    {
+      "id": 20,
+      "name": "are-abattement-10pct",
+      "prompt": "Je suis au chômage, j'ai touché 18 000 € d'allocations chômage (ARE) cette année, sans autre revenu. Est-ce que l'ARE a droit à l'abattement de 10 % comme les salaires, et dans quelle case je la déclare ?",
+      "expected_output": "L'ARE est un revenu de remplacement imposé selon les règles des traitements et salaires : elle bénéficie de la déduction forfaitaire de 10 % comme les salaires (BOI-RSA-BASE-30-50-20). RNI = 18 000 × 0,9 = 16 200 €. À déclarer en case 1AP/1BP (pas 1AJ) : la case distingue revenu de remplacement / d'activité, mais ne supprime pas l'abattement. À ce niveau de revenu, impôt nul après décote.",
+      "files": [],
+      "assertions": [
+        "Le skill confirme que l'ARE bénéficie de l'abattement forfaitaire de 10 % (revenu de remplacement imposé selon les règles des traitements et salaires)",
+        "Le skill NE dit PAS que l'ARE est exclue de l'abattement 10 %",
+        "Le RNI est calculé avec l'abattement (18 000 × 0,9 = 16 200 €)",
+        "Le skill indique la case 1AP/1BP (et non 1AJ) pour déclarer l'ARE",
+        "Le skill précise que la distinction 1AP vs 1AJ porte sur la nature du revenu (remplacement vs activité), pas sur l'abattement",
+        "L'abattement suit le régime des salaires (plancher commun 509 € / plafond commun 14 555 € sur le total salaires + ARE)"
+      ]
     }
   ]
 }

--- a/fiscaliste/foyer.example.json
+++ b/fiscaliste/foyer.example.json
@@ -44,7 +44,7 @@
 
     "crypto_plus_values": 0,
     "revenus_chomage": 0,
-    "_commentaire_chomage": "Case 1AP — PAS D'ABATTEMENT 10% (différent de 1AJ)"
+    "_commentaire_chomage": "Case 1AP (pas 1AJ) — saisir le NET IMPOSABLE; l'abattement 10% s'applique comme pour les salaires (BOI-RSA-BASE-30-50-20)"
   },
 
   "deductions": {

--- a/fiscaliste/references/cas-speciaux.md
+++ b/fiscaliste/references/cas-speciaux.md
@@ -196,14 +196,14 @@ Régimes spéciaux :
 
 ## Allocations chômage et revenus de remplacement
 
-Déclarées case **1AP / 1BP** (pas 1AJ).
+Déclarées case **1AP / 1BP** (pas 1AJ). Bien vérifier le pré-rempli France Travail.
 
 **Points critiques** :
-- **Pas d'abattement 10%** (contrairement aux salaires)
+- **Abattement 10 % applicable** : l'ARE est un revenu de remplacement imposé selon les règles des traitements et salaires (BOI-RSA-BASE-30-50-20). La déduction forfaitaire de 10 % s'applique sur le total salaires + ARE (plafond commun 14 555 €/membre). La déclarer en 1AP au lieu de 1AJ ne supprime PAS l'abattement.
 - CSG prélevée à taux réduit à la source
 - La fraction de CSG prélevée à taux réduit n'est pas déductible du revenu imposable
 
-**Erreur classique** : déclarer l'ARE en case 1AJ → bénéficie à tort de l'abattement 10% → redressement probable.
+**Pourquoi 1AP et pas 1AJ ?** L'ARE n'est pas un revenu d'*activité* mais de *remplacement* : la distinction compte pour les calculs fondés sur les seuls revenus d'activité (plafond de déduction PER, certaines prestations sociales), pas pour l'abattement de 10 %.
 
 ## Situations matrimoniales particulières
 

--- a/fiscaliste/references/declaration-workflow.md
+++ b/fiscaliste/references/declaration-workflow.md
@@ -41,7 +41,7 @@ Phase 4 : Vérification et suivi
 | Source | Document | Usage |
 |--------|----------|-------|
 | Employeur | Bulletin de décembre + attestation fiscale | Salaires imposables (1AJ), gain RSU (1TT) |
-| Pôle emploi | Attestation fiscale annuelle | ARE (1AP) — attention pas 1AJ |
+| France Travail (ex-Pôle emploi) | Attestation fiscale annuelle | ARE (1AP, pas 1AJ — abattement 10 % applicable malgré tout) |
 | Banque / courtier | IFU (Imprimé Fiscal Unique) | Intérêts, dividendes, PV mobilières |
 | Assurance-vie | Relevé annuel | Rachats, produits imposables |
 | Notaire | Acte de vente + formulaire 2048-IMM | PV immobilière |
@@ -97,7 +97,7 @@ Voir [foyer.example.json](../foyer.example.json) pour la structure. Champs criti
 | Patrimoine immobilier net > 1,3 M€ | — | **2042-IFI** |
 | Dons, emploi à domicile, garde d'enfant | — | **2042-RICI** |
 
-**Piège** : déclarer l'ARE en 1AJ bénéficie à tort de l'abattement 10 % → redressement probable.
+**Précision** : l'ARE se déclare en 1AP/1BP (revenu de remplacement), pas en 1AJ. Elle bénéficie **quand même** de l'abattement de 10 % comme les salaires (BOI-RSA-BASE-30-50-20) — la case ne change pas l'abattement. L'enjeu de la bonne case : l'ARE n'est pas un revenu d'activité (compte pour le plafond PER, prestations sociales, etc.).
 
 ---
 
@@ -234,7 +234,7 @@ Au **réel**, l'amortissement du bien (hors terrain, sur ~25-30 ans) rend souven
 - [ ] Plafonnement QF appliqué (si enfants) — gain réel ≤ N × 1 807 €
 - [ ] Décote testée (si impôt brut faible)
 - [ ] Abattement 10 % salaires appliqué (vérifier plancher 509 € / plafond 14 555 €)
-- [ ] Aucune confusion 1AJ / 1AP (salaires vs chômage)
+- [ ] ARE bien en 1AP (pas 1AJ) — l'abattement 10 % s'applique dans les deux cas ; la case sert à distinguer revenu d'activité / remplacement
 - [ ] Option PFU / barème choisie explicitement (case 2OP)
 - [ ] PER déduit dans la limite du plafond disponible
 - [ ] Réductions d'impôt ≤ plafond global 10 000 €
@@ -277,7 +277,7 @@ Au **réel**, l'amortissement du bien (hors terrain, sur ~25-30 ans) rend souven
 
 1. **Oublier un compte étranger** — obligation de déclarer l'ouverture (formulaire 3916) sous peine d'amende 1 500 € par compte.
 2. **Ne pas cocher 2OP** alors que le barème serait favorable au TMI 11 %.
-3. **ARE en 1AJ** — bénéficie à tort de l'abattement 10 %.
+3. **ARE en 1AJ au lieu de 1AP** — l'abattement 10 % s'applique dans les deux cas, mais la mauvaise case fausse la distinction revenu d'activité / remplacement (plafond PER, prestations).
 4. **Oublier le quotient** pour un vesting RSU massif.
 5. **Sous-déclarer les cessions crypto** > 305 € — imposition totale sur TOUT.
 6. **Déduire un PER > plafond** — fraction non déductible.

--- a/fiscaliste/references/ir-mecanisme.md
+++ b/fiscaliste/references/ir-mecanisme.md
@@ -55,13 +55,13 @@ La confusion la plus fréquente concerne le "salaire net imposable".
 |--------|-----------|-----------|--------|
 | Salaires | 1AJ/1BJ | 10% (min 509 €, max 14 555 €) ou frais réels | data/bareme-ir-2025.json |
 | Pensions / retraites | 1AS/1BS | 10% (min 450 €, max 4 446 €) par foyer | data/bareme-ir-2025.json |
-| Allocations chômage (ARE) | 1AP/1BP | **Aucun abattement** | — |
+| Allocations chômage (ARE) | 1AP/1BP | **10 %** (revenu de remplacement imposé selon les règles des T&S, BOI-RSA-BASE-30-50-20 ; l'abattement porte sur le total salaires + ARE, plafond commun 14 555 €) | — |
 | Dividendes (option barème) | 2DC | 40% | data/pfu-prelevements-sociaux.json |
 | Dividendes (PFU) | 2DC | Aucun abattement | — |
 | BNC régime normal | 5QC | Aucun abattement | — |
 | Micro-BNC | 5TE | 34% (plafond 77 700 €) | — |
 
-**Piège classique** : confondre 1AJ (salaires) et 1AP (chômage). L'abattement 10% s'applique uniquement sur 1AJ.
+**Précision** : l'ARE se déclare en 1AP/1BP (revenu de remplacement), **pas** dans les salaires 1AJ — mais elle bénéficie quand même de l'abattement de 10 % comme les salaires (BOI-RSA-BASE-30-50-20). La distinction de case n'enlève donc PAS l'abattement ; elle compte pour les calculs qui distinguent revenus d'activité et de remplacement (l'ARE n'est pas un revenu d'activité, ex. plafond PER).
 
 ## Application du barème progressif
 

--- a/fiscaliste/references/prelevement-a-la-source.md
+++ b/fiscaliste/references/prelevement-a-la-source.md
@@ -42,9 +42,11 @@ Possible si :
 - **Hausse de revenus** : modulation à la hausse autorisée sans seuil minimum.
 - **Changement de situation familiale** : mariage, PACS, naissance, divorce, décès → à signaler dans les **60 jours** (art. 204 I CGI).
 
-Procédure : espace impots.gouv.fr → "Gérer mon prélèvement à la source".
+Procédure : espace impots.gouv.fr → "Gérer mon prélèvement à la source" → "Actualiser suite à une hausse ou une baisse de vos revenus". On saisit une **estimation de tous les revenus du foyer pour l'année en cours** (toutes catégories) ; l'administration recalcule un **nouveau taux** affiché avant validation. Le taux modulé n'est donc PAS le taux issu de la dernière déclaration : il dépend de l'estimation saisie.
 
-**Pénalité si modulation à la baisse excessive** (majoration 10 % si écart > 10 % et non justifié).
+Cas fréquent (perte d'emploi → ARE) : un taux personnalisé calculé sur une année d'activité élevée reste appliqué jusqu'au septembre suivant. Pour récupérer la trésorerie immédiatement plutôt que d'attendre la mise à jour de septembre, faire une modulation à la baisse. L'**ARE bénéficie de l'abattement de 10 %** (revenu de remplacement, BOI-RSA-BASE-30-50-20) : saisir le **net imposable** sans retrancher soi-même le 10 % (le système l'applique).
+
+**Pénalité si modulation à la baisse excessive** (majoration 10 % si écart > 10 % et non justifié). Si reprise d'emploi en cours d'année, refaire une modulation à la hausse (sans seuil, sans pénalité).
 
 ## Régularisation annuelle
 

--- a/fiscaliste/scripts/calc_ir.py
+++ b/fiscaliste/scripts/calc_ir.py
@@ -226,20 +226,28 @@ def from_foyer(foyer, bareme, pfu_data):
     demi_parts_alt = 0.25 * min(enfants_alternee, 2) + 0.5 * max(0, enfants_alternee - 2)
     parts = parts_base + demi_parts_enfants + demi_parts_alt
 
-    # Revenu net catégoriel salaires (abattement 10 %)
+    # Limitation connue : salaires + ARE partagent ici un seul plafond d'abattement
+    # (14 555 €). Correct pour un même déclarant ; un foyer où salaire et ARE
+    # relèvent de deux conjoints distincts aurait droit à deux plafonds. Non géré
+    # (limitation préexistante) — voir issue dédiée plutôt que d'élargir cette PR.
+    #
+    # Revenu net catégoriel salaires + ARE (abattement 10 %).
+    # L'ARE est un revenu de remplacement imposé selon les règles des T&S
+    # (BOI-RSA-BASE-30-50-20) : même abattement 10 % et même plafond (14 555 €)
+    # que les salaires. On l'intègre donc à la base salaires.
     salaires = r.get("salaires_declarant1", 0) + r.get("salaires_declarant2", 0)
-    net_salaires = abattement_salaires(salaires, bareme) if salaires else 0
+    chomage = r.get("revenus_chomage", 0)
+    base_traitements = salaires + chomage
+    net_salaires = abattement_salaires(base_traitements, bareme) if base_traitements else 0
 
     pensions = r.get("pensions_declarant1", 0) + r.get("pensions_declarant2", 0)
     net_pensions = abattement_pensions(pensions, bareme) if pensions else 0
 
-    # Autres revenus ajoutés au RNI sans abattement (simplification) :
-    # revenus fonciers (déjà calculés au net), chômage (pas d'abattement)
+    # Revenus fonciers : déjà au net (micro post-abattement / réel post-charges).
     fonciers = r.get("revenus_fonciers_reels", 0) + r.get("revenus_fonciers_micro", 0)
-    chomage = r.get("revenus_chomage", 0)
 
     # Revenus imposables au barème (hors revenus du capital si PFU)
-    revenu_global = net_salaires + net_pensions + fonciers + chomage
+    revenu_global = net_salaires + net_pensions + fonciers
 
     # Déductions (PER + pension alimentaire + CSG déductible)
     per = d.get("per_declarant1", 0) + d.get("per_declarant2", 0)


### PR DESCRIPTION
Merci beaucoup Romain pour ce projet qui m'a beaucoup aidé pour mes déclarations. Une petite contribution sur l'ARE.

---

## Problème

Le skill `fiscaliste` indique que les allocations chômage (ARE) ne bénéficient d'aucun abattement de 10 %. C'est faux.

## Correctif

L'ARE est un revenu de remplacement imposé selon les règles des traitements et salaires → déduction forfaitaire de 10 % applicable (BOFiP **BOI-RSA-BASE-30-50-20**, qui cite explicitement « les allocations de chômage payées par Pôle Emploi »).

- Doc corrigée dans 6 fichiers (`SKILL.md`, `references/ir-mecanisme.md`, `references/cas-speciaux.md`, `references/declaration-workflow.md`, `references/prelevement-a-la-source.md`, `foyer.example.json`).
- Bug de calcul corrigé dans `scripts/calc_ir.py` : le chômage était ajouté au RNI **sans abattement** → IR sur-estimé pour tout foyer percevant des ARE. Désormais intégré à la base traitements & salaires (même abattement 10 %, même plafond).
- Eval dédiée ajoutée (`evals/evals.json` → `#20 are-abattement-10pct`) qui vérifie que l'ARE bénéficie bien de l'abattement, avec une assertion négative anti-régression.
- `data/bareme-ir-2025.json` : description de l'abattement précisée pour inclure l'ARE (case 1AP).
- La case **1AP/1BP** reste correcte ; clarification de son rôle réel (distinction revenu d'activité / remplacement — plafond PER, prestations — et **non** l'abattement).
- `last_updated` du skill mis à jour (2026-04-19 → 2026-05-30).

## Citation BOFiP (vérifiée en direct)

**BOI-RSA-BASE-30-50-20**, *« RSA - Base d'imposition des traitements, salaires et revenus assimilés - Charges déductibles du revenu brut - Dépenses professionnelles des salariés - Déduction forfaitaire de 10 % »*, **§ 10** :

> « La déduction forfaitaire de 10 % est applicable à tous les revenus taxés suivant les règles relatives aux traitements et salaires. Elle est pratiquée, en particulier, sur le montant : **des allocations de chômage payées par le Pôle Emploi** ; des indemnités journalières de maladie imposables […] ; de la fraction imposable des indemnités de licenciement et de départ à la retraite ou en préretraite ; […]. »

## Origine de l'erreur

Confusion classique : on retient (à juste titre) qu'il ne faut **pas** déclarer l'ARE en 1AJ (salaires) mais en 1AP. L'erreur a été d'en déduire « pas en 1AJ » ⇒ « pas d'abattement 10 % ». Or l'abattement suit la **nature** du revenu (règles T&S), pas le **numéro de case**.

## Limitation connue (non traitée ici — scope minimal)

Le correctif fusionne salaires + ARE sous un **seul** plafond d'abattement de 14 555 €. C'est correct tant que ces revenus relèvent du **même déclarant** (le plafond est par personne). Pour un foyer où salaire et ARE relèvent de deux conjoints distincts, chacun aurait droit à son propre plafond — le script ne ventile pas par déclarant. Cette limitation est **préexistante** (non introduite par ce correctif) ; elle est documentée par un commentaire dans le code et mériterait une issue dédiée plutôt que d'élargir cette PR.

## Sources

- **BOFiP BOI-RSA-BASE-30-50-20 § 10** (déduction forfaitaire de 10 % ; cite « les allocations de chômage payées par le Pôle Emploi »)
- service-public.gouv.fr fiche **F410** — *« L'allocation chômage ou de préretraite est-elle imposée ? »* (imposition selon les règles des traitements et salaires)
- impots.gouv.fr (« Dois-je déclarer mes allocations chômage ? » cases 1AP–1DP ; « Comment bénéficier de la déduction forfaitaire de 10 % ? » bornes revenus 2025 : min 509 €, max 14 555 €)

## Test

`scripts/calc_ir.py` sur un foyer ARE-seule 18 000 € → **RNI 16 200 €** (abattement 10 % appliqué), **IR net 0 €** (décote). Vérifié aussi : « salaire seul 18 000 € » donne un RNI identique (16 200 €), confirmant le traitement à l'identique. Non-régression OK sur un salaire seul (50 000 € → RNI 45 000 €).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
