### PR TITLE
Corrige les références juridiques du skill syndic

### DIFF
--- a/syndic/SKILL.md
+++ b/syndic/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: syndic
 metadata:
-  last_updated: 2026-03-26
+  last_updated: 2026-07-11
 includes:
   - data/**
   - templates/**
@@ -161,7 +161,7 @@ Transition — {{copro.name}} — Syndic sortant : {{nom}}
 - [ ] Phase 4 AG : vote obtenu, PV rédigé, notification absents/opposants sous 1 mois
 - [ ] Phase 5 ARCHIVES : notification syndic sortant, réception 7 catégories (3 mois, art. 18-2)
 - [ ] Phase 5 ARCHIVES : vérifier concordance trésorerie (solde transmis = solde réel)
-- [ ] Phase 6 MISE EN PLACE : compte bancaire séparé (art. 26-7), transfert fonds
+- [ ] Phase 6 MISE EN PLACE : compte bancaire séparé (art. 18, II loi 1965), transfert fonds
 - [ ] Phase 6 MISE EN PLACE : fournisseurs + copropriétaires informés, RNC mis à jour (2 mois)
 ```
 

--- a/syndic/evals/evals.json
+++ b/syndic/evals/evals.json
@@ -16,7 +16,7 @@
         "Le skill demande les dates de l'exercice comptable",
         "Le skill demande le type de syndic actuel et note la transition souhaitée",
         "Le skill demande la composition du conseil syndical",
-        "Le skill demande les informations du compte bancaire séparé (art. 26-7 décret 1967)",
+        "Le skill demande les informations du compte bancaire séparé (art. 18, II loi 1965)",
         "Le skill génère copros/les-oliviers.json avec tous les champs obligatoires",
         "Le skill mentionne la nécessité de voter le changement de syndic en AG (art. 25)",
         "Le skill propose de configurer une autre copropriété"
@@ -33,7 +33,7 @@
       "assertions": [
         "Le skill identifie la copropriété Les Oliviers et charge copros/les-oliviers.json",
         "Le skill vérifie le calendrier et les échéances",
-        "Le délai de 21 jours minimum est rappelé (art. 9-1 décret 1967)",
+        "Le délai de 21 jours minimum est rappelé (art. 9 décret 1967)",
         "L'ordre du jour contient la désignation du bureau en premier",
         "L'approbation des comptes est à la majorité de l'art. 24",
         "Le vote du budget prévisionnel est à la majorité de l'art. 24",
@@ -143,8 +143,8 @@
         "Le skill mentionne l'extranet copropriétaires comme source d'information avant le vote (obligation ALUR)",
         "Le skill recommande de consulter les copropriétaires AVANT l'AG pour estimer le soutien",
         "Le skill calcule le seuil de majorité art. 25 nécessaire",
-        "La LRAR de convocation est mentionnée avec le délai de 21 jours (art. 9-1)",
-        "La LRAR de notification du PV est mentionnée avec le délai de 1 mois (art. 18 décret)",
+        "La LRAR de convocation est mentionnée avec le délai de 21 jours (art. 9 décret 1967)",
+        "La notification du PV aux opposants et défaillants est mentionnée avec le délai de 1 mois (art. 18 décret 1967 et art. 42 loi 1965)",
         "Le délai de contestation de 2 mois est mentionné (art. 42, court à compter de la notification)",
         "La LRAR au syndic sortant pour demander la transmission est mentionnée",
         "Le délai de 3 mois pour la transmission des archives est cité (art. 18-2)",

--- a/syndic/references/administration.md
+++ b/syndic/references/administration.md
@@ -47,7 +47,7 @@ Demander :
 ### Étape 5 : Informations bancaires
 
 Demander :
-1. Banque et numéro de compte séparé (obligatoire, art. 26-7 décret 1967)
+1. Banque et numéro de compte séparé (obligatoire, art. 18, II loi 1965)
 2. Signataires autorisés
 
 ### Étape 6 : Intégration Qonto (optionnel)

--- a/syndic/references/assemblee-generale.md
+++ b/syndic/references/assemblee-generale.md
@@ -16,7 +16,7 @@ L'AG est l'organe souverain de la copropriété. Elle seule peut voter le budget
 
 ### Délai
 
-**21 jours minimum** entre l'envoi de la convocation et la date de l'AG (art. 9-1 décret 1967).
+**21 jours minimum** entre l'envoi de la convocation et la date de l'AG (art. 9 décret 1967).
 
 Le délai court à compter :
 - Du lendemain de la première présentation de la LRAR
@@ -24,7 +24,7 @@ Le délai court à compter :
 
 ### Contenu de la convocation
 
-**Obligatoire** (art. 9-1 et 11 décret 1967) :
+**Obligatoire** (art. 9 et 11 décret 1967) :
 
 1. Lieu, date et heure de l'AG
 2. Ordre du jour détaillé (chaque résolution formulée)
@@ -81,20 +81,19 @@ Le PV est obligatoire et doit contenir :
   - Noms des copropriétaires opposants ou abstentionnistes
   - Majorité requise et atteinte ou non
 
-**Délai de rédaction** : le PV doit être signé et notifié dans un délai raisonnable. La pratique courante est 2 mois maximum.
+**Délai de signature** : le PV doit être signé à la fin de la séance ou dans les 8 jours suivant l'AG (art. 17 décret 1967).
 
 **Signatures** : président de séance + secrétaire + scrutateurs (le cas échéant).
 
 Voir template : [templates/pv-ag.md](../templates/pv-ag.md)
 
-## Notification du PV (art. 18 et 42 décret 1967)
+## Notification du PV (art. 18 décret 1967 et art. 42 loi 1965)
 
 **Obligatoire** pour les copropriétaires :
 - Opposants (ayant voté contre)
-- Abstentionnistes (n'ayant pas pris part au vote)
-- Absents et non représentés
+- Défaillants (absents et non représentés)
 
-**Délai** : dans le mois suivant l'AG (bonne pratique).
+**Délai** : dans le mois suivant l'AG (art. 42 loi 1965).
 
 **Mode** : LRAR ou notification électronique (si accord).
 

--- a/syndic/references/calendrier.md
+++ b/syndic/references/calendrier.md
@@ -52,10 +52,10 @@ Le calendrier doit être **adapté** à l'exercice comptable de chaque copropri�
 
 | Action | Détail | Obligatoire |
 |--------|--------|------------|
-| Rédaction PV | Dans les 2 mois suivant l'AG | Oui |
-| Notification PV | Envoi aux opposants, abstentionnistes, absents | Oui |
+| Signature du PV | À la fin de la séance ou dans les 8 jours suivant l'AG | Oui |
+| Notification PV | Envoi aux opposants et défaillants | Oui |
 | Exécution décisions | Lancer les travaux votés, signer les contrats | Oui |
-| Mise à jour RNC | Dans les 2 mois suivant l'AG | Oui |
+| Mise à jour RNC | Dans les 2 mois suivant l'AG ayant approuvé les comptes | Oui |
 
 ### Juillet
 
@@ -106,11 +106,11 @@ Le calendrier doit être **adapté** à l'exercice comptable de chaque copropri�
 
 | Échéance | Délai | Fondement |
 |----------|-------|-----------|
-| Convocation AG | 21 jours minimum avant l'AG | Art. 9-1 décret 1967 |
-| AG annuelle | Au moins 1 fois par an, dans les 6 mois suivant la clôture | Art. 7 décret 1967 |
-| Rédaction PV | Délai raisonnable (2 mois max recommandé) | Art. 17 décret 1967 |
-| Notification PV | Dans le mois suivant l'AG | Art. 18 décret 1967 |
-| Mise à jour RNC | 2 mois après l'AG | Art. 55 loi 1965 |
+| Convocation AG | 21 jours minimum avant l'AG | Art. 9 décret 1967 |
+| AG annuelle | Au moins 1 fois par an, dans les 6 mois suivant la clôture | Art. 7 décret 1967 et art. 14-1 loi 1965 |
+| Signature du PV | À la fin de la séance ou dans les 8 jours suivant l'AG | Art. 17 décret 1967 |
+| Notification PV | Dans le mois suivant l'AG | Art. 18 décret 1967 et art. 42 loi 1965 |
+| Mise à jour RNC | 2 mois après l'AG ayant approuvé les comptes | Art. R. 711-10 CCH |
 | Transmission archives (changement syndic) | 3 mois | Art. 18-2 loi 1965 |
 | Contestation décision AG | 2 mois après notification PV | Art. 42 loi 1965 |
 | Prescription actions personnelles | 5 ans | Art. 42 loi 1965 |

--- a/syndic/references/formats.md
+++ b/syndic/references/formats.md
@@ -161,7 +161,7 @@ Tableau de suivi de tous les recommandés envoyés. Essentiel pour le respect de
 └────┴────────────┴──────────────────┴──────────────────────┴───────────────┴────────────┴──────────────────────────┘
 
 Délais courants :
-- Convocation AG : 21 jours à compter du lendemain de la 1ère présentation (art. 9-1)
+- Convocation AG : 21 jours à compter du lendemain de la 1ère présentation (art. 9 décret 1967)
 - Notification PV : contestation 2 mois à compter de la réception (art. 42)
 - Mise en demeure : 30 jours pour régulariser
 - Transmission archives : 3 mois à compter de la cessation (art. 18-2)

--- a/syndic/references/loi-1965.md
+++ b/syndic/references/loi-1965.md
@@ -18,7 +18,8 @@ Statut de la copropriété des immeubles bâtis. Texte fondateur qui régit tout
 | Art. 8-2 | Fiche synthétique |
 | Art. 10 | Répartition des charges |
 | Art. 10-1 | Charges de recouvrement imputées au débiteur |
-| Art. 14-1 | Personnalité morale du syndicat |
+| Art. 14 | Personnalité civile du syndicat |
+| Art. 14-1 | Budget prévisionnel et provisions |
 | Art. 14-2 | Fonds de travaux obligatoire |
 | Art. 15 | Conseil syndical |
 | Art. 17 | Organes de la copropriété |
@@ -33,9 +34,8 @@ Statut de la copropriété des immeubles bâtis. Texte fondateur qui régit tout
 | Art. 25-1 | Passerelle art. 25 → art. 24 |
 | Art. 26 | Double majorité |
 | Art. 29-1A | Copropriétés en difficulté |
-| Art. 33 | Notification du PV |
-| Art. 42 | Prescription des actions (5 ans) |
-| Art. 55 | Immatriculation au registre national |
+| Art. 33 | Paiement par annuités de certains travaux d'amélioration |
+| Art. 42 | Notification du PV, contestation des décisions d'AG et prescription |
 
 ### Décret n67-223 du 17 mars 1967
 
@@ -45,20 +45,19 @@ Décret d'application de la loi de 1965.
 
 | Article | Objet |
 |---------|-------|
-| Art. 7 | Délibérations du conseil syndical |
-| Art. 9 | Convocation du conseil syndical |
-| Art. 9-1 | Convocation de l'AG |
+| Art. 7 | AG annuelle et convocation par le syndic |
+| Art. 9 | Contenu et délai de convocation de l'AG |
+| Art. 9-1 | Consultation des pièces justificatives de charges |
 | Art. 11 | Documents joints à la convocation |
 | Art. 13 | Feuille de présence |
 | Art. 14 | Bureau de l'AG (président, scrutateurs, secrétaire) |
 | Art. 17 | Procès-verbal d'AG |
 | Art. 18 | Notification du PV |
-| Art. 26-7 | Compte séparé obligatoire |
 | Art. 29 | Rémunération du syndic |
-| Art. 33 | Budget prévisionnel |
-| Art. 35 | Comptes du syndicat |
-| Art. 35-2 | Annexes comptables |
-| Art. 45-1 | Immatriculation au registre national |
+| Art. 33 | Conservation et communication des archives |
+| Art. 35 | Avances, provisions et cotisations exigibles |
+| Art. 35-2 | Avis d'appels de fonds |
+| Art. 45-1 | Définition des charges, provisions et avances |
 
 ### Loi ALUR (24 mars 2014)
 
@@ -99,7 +98,7 @@ Plan comptable des copropriétés. Comptabilité en partie double obligatoire po
 
 ## Registre National des Copropriétés (RNC)
 
-**Immatriculation obligatoire** depuis la loi ALUR (art. 55 loi 1965).
+**Immatriculation obligatoire** : art. L. 711-1 à L. 711-7 du Code de la construction et de l'habitation, créés par l'art. 52 de la loi ALUR. L'art. 18 de la loi de 1965 confie au syndic les démarches prévues aux art. L. 711-1 à L. 711-6.
 
 Plateforme : https://www.registre-coproprietes.gouv.fr
 
@@ -107,4 +106,4 @@ Données à déclarer :
 - Identité du syndicat (nom, adresse, date de création du syndicat, nombre de lots)
 - Identité du syndic
 - Données financières (budget, charges, dettes fournisseurs, impayés)
-- Mise à jour annuelle obligatoire (dans les 2 mois suivant l'AG)
+- Mise à jour annuelle obligatoire dans les 2 mois suivant l'AG ayant approuvé les comptes (art. R. 711-10 CCH)

--- a/syndic/references/transition.md
+++ b/syndic/references/transition.md
@@ -164,7 +164,7 @@ SI REFUS OU RETARD DE TRANSMISSION :
 PHASE 6 — MISE EN PLACE (dans le mois suivant la prise de fonction)
 ══════════════════════════════════════════════════════════════
 
-- [ ] Ouvrir le compte bancaire séparé au nom du syndicat (art. 26-7 décret 1967)
+- [ ] Ouvrir le compte bancaire séparé au nom du syndicat (art. 18, II loi 1965)
 - [ ] Transférer les fonds depuis l'ancien compte
 - [ ] Informer tous les fournisseurs :
       • Nouveau contact syndic (nom, téléphone, email)
@@ -174,7 +174,7 @@ PHASE 6 — MISE EN PLACE (dans le mois suivant la prise de fonction)
       • Coordonnées du nouveau syndic
       • Nouvelles modalités de paiement des charges
       • IBAN pour les virements
-- [ ] Mettre à jour l'immatriculation RNC (dans les 2 mois, art. 55 loi 1965)
+- [ ] Mettre à jour l'immatriculation RNC (dans les 2 mois suivant l'AG ayant approuvé les comptes, art. R. 711-10 CCH)
       → https://www.registre-coproprietes.gouv.fr
 - [ ] Reprendre la comptabilité :
       • Rapprochement bancaire au jour du changement
@@ -288,7 +288,7 @@ Si le syndic sortant ne transmet pas les archives dans le délai de 3 mois :
 
 ### Phase 4 : Mise en place
 
-1. **Ouvrir le compte bancaire séparé** (obligatoire, art. 26-7 décret 1967)
+1. **Ouvrir le compte bancaire séparé** (obligatoire, art. 18, II loi 1965)
    - Compte au nom du syndicat des copropriétaires
    - Signataire : le syndic (ou le président du conseil syndical en coopératif)
 

--- a/syndic/templates/contrat-syndic.md
+++ b/syndic/templates/contrat-syndic.md
@@ -108,7 +108,7 @@ Les frais engagés dans l'exercice de leurs fonctions sont remboursés sur justi
 
 ## Article 6 : Compte bancaire séparé
 
-Conformément à l'article 26-7 du décret du 17 mars 1967, les fonds du syndicat sont déposés sur un compte bancaire séparé, ouvert au nom du syndicat des copropriétaires.
+Conformément à l'article 18, II de la loi du 10 juillet 1965, les fonds du syndicat sont déposés sur un compte bancaire séparé, ouvert au nom du syndicat des copropriétaires.
 
 **Banque** : {{banque}}
 **IBAN** : {{iban}}


### PR DESCRIPTION
## Résumé

- corrige les cinq renvois signalés dans `loi-1965.md`, `assemblee-generale.md` et `calendrier.md`
- aligne les passages connexes sur les bons fondements : convocation de l’AG, signature et notification du PV, mise à jour du RNC
- corrige une erreur répétée sur le compte bancaire séparé (art. 18, II de la loi de 1965)
- met à jour les templates, le skill et les assertions d’eval concernés

## Pourquoi

Plusieurs objets d’articles avaient été intervertis entre la loi du 10 juillet 1965, son décret d’application et le Code de la construction et de l’habitation. Cela pouvait conduire l’agent à fournir un bon conseil avec une mauvaise base légale.

## Vérifications

Les références ont été contrôlées dans les versions en vigueur sur Légifrance, notamment :

- loi de 1965 : art. 14, 14-1, 18, 33 et 42
- décret de 1967 : art. 7, 9, 9-1, 17, 18, 33, 35, 35-2 et 45-1
- CCH : art. L. 711-1 à L. 711-7 et R. 711-10

Contrôles locaux :

- validation JSON de `syndic/evals/evals.json`
- `git diff --check`
- recherche globale des anciennes références fautives dans `syndic/`

Merci à Emmanuel pour le signalement précis et vérifié.