### PR TITLE
fix(qonto): filtrer les transactions sur settled_at au lieu de updated_at (#54)

### DIFF
--- a/integrations/qonto/fetch.js
+++ b/integrations/qonto/fetch.js
@@ -51,18 +51,19 @@ async function getOrganization() {
 }
 
 /**
- * Récupère les transactions d'un compte bancaire spécifique.
+ * Construit les paramètres de requête pour l'endpoint /transactions.
+ *
+ * Filtres de date supportés (cf. doc API Qonto) :
+ * - settled_at_from / settled_at_to : date de règlement (impacte le solde) — à utiliser pour la comptabilité
+ * - emitted_at_from / emitted_at_to : date d'émission
+ * - updated_at_from / updated_at_to : date de dernière modification de la fiche (rarement pertinent en compta)
+ *
+ * Extrait dans une fonction pure pour être testable sans appel réseau.
  * @param {string} iban - IBAN du compte bancaire
  * @param {object} options - Options de requête
- * @param {string} options.status - Filtre par statut (défaut : 'completed')
- * @param {string} options.updated_at_from - Date de début (format ISO)
- * @param {string} options.updated_at_to - Date de fin (format ISO)
- * @param {number} options.per_page - Résultats par page (max 100)
- * @param {number} options.current_page - Numéro de page
+ * @returns {URLSearchParams}
  */
-async function getTransactions(iban, options = {}) {
-  const headers = await getHeaders();
-
+function buildTransactionsParams(iban, options = {}) {
   const params = new URLSearchParams({
     iban,
     status: options.status || 'completed',
@@ -70,12 +71,34 @@ async function getTransactions(iban, options = {}) {
     current_page: String(options.current_page || 1)
   });
 
-  if (options.updated_at_from) {
-    params.append('updated_at_from', options.updated_at_from);
+  const dateFilters = [
+    'settled_at_from', 'settled_at_to',
+    'emitted_at_from', 'emitted_at_to',
+    'updated_at_from', 'updated_at_to'
+  ];
+  for (const key of dateFilters) {
+    if (options[key]) {
+      params.append(key, options[key]);
+    }
   }
-  if (options.updated_at_to) {
-    params.append('updated_at_to', options.updated_at_to);
-  }
+
+  return params;
+}
+
+/**
+ * Récupère les transactions d'un compte bancaire spécifique.
+ * @param {string} iban - IBAN du compte bancaire
+ * @param {object} options - Options de requête
+ * @param {string} options.status - Filtre par statut (défaut : 'completed')
+ * @param {string} options.settled_at_from - Date de règlement de début (format ISO)
+ * @param {string} options.settled_at_to - Date de règlement de fin (format ISO)
+ * @param {number} options.per_page - Résultats par page (max 100)
+ * @param {number} options.current_page - Numéro de page
+ */
+async function getTransactions(iban, options = {}) {
+  const headers = await getHeaders();
+
+  const params = buildTransactionsParams(iban, options);
 
   const url = `${QONTO_API_BASE}/transactions?${params}`;
   const response = await fetch(url, { headers });
@@ -118,6 +141,39 @@ async function getAllTransactions(iban, options = {}) {
   }
 
   return allTransactions;
+}
+
+/**
+ * Contrôle de cohérence : détecte les transactions manquantes en vérifiant la
+ * continuité du solde cumulé (settled_balance). Pour chaque transaction (triée
+ * par settled_at croissant), le solde précédent + le montant doit égaler le
+ * solde courant. Toute rupture révèle une opération absente de l'export.
+ *
+ * @param {Array} transactions - Transactions brutes de l'API Qonto (champ settled_balance)
+ * @returns {Array<object>} Liste des ruptures détectées (vide si tout est cohérent)
+ */
+function findBalanceDiscontinuities(transactions) {
+  const settled = transactions
+    .filter(t => t.settled_at && typeof t.settled_balance === 'number')
+    .sort((a, b) => new Date(a.settled_at) - new Date(b.settled_at));
+
+  const gaps = [];
+  for (let i = 1; i < settled.length; i++) {
+    const prev = settled[i - 1];
+    const cur = settled[i];
+    const signed = cur.side === 'credit' ? cur.amount : -cur.amount;
+    const expected = Math.round((prev.settled_balance + signed) * 100) / 100;
+    if (Math.abs(expected - cur.settled_balance) > 0.01) {
+      gaps.push({
+        date: cur.settled_at,
+        label: cur.label,
+        expected_balance: expected,
+        actual_balance: cur.settled_balance,
+        gap: Math.round((cur.settled_balance - expected) * 100) / 100
+      });
+    }
+  }
+  return gaps;
 }
 
 /**
@@ -168,10 +224,12 @@ async function main() {
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--start' && args[i + 1]) {
-      options.updated_at_from = args[i + 1];
+      // Filtre sur la date de règlement (settled_at), pas la date de modification :
+      // c'est la date qui a un sens comptable et qui impacte le solde.
+      options.settled_at_from = args[i + 1];
       i++;
     } else if (args[i] === '--end' && args[i + 1]) {
-      options.updated_at_to = args[i + 1];
+      options.settled_at_to = args[i + 1];
       i++;
     }
   }
@@ -191,6 +249,18 @@ async function main() {
     const transactions = await getAllTransactions(account.iban, options);
     console.log(`${transactions.length} transactions trouvées`);
 
+    // Contrôle de cohérence : alerter si le solde cumulé présente des ruptures,
+    // signe qu'il manque des transactions dans l'export.
+    const gaps = findBalanceDiscontinuities(transactions);
+    if (gaps.length > 0) {
+      console.warn(`\n⚠️  ${gaps.length} rupture(s) de continuité du solde détectée(s) : des transactions sont probablement manquantes.`);
+      for (const g of gaps.slice(0, 5)) {
+        console.warn(`   ${g.date} ${g.label} — solde attendu ${g.expected_balance} vs réel ${g.actual_balance} (écart ${g.gap})`);
+      }
+      if (gaps.length > 5) console.warn(`   ... et ${gaps.length - 5} autre(s).`);
+      console.warn('   Vérifiez la période demandée et rapprochez avec le relevé Qonto.');
+    }
+
     const transformed = transactions.map(transformTransaction);
 
     const outputFile = path.join(outputDir, `qonto-${account.slug}.json`);
@@ -205,7 +275,9 @@ module.exports = {
   getOrganization,
   getTransactions,
   getAllTransactions,
-  transformTransaction
+  transformTransaction,
+  buildTransactionsParams,
+  findBalanceDiscontinuities
 };
 
 if (require.main === module) {

--- a/integrations/qonto/fetch.test.js
+++ b/integrations/qonto/fetch.test.js
@@ -1,0 +1,65 @@
+/**
+ * Tests du connecteur Qonto (integrations/qonto/fetch.js).
+ * Exécution : node integrations/qonto/fetch.test.js
+ *
+ * Couvre la régression #54 : le filtre de date doit porter sur settled_at
+ * (date de règlement) et non sur updated_at (date de modification), sinon des
+ * transactions réglées dans la période sont silencieusement exclues.
+ */
+
+const assert = require('node:assert');
+const { buildTransactionsParams, findBalanceDiscontinuities } = require('./fetch');
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`  ✓ ${name}`);
+}
+
+console.log('buildTransactionsParams');
+
+test('mappe les bornes de période sur settled_at_from / settled_at_to', () => {
+  const p = buildTransactionsParams('FR76', {
+    settled_at_from: '2025-07-01',
+    settled_at_to: '2026-06-30'
+  });
+  assert.strictEqual(p.get('settled_at_from'), '2025-07-01');
+  assert.strictEqual(p.get('settled_at_to'), '2026-06-30');
+  // Régression #54 : ne doit PAS retomber sur updated_at.
+  assert.strictEqual(p.get('updated_at_from'), null);
+  assert.strictEqual(p.get('updated_at_to'), null);
+});
+
+test('applique le statut completed par défaut', () => {
+  const p = buildTransactionsParams('FR76', {});
+  assert.strictEqual(p.get('status'), 'completed');
+  assert.strictEqual(p.get('iban'), 'FR76');
+});
+
+console.log('findBalanceDiscontinuities');
+
+test('ne signale aucune rupture sur une suite de soldes cohérente', () => {
+  const txs = [
+    { settled_at: '2025-07-01T10:00:00Z', side: 'credit', amount: 100, settled_balance: 1100 },
+    { settled_at: '2025-07-02T10:00:00Z', side: 'debit', amount: 40, settled_balance: 1060 },
+    { settled_at: '2025-07-03T10:00:00Z', side: 'credit', amount: 200, settled_balance: 1260 }
+  ];
+  assert.deepStrictEqual(findBalanceDiscontinuities(txs), []);
+});
+
+test('détecte une transaction manquante via la rupture de solde', () => {
+  // Entre la 1ère et la 2e, une opération de -50 est absente de l'export :
+  // solde attendu 1100 - 40 = 1060, mais le solde réel est 1010.
+  const txs = [
+    { settled_at: '2025-07-01T10:00:00Z', side: 'credit', amount: 100, settled_balance: 1100 },
+    { settled_at: '2025-07-02T10:00:00Z', side: 'debit', amount: 40, settled_balance: 1010, label: 'X' }
+  ];
+  const gaps = findBalanceDiscontinuities(txs);
+  assert.strictEqual(gaps.length, 1);
+  assert.strictEqual(gaps[0].expected_balance, 1060);
+  assert.strictEqual(gaps[0].actual_balance, 1010);
+  assert.strictEqual(gaps[0].gap, -50);
+});
+
+console.log(`\n${passed} test(s) OK`);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "validate:facture": "node scripts/validate-facture.js",
     "fetch": "node integrations/stripe/fetch.js; node integrations/qonto/fetch.js",
     "fetch:qonto": "node integrations/qonto/fetch.js",
+    "test:qonto": "node integrations/qonto/fetch.test.js",
     "fetch:stripe": "node integrations/stripe/fetch.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Résumé

Corrige #54 : le connecteur Qonto filtrait les transactions sur `updated_at` (date de dernière modification de la fiche) au lieu de `settled_at` (date de règlement). Des transactions réglées dans la période mais modifiées en dehors (ajout de pièce jointe, changement de catégorie...) étaient silencieusement exclues, faussant le CA, la TVA et le résultat de clôture, sans aucune erreur.

## Changements

- `main()` mappe désormais `--start` / `--end` sur `settled_at_from` / `settled_at_to` (confirmé par la doc API Qonto : ces paramètres existent, et le tri par défaut est déjà `settled_at:desc`).
- Extraction de `buildTransactionsParams()` (fonction pure, testable) qui supporte `settled_at`, `emitted_at` et `updated_at` (rétrocompatibilité).
- Ajout de `findBalanceDiscontinuities()` : contrôle de continuité du solde cumulé (`settled_balance`) qui **alerte si des transactions manquent** dans l'export. Ce garde-fou aurait rendu le bug visible immédiatement.
- Tests : `integrations/qonto/fetch.test.js` (dont un cas qui reproduit la régression #54) + script `npm run test:qonto`.

## Test

```
$ npm run test:qonto
buildTransactionsParams
  ✓ mappe les bornes de période sur settled_at_from / settled_at_to
  ✓ applique le statut completed par défaut
findBalanceDiscontinuities
  ✓ ne signale aucune rupture sur une suite de soldes cohérente
  ✓ détecte une transaction manquante via la rupture de solde

4 test(s) OK
```

## Note

Le connecteur Stripe (`integrations/stripe/fetch.js`) mérite une vérification : s'il suit le même schéma de filtrage par date, il peut présenter le même défaut.

Closes #54
