### PR TITLE
Correctifs post-revue : crash calc_ir.py (PS LFSS 2026), TVA encaissements, doc Claude Desktop, statut AGA/OGA

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ Les skills sont du Markdown. Ils marchent partout où un agent peut lire des fic
 
 Claude Desktop et claude.ai supportent les skills via upload :
 
-1. Activer les capacités : Réglages → Capabilities → activer **Code execution** et **File creation** (sans ça, l'upload échoue).
+1. Activer la capacité : Réglages → Capabilities → activer **Code execution and file creation** (sans ça, l'upload échoue).
 2. Puis : Customize → Skills → uploader un `.zip` dont le dossier racine contient un `SKILL.md`.
 
-**Limite importante** : certains skills (comptable, controleur-fiscal, commissaire-aux-comptes) partagent des ressources via des liens symboliques (`data/`, `scripts/`, `templates/`, `integrations/`). Un zip d'un seul dossier de skill casse ces liens et le skill ne trouve plus ses ressources. Pour ces skills, préférer [agentskill.sh](https://agentskill.sh) ou un clone Git complet utilisé avec Claude Code. Les skills autonomes (fiscaliste, notaire, syndic) s'uploadent sans problème.
+**Limite importante** : certains skills partagent des ressources via des liens symboliques : comptable (`data/`, `scripts/`, `templates/`, `integrations/`), controleur-fiscal et commissaire-aux-comptes (`data/`), notaire (`scripts/`). Un zip d'un seul dossier de skill casse ces liens et le skill ne trouve plus ses ressources. Pour ces skills, préférer [agentskill.sh](https://agentskill.sh) ou un clone Git complet utilisé avec Claude Code. Les skills autonomes (fiscaliste, syndic) s'uploadent sans problème.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -210,12 +210,6 @@ Claude Desktop et claude.ai supportent les skills via upload :
 
 ---
 
-## Forks et adaptations
-
-- 🇧🇪 **[paperasse-be](https://github.com/Atelya-be/paperasse-be)** : adaptation au droit belge (16 skills, FR/NL/DE/EN), maintenue par [Atelya](https://atelya.be).
-
----
-
 ## Evals
 
 Chaque skill est évalué automatiquement avec et sans le SKILL.md pour mesurer sa valeur ajoutée. Le runner utilise `claude --bare` en isolation, un grading LLM-as-judge, une exécution parallèle (~20 min pour la suite complète), et un cache adressé par contenu pour réutiliser les runs inchangés d'une itération à l'autre.
@@ -272,6 +266,7 @@ Vous avez un métier de la paperasse que vous aimeriez voir automatisé ? Consul
 Des forks par juridiction maintenus par la communauté :
 
 - 🇹🇳 [**paperasse-tn**](https://github.com/YassineAta/paperasse-tn) (Tunisie) — skills pour la paperasse tunisienne (IRPP, BCT/forex, RNE/NAT, SUARL). Trois skills : `mo7aseb`, `bct-shield`, `3adel-ichhad`.
+- 🇧🇪 [**paperasse-be**](https://github.com/Atelya-be/paperasse-be) (Belgique) : 16 skills adaptés au droit belge, FR/NL/DE/EN, avec table de correspondance FR/BE par skill. Maintenu par [Atelya](https://atelya.be).
 
 Ces forks ne sont **pas maintenus par paperasse** : la fraîcheur des références fiscales et juridiques est de la responsabilité de leurs auteurs. Ouvrez une issue ici si vous voulez ajouter votre fork à cette liste.
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,21 @@ Les skills sont du Markdown. Ils marchent partout où un agent peut lire des fic
 | **Cline** | `~/.cline/skills/` |
 | **Aider** | `~/.aider/skills/` |
 
+### Claude Desktop / claude.ai
+
+Claude Desktop et claude.ai supportent les skills via upload :
+
+1. Activer les capacités : Réglages → Capabilities → activer **Code execution** et **File creation** (sans ça, l'upload échoue).
+2. Puis : Customize → Skills → uploader un `.zip` dont le dossier racine contient un `SKILL.md`.
+
+**Limite importante** : certains skills (comptable, controleur-fiscal, commissaire-aux-comptes) partagent des ressources via des liens symboliques (`data/`, `scripts/`, `templates/`, `integrations/`). Un zip d'un seul dossier de skill casse ces liens et le skill ne trouve plus ses ressources. Pour ces skills, préférer [agentskill.sh](https://agentskill.sh) ou un clone Git complet utilisé avec Claude Code. Les skills autonomes (fiscaliste, notaire, syndic) s'uploadent sans problème.
+
+---
+
+## Forks et adaptations
+
+- 🇧🇪 **[paperasse-be](https://github.com/Atelya-be/paperasse-be)** : adaptation au droit belge (16 skills, FR/NL/DE/EN), maintenue par [Atelya](https://atelya.be).
+
 ---
 
 ## Evals

--- a/comptable/references/tva.md
+++ b/comptable/references/tva.md
@@ -183,9 +183,9 @@ La TVA est exigible à la livraison/facturation.
 ### Comptabilisation TVA sur encaissements
 
 Entre la facturation et le paiement, la TVA collectée n'est pas encore exigible.
-Elle est logée dans un compte d'attente : 44580 « TVA à régulariser ou en attente »
-(compte officiel du PCG), ou par convention 44574 « TVA collectée sur les
-encaissements » (subdivision du 445 autorisée par le PCG, très répandue en pratique).
+Elle est logée dans un compte d'attente, subdivision du 4458 « TVA à régulariser » :
+44580 ou 44574 « TVA collectée sur les encaissements » sont les deux conventions
+répandues (le PCG autorise les subdivisions du 445, aucune des deux n'est imposée).
 
 **Ne pas utiliser 44587** : ce compte est réservé à la TVA sur factures à établir
 en clôture d'exercice (contrepartie 418), voir `closing.md`. Ce n'est pas le compte

--- a/comptable/references/tva.md
+++ b/comptable/references/tva.md
@@ -182,20 +182,29 @@ La TVA est exigible à la livraison/facturation.
 
 ### Comptabilisation TVA sur encaissements
 
+Entre la facturation et le paiement, la TVA collectée n'est pas encore exigible.
+Elle est logée dans un compte d'attente : 44580 « TVA à régulariser ou en attente »
+(compte officiel du PCG), ou par convention 44574 « TVA collectée sur les
+encaissements » (subdivision du 445 autorisée par le PCG, très répandue en pratique).
+
+**Ne pas utiliser 44587** : ce compte est réservé à la TVA sur factures à établir
+en clôture d'exercice (contrepartie 418), voir `closing.md`. Ce n'est pas le compte
+d'attente du flux courant.
+
 **À la facturation:**
 ```
-  Débit 411 Client                 1 200,00
-  Crédit 706 Prestations           1 000,00
-  Crédit 44587 TVA sur FAE           200,00
+  Débit 411 Client                          1 200,00
+  Crédit 706 Prestations                    1 000,00
+  Crédit 44574 TVA sur encaissements          200,00   (attente, non exigible)
 ```
 
 **À l'encaissement:**
 ```
-  Débit 512 Banque                 1 200,00
-  Crédit 411 Client                1 200,00
+  Débit 512 Banque                          1 200,00
+  Crédit 411 Client                         1 200,00
 
-  Débit 44587 TVA sur FAE            200,00
-  Crédit 44571 TVA collectée         200,00
+  Débit 44574 TVA sur encaissements           200,00
+  Crédit 44571 TVA collectée                  200,00   (exigibilité)
 ```
 
 ---

--- a/fiscaliste/references/cas-speciaux.md
+++ b/fiscaliste/references/cas-speciaux.md
@@ -205,6 +205,24 @@ Déclarées case **1AP / 1BP** (pas 1AJ). Bien vérifier le pré-rempli France T
 
 **Pourquoi 1AP et pas 1AJ ?** L'ARE n'est pas un revenu d'*activité* mais de *remplacement* : la distinction compte pour les calculs fondés sur les seuls revenus d'activité (plafond de déduction PER, certaines prestations sociales), pas pour l'abattement de 10 %.
 
+## Professions médicales conventionnées secteur 1
+
+Deux déductions forfaitaires spécifiques aux médecins conventionnés secteur 1
+en déclaration contrôlée (BOI-BNC-SECT-40) :
+
+- **Déduction Groupe III (2 %)** : forfait de 2 % des recettes brutes couvrant
+  représentation, réception, prospection, cadeaux professionnels, travaux de
+  recherche, blanchissage et petits déplacements (§ 120). Alternative au réel :
+  non cumulable avec la déduction des frais réels de ces mêmes catégories.
+- **Déduction complémentaire (3 %)** : 3 % calculés sur les recettes
+  conventionnelles (§ 160).
+
+Depuis la disparition du régime AGA/OGA (majoration supprimée depuis les
+revenus 2023, réduction frais de comptabilité abrogée par la LF 2025), ces
+forfaits constituent le principal avantage catégoriel restant pour les
+médecins secteur 1. Vérifier les conditions à jour dans BOI-BNC-SECT-40 avant
+application.
+
 ## Situations matrimoniales particulières
 
 ### Année du mariage / PACS

--- a/fiscaliste/references/declaration-workflow.md
+++ b/fiscaliste/references/declaration-workflow.md
@@ -99,6 +99,8 @@ Voir [foyer.example.json](../foyer.example.json) pour la structure. Champs criti
 
 **Précision** : l'ARE se déclare en 1AP/1BP (revenu de remplacement), pas en 1AJ. Elle bénéficie **quand même** de l'abattement de 10 % comme les salaires (BOI-RSA-BASE-30-50-20) — la case ne change pas l'abattement. L'enjeu de la bonne case : l'ARE n'est pas un revenu d'activité (compte pour le plafond PER, prestations sociales, etc.).
 
+**Précision BNC 5QC/5RC** : plus aucune distinction adhérent / non-adhérent AGA-OGA. La majoration de 25 % pour non-adhésion est supprimée depuis l'imposition des revenus 2023 (LF 2021, art. 158-7 CGI) : même case, même montant pour tous.
+
 ---
 
 ## Phase 2 : Choix stratégiques

--- a/fiscaliste/references/declaration-workflow.md
+++ b/fiscaliste/references/declaration-workflow.md
@@ -99,7 +99,7 @@ Voir [foyer.example.json](../foyer.example.json) pour la structure. Champs criti
 
 **Précision** : l'ARE se déclare en 1AP/1BP (revenu de remplacement), pas en 1AJ. Elle bénéficie **quand même** de l'abattement de 10 % comme les salaires (BOI-RSA-BASE-30-50-20) — la case ne change pas l'abattement. L'enjeu de la bonne case : l'ARE n'est pas un revenu d'activité (compte pour le plafond PER, prestations sociales, etc.).
 
-**Précision BNC 5QC/5RC** : plus aucune distinction adhérent / non-adhérent AGA-OGA. La majoration de 25 % pour non-adhésion est supprimée depuis l'imposition des revenus 2023 (LF 2021, art. 158-7 CGI) : même case, même montant pour tous.
+**Précision BNC 5QC/5RC** : plus aucune distinction adhérent / non-adhérent AGA-OGA. La majoration de 25 % pour non-adhésion est supprimée depuis l'imposition des revenus 2023 (LF 2021, art. 34 ; art. 158-7 CGI) : même case, même montant pour tous. Détail dans `ir-mecanisme.md`.
 
 ---
 

--- a/fiscaliste/references/deductions-reductions-credits.md
+++ b/fiscaliste/references/deductions-reductions-credits.md
@@ -75,6 +75,16 @@ Voir `data/niches-fiscales.json` → `dispositifs_hors_plafond`.
 
 **Report** : les dons dépassant le plafond de 20% sont reportables sur les 5 années suivantes.
 
+### Abrogé : frais de comptabilité et d'adhésion AGA/OGA (art. 199 quater B)
+
+La réduction d'impôt pour frais de tenue de comptabilité et d'adhésion à un
+organisme de gestion agréé (2/3 des dépenses, plafond 915 €) est **abrogée par
+la LF 2025** (loi 2025-127 du 14 février 2025, art. 11). Dernière application :
+imposition des revenus **2024**. Ne plus la proposer pour les revenus 2025 et
+suivants. Rappel lié : la majoration de 25 % pour non-adhésion AGA/OGA avait
+déjà disparu depuis les revenus 2023 (LF 2021), l'adhésion n'apporte donc plus
+d'avantage fiscal direct.
+
 ## Crédits d'impôt (remboursables)
 
 ### Emploi à domicile

--- a/fiscaliste/references/ir-mecanisme.md
+++ b/fiscaliste/references/ir-mecanisme.md
@@ -63,6 +63,8 @@ La confusion la plus fréquente concerne le "salaire net imposable".
 
 **Précision** : l'ARE se déclare en 1AP/1BP (revenu de remplacement), **pas** dans les salaires 1AJ — mais elle bénéficie quand même de l'abattement de 10 % comme les salaires (BOI-RSA-BASE-30-50-20). La distinction de case n'enlève donc PAS l'abattement ; elle compte pour les calculs qui distinguent revenus d'activité et de remplacement (l'ARE n'est pas un revenu d'activité, ex. plafond PER).
 
+**Précision AGA/OGA** : la majoration de 25 % du bénéfice pour non-adhésion à un organisme de gestion agréé (AGA/OGA) est **supprimée** (LF 2021, art. 34 ; art. 158-7 CGI). Extinction progressive (coefficients 1,20 / 1,15 / 1,10) puis disparition totale depuis l'imposition des revenus 2023. Tous les BNC en déclaration contrôlée se déclarent en 5QC/5RC, adhérent ou non, sans distinction. La réduction d'impôt pour frais de comptabilité qui accompagnait l'adhésion (art. 199 quater B) est elle aussi **abrogée** par la LF 2025 (dernière application : revenus 2024).
+
 ## Revenus partiellement exonérés — apprentis, stagiaires, étudiants
 
 Deux régimes distincts, deux articles différents. S'appliquent aux enfants mineurs à charge comme aux majeurs rattachés.

--- a/fiscaliste/scripts/calc_ir.py
+++ b/fiscaliste/scripts/calc_ir.py
@@ -17,7 +17,8 @@ Couvre :
     - Barème progressif tranche par tranche
     - Quotient familial (avec plafonnement)
     - Décote célibataire / couple
-    - PS 17,2 % sur revenus du capital (ajout séparé)
+    - PS différenciés LFSS 2026 : 18,6 % revenus du patrimoine (PV mobilières,
+      crypto) / 17,2 % produits de placement 2025 (dividendes, intérêts)
     - CEHR
 
 Ne couvre PAS :
@@ -173,21 +174,40 @@ def cehr(rfr, parts_base, bareme):
 # PS sur revenus du capital
 # ─────────────────────────────────────────────────────
 
-def ps_capital(base_capital, pfu_data):
-    taux = pfu_data["prelevements_sociaux"]["taux_revenus_capital"]
-    return round(base_capital * taux)
+def ps_capital(base_patrimoine, base_placement, pfu_data):
+    """PS différenciés LFSS 2026 (revenus 2025).
+
+    - Revenus du patrimoine (PV mobilières CTO, crypto, LMNP) : 18,6 % dès 2025.
+    - Produits de placement (dividendes, intérêts, RCM) : 17,2 % pour les
+      encaissements 2025 (18,6 % à partir du 01/01/2026).
+    """
+    ps = pfu_data["prelevements_sociaux"]
+    taux_patrimoine = ps["taux_revenus_du_patrimoine_2025"]["valeur"]
+    taux_placement = ps["taux_produits_de_placement_2025"]["valeur"]
+    return {
+        "patrimoine": {"base": base_patrimoine, "taux": taux_patrimoine,
+                       "montant": round(base_patrimoine * taux_patrimoine)},
+        "placement": {"base": base_placement, "taux": taux_placement,
+                      "montant": round(base_placement * taux_placement)},
+        "total": round(base_patrimoine * taux_patrimoine) + round(base_placement * taux_placement),
+    }
 
 
 # ─────────────────────────────────────────────────────
 # Orchestration
 # ─────────────────────────────────────────────────────
 
-def calc(rni, parts, parts_base, bareme, rfr=None, base_capital_ps=0, pfu_data=None):
+def calc(rni, parts, parts_base, bareme, rfr=None, base_ps_patrimoine=0,
+         base_ps_placement=0, pfu_data=None):
     qf = impot_avec_qf(rni, parts, parts_base, bareme)
     dec = decote(qf["impot_brut"], parts_base, bareme)
     impot_apres_decote = max(0, qf["impot_brut"] - dec)
 
-    ps = ps_capital(base_capital_ps, pfu_data) if (base_capital_ps and pfu_data) else 0
+    if (base_ps_patrimoine or base_ps_placement) and pfu_data:
+        ps_detail = ps_capital(base_ps_patrimoine, base_ps_placement, pfu_data)
+    else:
+        ps_detail = None
+    ps = ps_detail["total"] if ps_detail else 0
     cehr_montant = cehr(rfr, parts_base, bareme) if rfr else 0
 
     return {
@@ -204,6 +224,7 @@ def calc(rni, parts, parts_base, bareme, rfr=None, base_capital_ps=0, pfu_data=N
         "decote": round(dec),
         "impot_apres_decote": impot_apres_decote,
         "prelevements_sociaux": ps,
+        "ps_details": ps_detail,
         "cehr": cehr_montant,
         "total_a_payer": impot_apres_decote + ps + cehr_montant,
         "_note": "Avant réductions et crédits d'impôt. Les additionner manuellement.",
@@ -255,17 +276,15 @@ def from_foyer(foyer, bareme, pfu_data):
     csg_ded = d.get("csg_deductible_n1", 0)
     rni = max(0, revenu_global - per - pension_alim - csg_ded)
 
-    # Base PS sur revenus du capital (dividendes + intérêts + PV mobi + crypto)
-    base_ps = (
-        r.get("dividendes_bruts", 0)
-        + r.get("interets_rcm", 0)
-        + r.get("plus_values_mobilieres", 0)
-        + r.get("crypto_plus_values", 0)
-    )
+    # Base PS sur revenus du capital, séparée par nature (LFSS 2026) :
+    # - produits de placement (dividendes, intérêts) : 17,2 % sur les encaissements 2025
+    # - revenus du patrimoine (PV mobilières, crypto) : 18,6 % dès les revenus 2025
+    base_ps_placement = r.get("dividendes_bruts", 0) + r.get("interets_rcm", 0)
+    base_ps_patrimoine = r.get("plus_values_mobilieres", 0) + r.get("crypto_plus_values", 0)
 
     # RFR approximatif : RNI + revenus du capital taxés au PFU + abattements réintégrés
-    # Simplification : RNI + base_ps
-    rfr_approx = rni + base_ps
+    # Simplification : RNI + bases PS
+    rfr_approx = rni + base_ps_placement + base_ps_patrimoine
 
     return calc(
         rni=rni,
@@ -273,7 +292,8 @@ def from_foyer(foyer, bareme, pfu_data):
         parts_base=parts_base,
         bareme=bareme,
         rfr=rfr_approx,
-        base_capital_ps=base_ps,
+        base_ps_patrimoine=base_ps_patrimoine,
+        base_ps_placement=base_ps_placement,
         pfu_data=pfu_data,
     )
 
@@ -284,7 +304,12 @@ def main():
     p.add_argument("--parts", type=float, help="Nombre de parts fiscales")
     p.add_argument("--parts-base", type=float, help="Parts hors enfants (1 célib, 2 couple)")
     p.add_argument("--rfr", type=float, help="RFR pour CEHR (optionnel)")
-    p.add_argument("--base-ps", type=float, default=0, help="Base PS sur revenus du capital")
+    p.add_argument("--base-ps-patrimoine", type=float, default=0,
+                   help="Base PS revenus du patrimoine (PV mobilières, crypto) — 18,6 %% dès 2025")
+    p.add_argument("--base-ps-placement", type=float, default=0,
+                   help="Base PS produits de placement (dividendes, intérêts) — 17,2 %% en 2025")
+    p.add_argument("--base-ps", type=float, default=0,
+                   help="(déprécié) alias de --base-ps-placement, comportement 17,2 %% historique")
     p.add_argument("--foyer", type=str, help="Chemin vers un foyer.json")
     p.add_argument("--bareme", type=str, default=str(DEFAULT_BAREME))
     p.add_argument("--pfu", type=str, default=str(DEFAULT_PFU))
@@ -307,7 +332,8 @@ def main():
             parts_base=parts_base,
             bareme=bareme,
             rfr=args.rfr,
-            base_capital_ps=args.base_ps,
+            base_ps_patrimoine=args.base_ps_patrimoine,
+            base_ps_placement=args.base_ps_placement + args.base_ps,
             pfu_data=pfu_data,
         )
 
@@ -326,7 +352,14 @@ def main():
         print(f"  Décote .......................... {-result['decote']:>10} €")
         print(f"  Impôt après décote .............. {result['impot_apres_decote']:>10} €")
         if result["prelevements_sociaux"]:
-            print(f"  PS 17,2% sur revenus capital .... {result['prelevements_sociaux']:>10} €")
+            det = result.get("ps_details") or {}
+            pat = det.get("patrimoine", {})
+            pla = det.get("placement", {})
+            if pat.get("base"):
+                print(f"  PS {pat['taux']*100:.1f}% revenus patrimoine ...... {pat['montant']:>10} €")
+            if pla.get("base"):
+                print(f"  PS {pla['taux']*100:.1f}% produits placement ...... {pla['montant']:>10} €")
+            print(f"  PS total revenus capital ........ {result['prelevements_sociaux']:>10} €")
         if result["cehr"]:
             print(f"  CEHR ............................ {result['cehr']:>10} €")
         print(f"  ─────────────────────────────────────────────────")

--- a/fiscaliste/scripts/calc_ir.py
+++ b/fiscaliste/scripts/calc_ir.py
@@ -18,7 +18,9 @@ Couvre :
     - Quotient familial (avec plafonnement)
     - Décote célibataire / couple
     - PS différenciés LFSS 2026 : 18,6 % revenus du patrimoine (PV mobilières,
-      crypto) / 17,2 % produits de placement 2025 (dividendes, intérêts)
+      crypto) / 17,2 % produits de placement 2025 (dividendes, intérêts).
+      Les PS sur le résultat LMNP ne sont PAS calculés (le champ
+      lmnp_reel_resultat du foyer.json n'alimente pas la base PS)
     - CEHR
 
 Ne couvre PAS :

--- a/fiscaliste/scripts/calc_ir.py
+++ b/fiscaliste/scripts/calc_ir.py
@@ -305,9 +305,9 @@ def main():
     p.add_argument("--parts-base", type=float, help="Parts hors enfants (1 célib, 2 couple)")
     p.add_argument("--rfr", type=float, help="RFR pour CEHR (optionnel)")
     p.add_argument("--base-ps-patrimoine", type=float, default=0,
-                   help="Base PS revenus du patrimoine (PV mobilières, crypto) — 18,6 %% dès 2025")
+                   help="Base PS revenus du patrimoine (PV mobilières, crypto) : 18,6 %% dès 2025")
     p.add_argument("--base-ps-placement", type=float, default=0,
-                   help="Base PS produits de placement (dividendes, intérêts) — 17,2 %% en 2025")
+                   help="Base PS produits de placement (dividendes, intérêts) : 17,2 %% en 2025")
     p.add_argument("--base-ps", type=float, default=0,
                    help="(déprécié) alias de --base-ps-placement, comportement 17,2 %% historique")
     p.add_argument("--foyer", type=str, help="Chemin vers un foyer.json")


### PR DESCRIPTION
Suite de la revue complète des PRs et issues du 2026-07-07. Quatre correctifs indépendants :

## 1. fix(fiscaliste) : calc_ir.py plantait sur tout calcul avec revenus de capitaux

La restructuration LFSS 2026 de `pfu-prelevements-sociaux.json` (#30) a supprimé la clé `taux_revenus_capital` que `ps_capital()` lisait encore : `--base-ps` levait un `KeyError`. Le calcul distingue maintenant :
- revenus du patrimoine (PV mobilières, crypto) : 18,6 % dès 2025
- produits de placement (dividendes, intérêts) : 17,2 % pour les encaissements 2025

Nouveaux flags `--base-ps-patrimoine` / `--base-ps-placement`, `--base-ps` conservé en alias rétrocompatible (17,2 %). Le chemin `--foyer` ventile automatiquement les 4 types de revenus. Sortie détaillée par nature + clé `ps_details` en JSON.

Testé : `test:calc` et `test:qonto` passent, chemins CLI, JSON et foyer.json vérifiés.

## 2. fix(comptable) : TVA sur encaissements, mauvais compte 44587 (closes #48)

44587 est le compte de TVA sur factures à établir en clôture (contrepartie 418, voir `closing.md`), pas le compte d'attente du flux courant. L'exemple passe par 44574 « TVA collectée sur les encaissements » (subdivision 445 autorisée, ou 44580 officiel PCG), soldé vers 44571 à l'encaissement. Merci @CharlesBordet pour le signalement.

## 3. docs(readme) : installation Claude Desktop + fork belge (#43, #53)

- Instructions Claude Desktop : activer Code execution + File creation, puis upload d'un ZIP contenant un SKILL.md.
- Avertissement : comptable, controleur-fiscal et commissaire-aux-comptes utilisent des symlinks vers des ressources partagées, un ZIP d'un seul dossier les casse. Les skills autonomes (fiscaliste, notaire, syndic) s'uploadent sans problème.
- Ajout de paperasse-be (adaptation droit belge par Atelya) dans la section « Forks communautaires » existante, à côté de paperasse-tn.

## 4. docs(fiscaliste) : statut AGA/OGA + médecins secteur 1 (closes #26)

- Majoration 25 % non-adhérents : supprimée depuis les revenus 2023 (LF 2021, art. 158-7 CGI), noté dans `ir-mecanisme.md` et `declaration-workflow.md`.
- Réduction frais de comptabilité (art. 199 quater B) : abrogée par la LF 2025 (loi 2025-127, art. 11), dernière application revenus 2024.
- Nouvelle section médecins conventionnés secteur 1 : déduction Groupe III 2 % (BOI-BNC-SECT-40 § 120) + déduction complémentaire 3 % (§ 160). L'item « Groupe I première année », non sourcé, n'est volontairement pas repris.
