### PR TITLE
feat(comptable): déclaration de TVA CA3 semi-automatique depuis la banque (Qonto)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 evals-workspace/
 evals/.venv/
 evals/uv.lock
+data/declarations-tva/

--- a/company.example.json
+++ b/company.example.json
@@ -24,6 +24,30 @@
     "regime_is": "reel_simplifie",
     "tva_rate": 0.20
   },
+  "vat": {
+    "_comment": "Utilisé par scripts/declaration-tva.js (CA3 réel normal depuis la banque). base_exigibilite: 'encaissements' (défaut services) ou 'debits'. classification: regex sur le libellé des transactions pour la TVA déductible. Voir comptable/references/declaration-tva.md.",
+    "base_exigibilite": "encaissements",
+    "classification": {
+      "exclude": [
+        { "pattern": "NOM_SALARIE", "reason": "salaire net (hors champ TVA)" },
+        { "pattern": "URSSAF|DGFIP", "reason": "taxe / charge sociale (hors champ TVA)" },
+        { "pattern": "NOM_SS_TRAITANT_FRANCHISE", "reason": "franchise en base art. 293 B (0 TVA)" },
+        { "pattern": "ALAN|MUTUELLE", "reason": "assurance / mutuelle exonérée" }
+      ],
+      "intragroup": [
+        { "pattern": "NOM_HOLDING", "reason": "flux intra-groupe / compte courant" }
+      ],
+      "intracom_services": [
+        { "pattern": "INDEED|GOOGLE IRELAND|META", "reason": "service intra-UE (autoliquidation A3 + DES)" }
+      ],
+      "fuel_categories": ["gas_station"],
+      "fuel_patterns": ["TOTAL|ESSO|BP|SHELL"],
+      "fuel_deductible_pct": 1.0,
+      "fee_operation_types": ["qonto_fee"],
+      "fee_patterns": ["^Qonto$"],
+      "estimate_categories": ["hardware_and_equipment", "other_service", "food_and_grocery", "other_expense"]
+    }
+  },
   "banks": [
     {
       "id": "bank-1",

--- a/comptable/SKILL.md
+++ b/comptable/SKILL.md
@@ -170,6 +170,7 @@ Consulter selon le besoin :
 | [references/formats.md](references/formats.md) | **Formats de sortie (écritures, journal JSON, risques)** |
 | [references/pcg.md](references/pcg.md) | Plan Comptable Général : structure des classes |
 | [references/tva.md](references/tva.md) | TVA : régimes, taux, déclarations, intra-UE |
+| [references/declaration-tva.md](references/declaration-tva.md) | **Déclaration CA3 semi-automatique depuis la banque (Qonto → cases CA3)** |
 | [references/taxes.md](references/taxes.md) | IS, IR, CFE, CVAE, autres impôts |
 | [references/legal-forms.md](references/legal-forms.md) | Spécificités par forme juridique |
 | [references/calendar.md](references/calendar.md) | Échéances fiscales et sociales |
@@ -194,6 +195,8 @@ Consulter selon le besoin :
 | `scripts/fetch_company.py <SIREN>` | Recherche info entreprise via API |
 | `scripts/update_data.py` | Vérifier fraîcheur des données et télécharger MAJ |
 | `scripts/calc.js` | Calculs déterministes (CCA, amortissement, IS, acomptes TVA simplifié, prorata) |
+| `scripts/declaration-tva.js --from <YYYY-MM> --to <YYYY-MM>` | **Reconstituer une CA3 (réel normal) depuis Qonto : collectée, déductible, autoliquidation intra-UE, cases CA3, net à payer. Lecture seule, ne télédéclare rien.** Voir [references/declaration-tva.md](references/declaration-tva.md) |
+| `scripts/declaration-tva.js ... --offline <dir>` | Rejouer sur des dumps déjà extraits (transactions.json, client_invoices.json, supplier_invoices.json) |
 | `scripts/generate-statements.js` | Générer Bilan, Compte de résultat, Balance |
 | `scripts/generate-fec.js` | Générer le FEC |
 | `scripts/generate-pdfs.js` | Convertir les états financiers en PDFs |
@@ -213,6 +216,7 @@ Consulter selon le besoin :
 Commandes npm équivalentes :
 - `npm run facture -- --invoice <facture.json>` : générer Factur-X
 - `npm run validate:facture -- --invoice <facture.json>` : valider
+- `npm run declaration:tva -- --from <YYYY-MM> --to <YYYY-MM>` : reconstituer la CA3 depuis Qonto (brouillon)
 
 Règle de calcul : pour tout calcul chiffré (TVA, IS, amortissement, prorata, CCA), utiliser `node scripts/calc.js` plutôt qu'un calcul mental.
 

--- a/comptable/evals/evals.json
+++ b/comptable/evals/evals.json
@@ -185,6 +185,27 @@
         "L'amende pour défaut de transmission est mentionnée (250 EUR par transmission)",
         "L'échéance est correcte (1er septembre 2027 pour PME/micro)"
       ]
+    },
+    {
+      "id": 11,
+      "name": "declaration-tva-ca3",
+      "prompt": "Prépare la déclaration de TVA (CA3, régime réel normal) de mai 2026 pour DEMO SERVICES SAS à partir de ses données bancaires Qonto. La configuration est dans evals/files/company-demo-tva.json et les extractions Qonto sont dans evals/files/tva-demo/ (transactions.json, client_invoices.json, supplier_invoices.json). Utilise scripts/declaration-tva.js en mode --offline. Donne les cases CA3 et le net à payer.",
+      "expected_output": "Le skill exécute scripts/declaration-tva.js en --offline sur les fixtures et restitue : TVA collectée 300 €, déductible certaine 34,17 €, autoliquidation intra-UE (base A3 50 €, net 0) et TVA nette à payer 266 €. Il précise que c'est un brouillon à valider avant dépôt.",
+      "files": [
+        "evals/files/company-demo-tva.json",
+        "evals/files/tva-demo/transactions.json",
+        "evals/files/tva-demo/client_invoices.json",
+        "evals/files/tva-demo/supplier_invoices.json"
+      ],
+      "assertions": [
+        "La TVA collectée du mois est 300 € (factures clients payées en mai, base encaissements)",
+        "La TVA déductible certaine est 34,17 € (facture fournisseur analysée + carburant + frais bancaires)",
+        "Les services intra-UE (INTLADS) sont autoliquidés en ligne A3 (base 50 €) avec un effet net nul",
+        "Les salaires, l'URSSAF et le flux intra-groupe (HOLDING) sont exclus (0 TVA)",
+        "La TVA nette à payer (case 28) est 266 €",
+        "La dépense sans justificatif (FOURNITURE Z) est signalée comme 'à justifier'",
+        "Le résultat est présenté comme un brouillon à valider avant télédéclaration"
+      ]
     }
   ]
 }

--- a/comptable/evals/files/company-demo-tva.json
+++ b/comptable/evals/files/company-demo-tva.json
@@ -1,0 +1,32 @@
+{
+  "name": "DEMO SERVICES SAS",
+  "legal_form": "SAS",
+  "siren": "111222333",
+  "tax": {
+    "regime_tva": "reel_normal",
+    "regime_is": "reel_normal",
+    "tva_rate": 0.20
+  },
+  "vat": {
+    "base_exigibilite": "encaissements",
+    "classification": {
+      "exclude": [
+        { "pattern": "SALAIRE|DUPONT", "reason": "salaire net (hors champ TVA)" },
+        { "pattern": "URSSAF|DGFIP", "reason": "taxe / charge sociale (hors champ TVA)" },
+        { "pattern": "MUTUELLE", "reason": "assurance exonérée de TVA" }
+      ],
+      "intragroup": [
+        { "pattern": "HOLDING", "reason": "flux intra-groupe / compte courant" }
+      ],
+      "intracom_services": [
+        { "pattern": "INTLADS", "reason": "service intra-UE (autoliquidation A3 + DES)" }
+      ],
+      "fuel_categories": ["gas_station"],
+      "fuel_patterns": ["STATION"],
+      "fuel_deductible_pct": 1.0,
+      "fee_operation_types": ["qonto_fee"],
+      "fee_patterns": ["^Banque$"],
+      "estimate_categories": ["other_expense", "other_service"]
+    }
+  }
+}

--- a/comptable/evals/files/tva-demo/client_invoices.json
+++ b/comptable/evals/files/tva-demo/client_invoices.json
@@ -1,0 +1,5 @@
+[
+  { "number": "F-2026-001", "status": "paid", "issue_date": "2026-04-28", "finalized_at": "2026-04-28T10:00:00Z", "paid_at": "2026-05-06T09:00:00Z", "total_amount": { "value": "1200.00", "currency": "EUR" }, "vat_amount": { "value": "200.00", "currency": "EUR" } },
+  { "number": "F-2026-002", "status": "paid", "issue_date": "2026-05-02", "finalized_at": "2026-05-02T10:00:00Z", "paid_at": "2026-05-20T09:00:00Z", "total_amount": { "value": "600.00", "currency": "EUR" }, "vat_amount": { "value": "100.00", "currency": "EUR" } },
+  { "number": "F-2026-003", "status": "unpaid", "issue_date": "2026-05-25", "finalized_at": "2026-05-25T10:00:00Z", "paid_at": "", "total_amount": { "value": "360.00", "currency": "EUR" }, "vat_amount": { "value": "60.00", "currency": "EUR" } }
+]

--- a/comptable/evals/files/tva-demo/supplier_invoices.json
+++ b/comptable/evals/files/tva-demo/supplier_invoices.json
@@ -1,0 +1,3 @@
+[
+  { "supplier_name": "CLOUD FR SARL", "issue_date": "2026-05-05", "payment_date": "2026-05-06", "status": "paid", "total_amount": { "value": "120.00", "currency": "EUR" }, "total_amount_excluding_taxes": { "value": "100.00", "currency": "EUR" }, "total_tax_amount": { "value": "20.00", "currency": "EUR" }, "matched_transactions_ids": ["t1"] }
+]

--- a/comptable/evals/files/tva-demo/transactions.json
+++ b/comptable/evals/files/tva-demo/transactions.json
@@ -1,0 +1,11 @@
+[
+  { "id": "t5", "side": "debit", "amount": 25.00, "currency": "EUR", "label": "Banque", "category": "fees", "operation_type": "qonto_fee", "settled_at": "2026-05-01T08:00:00Z", "status": "completed" },
+  { "id": "t3", "side": "debit", "amount": 1500.00, "currency": "EUR", "label": "SALAIRE DUPONT", "category": "other_expense", "operation_type": "transfer", "settled_at": "2026-05-02T08:00:00Z", "status": "completed" },
+  { "id": "t1", "side": "debit", "amount": 120.00, "currency": "EUR", "label": "CLOUD FR SARL", "category": "other_service", "operation_type": "card", "settled_at": "2026-05-06T08:00:00Z", "status": "completed" },
+  { "id": "t2", "side": "debit", "amount": 60.00, "currency": "EUR", "label": "STATION SERVICE X", "category": "gas_station", "operation_type": "card", "settled_at": "2026-05-10T08:00:00Z", "status": "completed" },
+  { "id": "t8", "side": "debit", "amount": 500.00, "currency": "EUR", "label": "HOLDING SAS", "category": "other_expense", "operation_type": "transfer", "settled_at": "2026-05-12T08:00:00Z", "status": "completed" },
+  { "id": "t6", "side": "debit", "amount": 50.00, "currency": "EUR", "label": "INTLADS LTD", "category": "other_service", "operation_type": "card", "settled_at": "2026-05-15T08:00:00Z", "status": "completed" },
+  { "id": "t4", "side": "debit", "amount": 300.00, "currency": "EUR", "label": "URSSAF IDF", "category": "tax", "operation_type": "direct_debit", "settled_at": "2026-05-18T08:00:00Z", "status": "completed" },
+  { "id": "t7", "side": "debit", "amount": 90.00, "currency": "EUR", "label": "FOURNITURE Z", "category": "other_expense", "operation_type": "card", "settled_at": "2026-05-20T08:00:00Z", "status": "completed" },
+  { "id": "c1", "side": "credit", "amount": 1200.00, "currency": "EUR", "label": "CLIENT ALPHA", "category": "other_income", "operation_type": "income", "settled_at": "2026-05-06T09:00:00Z", "status": "completed" }
+]

--- a/comptable/references/declaration-tva.md
+++ b/comptable/references/declaration-tva.md
@@ -1,0 +1,117 @@
+# Déclaration de TVA CA3 — reconstitution semi-automatique depuis la banque
+
+Workflow opérationnel pour préparer une **déclaration de TVA CA3 (formulaire 3310-CA3, régime réel
+normal)** à partir du compte bancaire (Qonto), via le script `scripts/declaration-tva.js`.
+
+> **Lecture seule.** Le script ne télédéclare rien et n'écrit rien chez un tiers. La sortie est un
+> **brouillon à valider par un humain** (ou son expert-comptable) avant dépôt sur impots.gouv.fr.
+> Déposer la CA3 et payer la TVA restent des actes à la main de l'utilisateur.
+
+## Quand l'utiliser
+
+« prépare / calcule / reprends la TVA de mai (et juin) », « fais la déclaration de TVA », « la CA3
+du mois dernier », « combien de TVA doit-on payer ce mois-ci ? », reconstituer la TVA d'une période
+passée depuis la banque.
+
+## Méthode
+
+1. **Extraction Qonto** (via `integrations/qonto/fetch.js`) : transactions `completed` de la
+   période, factures clients, factures fournisseurs.
+2. **TVA collectée** sur la base retenue :
+   - **encaissements** (défaut pour les prestations de services, art. 269-2 CGI) → TVA des factures
+     clients **payées** dans le mois (`paid_at`) ;
+   - **débits** (uniquement si l'option a été exercée, mention « TVA d'après les débits » sur les
+     factures) → TVA des factures **émises** (`finalized_at`).
+3. **TVA déductible**, **ancrée sur les décaissements** (une TVA par transaction, pas de double
+   compte) : chaque dépense est rapprochée de la **facture fournisseur analysée par Qonto**
+   (`total_tax_amount`), par id de transaction puis par montant+date ; les postes hors factures
+   (carburant, frais bancaires) sont ajoutés depuis la transaction ; les dépenses sans justificatif
+   sont marquées **« à justifier »**.
+4. **Exclusions à 0** (hors champ TVA) : salaires, charges sociales (URSSAF), impôts/taxes (DGFiP),
+   sous-traitants en franchise (art. 293 B), assurances/mutuelles, flux intra-groupe / compte
+   courant d'associé.
+5. **Autoliquidation des services intra-UE reçus** (art. 259-1° et 283-2 CGI) : base HT en
+   **ligne A3**, TVA autoliquidée ajoutée en **collectée (08)** ET **déductible (20)** → **net 0** ;
+   penser à la **DES** (déclaration européenne de services).
+
+## Utilisation
+
+```bash
+# 1) activer Qonto dans company.json et définir QONTO_ID / QONTO_API_SECRET (voir integrations/)
+# 2) calculer la CA3 d'une ou plusieurs périodes
+node scripts/declaration-tva.js --from 2026-05 --to 2026-06
+npm run declaration:tva -- --from 2026-05 --to 2026-06 --json
+
+# variante hors-ligne : rejouer sur des dumps déjà extraits
+node scripts/declaration-tva.js --from 2026-05 --to 2026-06 --offline data/transactions
+```
+
+Sortie : un brouillon lisible (cases CA3 + net à payer par mois) + un JSON dans
+`data/declarations-tva/`.
+
+## Configuration (`company.json`, bloc `vat`)
+
+```json
+"tax": { "regime_tva": "reel_normal", "tva_rate": 0.20 },
+"vat": {
+  "base_exigibilite": "encaissements",
+  "classification": {
+    "exclude":            [{ "pattern": "NOM_SALARIE", "reason": "salaire net" }],
+    "intragroup":         [{ "pattern": "NOM_HOLDING", "reason": "compte courant" }],
+    "intracom_services":  [{ "pattern": "INDEED|GOOGLE IRELAND", "reason": "service intra-UE" }],
+    "fuel_categories":    ["gas_station"],
+    "fuel_patterns":      ["TOTAL|ESSO|BP"],
+    "fuel_deductible_pct": 1.0,
+    "fee_operation_types": ["qonto_fee"],
+    "estimate_categories": ["hardware_and_equipment", "other_service", "other_expense"]
+  }
+}
+```
+
+Les `pattern` sont des regex appliquées au libellé des transactions ; à adapter à chaque société
+(noms des salariés, du sous-traitant en franchise, de la holding…). `fuel_deductible_pct` = 1.0 pour
+un véhicule utilitaire au gazole, 0.8 pour l'essence ou un véhicule de tourisme.
+
+## Mapping des cases CA3 (3310-CA3)
+
+Vérifié contre le formulaire et la notice officiels `3310-CA3-SD` (impots.gouv.fr) **et** la
+localisation française d'Odoo (`l10n_fr_account/data/tax_report_data.xml`), mapping de référence
+maintenu.
+
+| Case | Libellé (CA3) | Contenu |
+|------|---------------|---------|
+| **A1 / 01** | Ventes, prestations de services | Base HT taxable (CA du mois sur la base retenue) |
+| **A3** | Achats de prestations de services intracommunautaires | Base HT des services intra-UE reçus (autoliquidation) |
+| **08** | Taux normal 20 % (base / taxe) | base = A1 + A3 ; taxe = 20 % |
+| **09 / 9B** | Taux réduits 5,5 % / 10 % | si opérations à ces taux |
+| **16** | Total de la TVA brute due | somme des taxes dues |
+| **19** | TVA déductible sur immobilisations | achats d'immobilisations |
+| **20** | TVA déductible sur autres biens et services (ABS) | achats courants, sous-traitance, énergie, carburant, honoraires, frais bancaires, **+ TVA autoliquidée** ; **agrège tous les taux** (20/10/5,5 %) |
+| **22** | Report du crédit de la déclaration précédente | = case 27 de la CA3 précédente |
+| **23** | Total TVA déductible | 19 + 20 + 21 + 22 |
+| **28** | TVA nette due | 16 − 23 (si positif) |
+| **32 (AB)** | Total à payer | 28 + taxes assimilées |
+
+> **Attention** : les services intra-UE « généraux » (Indeed, Google Ireland, Meta…) vont en **A3**,
+> **pas** en B2 (qui est réservée aux acquisitions intracommunautaires de **biens**). Odoo confirme :
+> `A3 - Achats de prestations de services intracommunautaires`, `B2 - Acquisitions
+> intracommunautaires`.
+
+## Règles de calcul
+
+- **Arrondi fiscal** : bases et taxes à l'euro le plus proche.
+- **Carburant** : gazole en véhicule utilitaire = 100 % déductible ; gazole en véhicule de tourisme
+  et essence = 80 %.
+- **Frais bancaires** (abonnement + commissions Qonto) : TVA 20 % déductible, rarement présents dans
+  les factures fournisseurs → réintégrés depuis la transaction.
+- **Autoliquidation intra-UE** : nette de 0 si droit à déduction total ; **DES** obligatoire.
+
+## Ce que le script NE gère PAS (déférer à un humain / au reste du skill `comptable`)
+
+- crédit de TVA remboursable (formulaire 3519), report case 27 → 22 entre déclarations ;
+- acquisitions intracommunautaires de **biens** (B2), importations, DEB ;
+- régularisations sur immobilisations, prorata / coefficient de déduction < 100 % ;
+- taux réduits multiples côté **collecté** (le script suppose le taux normal pour les ventes).
+
+Pour le cadre TVA général (régimes, taux, exigibilité, intra-UE), voir
+[references/tva.md](tva.md).

--- a/comptable/references/declaration-tva.md
+++ b/comptable/references/declaration-tva.md
@@ -31,8 +31,9 @@ passée depuis la banque.
    sous-traitants en franchise (art. 293 B), assurances/mutuelles, flux intra-groupe / compte
    courant d'associé.
 5. **Autoliquidation des services intra-UE reçus** (art. 259-1° et 283-2 CGI) : base HT en
-   **ligne A3**, TVA autoliquidée ajoutée en **collectée (08)** ET **déductible (20)** → **net 0** ;
-   penser à la **DES** (déclaration européenne de services).
+   **ligne A3**, TVA autoliquidée ajoutée en **collectée (08)** ET **déductible (20)** → **net 0**.
+   ⚠️ **Pas de DES** dans ce sens : la Déclaration Européenne de Services incombe au *prestataire*
+   qui **rend** le service, pas au preneur qui le reçoit.
 
 ## Utilisation
 
@@ -104,7 +105,8 @@ maintenu.
   et essence = 80 %.
 - **Frais bancaires** (abonnement + commissions Qonto) : TVA 20 % déductible, rarement présents dans
   les factures fournisseurs → réintégrés depuis la transaction.
-- **Autoliquidation intra-UE** : nette de 0 si droit à déduction total ; **DES** obligatoire.
+- **Autoliquidation intra-UE (services reçus)** : nette de 0 si droit à déduction total. La **DES**
+  n'est due que si l'entreprise **rend** des services intra-UE, jamais pour ceux qu'elle reçoit.
 
 ## Ce que le script NE gère PAS (déférer à un humain / au reste du skill `comptable`)
 

--- a/comptable/references/tva.md
+++ b/comptable/references/tva.md
@@ -136,8 +136,10 @@ Prestation service intra-UE 500€:
 ```
 
 **Déclaration:**
-- Ligne 2A de la CA3: services
-- DES (Déclaration Européenne de Services)
+- **Service REÇU** (vous êtes le preneur) : autoliquidation sur la **CA3 ligne A3** (base HT) + TVA en lignes 08 puis 20, net 0. **Pas de DES** — c'est le prestataire étranger qui souscrit l'état récapitulatif dans son pays.
+- **Service RENDU** (vous êtes le prestataire à un client assujetti d'un autre État membre) : exonéré (TVA due chez le preneur, art. 259-1°) + **DES** obligatoire (Déclaration Européenne de Services, art. 289 B CGI) sur pro.douane.gouv.fr.
+
+> La **DES est déposée par le prestataire qui *rend* le service**, jamais par celui qui le reçoit. Pour un simple achat de service intra-UE (SaaS, publicité en ligne…), il n'y a donc qu'une autoliquidation en A3, sans DES.
 
 ---
 

--- a/integrations/qonto/fetch.js
+++ b/integrations/qonto/fetch.js
@@ -271,13 +271,61 @@ async function main() {
   console.log('\nTerminé !');
 }
 
+/**
+ * Pagination générique pour les endpoints de facturation Qonto
+ * (client_invoices, supplier_invoices).
+ * @param {string} endpoint - Nom de l'endpoint v2 (ex. 'client_invoices')
+ * @param {string} listKey - Clé du tableau dans la réponse
+ * @param {object} params - Filtres additionnels
+ * @returns {Array} Tous les éléments paginés
+ */
+async function paginate(endpoint, listKey, params = {}) {
+  const headers = await getHeaders();
+  const out = [];
+  let page = 1;
+  // Garde-fou : borne dure à 200 pages pour éviter toute boucle infinie
+  while (page <= 200) {
+    const qs = new URLSearchParams({ ...params, per_page: '100', current_page: String(page) });
+    const res = await fetch(`${QONTO_API_BASE}/${endpoint}?${qs}`, { headers });
+    if (!res.ok) {
+      throw new Error(`Erreur API Qonto (${endpoint}) : ${res.status} ${res.statusText}`);
+    }
+    const data = await res.json();
+    out.push(...(data[listKey] || []));
+    const next = data.meta && data.meta.next_page;
+    if (!next || next === page) break;
+    page = next;
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+  return out;
+}
+
+/**
+ * Récupère toutes les factures clients émises (base de la TVA collectée).
+ * Chaque facture porte `vat_amount`, `total_amount`, `issue_date`, `finalized_at`, `paid_at`.
+ */
+async function getAllClientInvoices(params = {}) {
+  return paginate('client_invoices', 'client_invoices', params);
+}
+
+/**
+ * Récupère toutes les factures fournisseurs (base de la TVA déductible).
+ * Chaque facture porte `total_tax_amount`, `total_amount`, `payment_date`, `matched_transactions_ids`.
+ */
+async function getAllSupplierInvoices(params = {}) {
+  return paginate('supplier_invoices', 'supplier_invoices', params);
+}
+
 module.exports = {
   getOrganization,
   getTransactions,
   getAllTransactions,
   transformTransaction,
   buildTransactionsParams,
-  findBalanceDiscontinuities
+  findBalanceDiscontinuities,
+  paginate,
+  getAllClientInvoices,
+  getAllSupplierInvoices
 };
 
 if (require.main === module) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "closing": "node scripts/generate-fec.js && node scripts/generate-statements.js && node scripts/generate-pdfs.js",
     "facture": "node scripts/generate-facturx.js",
     "validate:facture": "node scripts/validate-facture.js",
+    "declaration:tva": "node scripts/declaration-tva.js",
     "fetch": "node integrations/stripe/fetch.js; node integrations/qonto/fetch.js",
     "fetch:qonto": "node integrations/qonto/fetch.js",
     "test:qonto": "node integrations/qonto/fetch.test.js",

--- a/scripts/declaration-tva.js
+++ b/scripts/declaration-tva.js
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+/**
+ * Déclaration de TVA CA3 (régime réel normal) — reconstitution semi-automatique depuis la banque.
+ *
+ * Calcule, pour une ou plusieurs périodes mensuelles :
+ *   - la TVA COLLECTÉE (base encaissements par défaut pour les services, ou débits) à partir des
+ *     factures clients Qonto ;
+ *   - la TVA DÉDUCTIBLE, ancrée sur les décaissements (1 TVA par transaction), rapprochée des
+ *     factures fournisseurs analysées par Qonto, complétée par les postes hors factures
+ *     (carburant, frais bancaires) et une liste « à justifier » ;
+ *   - l'autoliquidation des services intra-UE reçus (net 0, ligne A3 + DES) ;
+ *   - les cases CA3 (01, A3, 08, 16, 19, 20, 22, 23, 28) et un net à payer par mois.
+ *
+ * LECTURE SEULE. Ne télédéclare rien, n'écrit rien chez un tiers. La sortie est un BROUILLON à
+ * faire valider par un humain (ou son expert-comptable) avant dépôt sur impots.gouv.fr.
+ *
+ * Config : lit `company.json` (bloc `vat` + `tax.tva_rate` + `tax.regime_tva`). Voir
+ * `company.example.json` et `comptable/references/declaration-tva.md`.
+ *
+ * Usage :
+ *   node scripts/declaration-tva.js --from 2026-05 --to 2026-06
+ *   node scripts/declaration-tva.js --from 2026-05 --to 2026-06 --offline data/transactions
+ *   npm run declaration:tva -- --from 2026-05 --to 2026-06
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ----------------------------- utilitaires argent (centimes entiers) -----------------------------
+function cents(x) {
+  if (x === null || x === undefined) return 0;
+  if (typeof x === 'object') x = x.value; // {value, currency}
+  return Math.round(parseFloat(x) * 100);
+}
+function eur(c) { return (c / 100).toFixed(2); }
+function round0(c) { return Math.round(c / 100); } // arrondi fiscal à l'euro
+function monthOf(d) { return d ? String(d).slice(0, 7) : null; }
+function dateOnly(d) { return d ? String(d).slice(0, 10) : null; }
+function daysBetween(a, b) {
+  return Math.abs((new Date(a) - new Date(b)) / 86400000);
+}
+
+// ----------------------------- config -----------------------------
+function loadCompany(configPath) {
+  const p = configPath
+    ? path.resolve(configPath)
+    : path.join(__dirname, '..', 'company.json');
+  if (!fs.existsSync(p)) {
+    throw new Error(
+      `company.json introuvable (${p}). Copiez company.example.json et renseignez le bloc "vat".`
+    );
+  }
+  return JSON.parse(fs.readFileSync(p, 'utf-8'));
+}
+
+function compileRules(list) {
+  return (list || []).map(r => ({ re: new RegExp(r.pattern, 'i'), reason: r.reason || '' }));
+}
+
+// ----------------------------- moteur -----------------------------
+class VatEngine {
+  constructor(company) {
+    const vat = company.vat || {};
+    const tax = company.tax || {};
+    this.rate = tax.tva_rate != null ? Number(tax.tva_rate) : 0.20;
+    this.base = vat.base_exigibilite || 'encaissements'; // encaissements | debits
+    const c = vat.classification || {};
+    this.exclude = compileRules(c.exclude);
+    this.intragroup = compileRules(c.intragroup);
+    this.intracom = compileRules(c.intracom_services);
+    this.fuelCats = new Set(c.fuel_categories || ['gas_station']);
+    this.fuelPatterns = (c.fuel_patterns || ['TOTAL']).map(p => new RegExp(p, 'i'));
+    this.fuelPct = c.fuel_deductible_pct != null ? Number(c.fuel_deductible_pct) : 1.0;
+    this.feeOps = new Set(c.fee_operation_types || ['qonto_fee']);
+    this.feePatterns = (c.fee_patterns || ['^Qonto$']).map(p => new RegExp(p, 'i'));
+    this.estimateCats = new Set(
+      c.estimate_categories || ['hardware_and_equipment', 'other_service', 'food_and_grocery', 'other_expense']
+    );
+  }
+
+  // VAT (centimes) d'un TTC pour un taux donné : TTC - TTC/(1+taux)
+  vatFromTtc(ttcCents, rate) {
+    return Math.round(ttcCents - ttcCents / (1 + rate));
+  }
+
+  // Facture fournisseur analysée rapprochée d'un décaissement (id natif puis montant+date)
+  matchSupplier(tx, supplierInvoices) {
+    const amt = cents(tx.amount);
+    const sdate = tx.settled_at;
+    let best = null;
+    for (const s of supplierInvoices) {
+      if ((s.matched_transactions_ids || []).includes(tx.id)) {
+        if (!best || cents(s.total_tax_amount) > cents(best.total_tax_amount)) best = s;
+      }
+    }
+    if (best) return best;
+    for (const s of supplierInvoices) {
+      if (Math.abs(cents(s.total_amount) - amt) > 2) continue;
+      const pd = s.payment_date || s.issue_date;
+      if (pd && sdate && daysBetween(pd, sdate) > 7) continue;
+      if (!best || cents(s.total_tax_amount) > cents(best.total_tax_amount)) best = s;
+    }
+    return best;
+  }
+
+  // Classe une dépense → { vat (centimes), reason, status: certain|a_justifier|auto|exclu }
+  classifyExpense(tx, supplierInvoices) {
+    const label = tx.label || '';
+    const cat = tx.category;
+    const op = tx.operation_type;
+    const amt = cents(tx.amount);
+    for (const r of this.intracom) if (r.re.test(label)) return { vat: 0, reason: r.reason, status: 'auto' };
+    for (const r of this.intragroup) {
+      if (r.re.test(label)) {
+        const s = this.matchSupplier(tx, supplierInvoices);
+        if (s && cents(s.total_tax_amount) > 0) {
+          return { vat: cents(s.total_tax_amount), reason: 'facture intra-groupe (TVA analysée)', status: 'certain' };
+        }
+        return { vat: 0, reason: r.reason + ' (0 TVA)', status: 'exclu' };
+      }
+    }
+    for (const r of this.exclude) if (r.re.test(label)) return { vat: 0, reason: r.reason, status: 'exclu' };
+    if (cat === 'tax') return { vat: 0, reason: 'taxe (hors champ TVA)', status: 'exclu' };
+    const s = this.matchSupplier(tx, supplierInvoices);
+    if (s) {
+      return {
+        vat: cents(s.total_tax_amount),
+        reason: `facture fourn. ${(s.supplier_name || '').slice(0, 22)}`,
+        status: 'certain'
+      };
+    }
+    if (this.fuelCats.has(cat) || this.fuelPatterns.some(p => p.test(label))) {
+      return {
+        vat: Math.round(this.vatFromTtc(amt, this.rate) * this.fuelPct),
+        reason: `carburant (${Math.round(this.fuelPct * 100)}% déd.)`,
+        status: 'certain'
+      };
+    }
+    if (this.feeOps.has(op) || this.feePatterns.some(p => p.test(label))) {
+      return { vat: this.vatFromTtc(amt, this.rate), reason: 'frais bancaires', status: 'certain' };
+    }
+    if (amt > 0 && this.estimateCats.has(cat)) {
+      return {
+        vat: this.vatFromTtc(amt, this.rate),
+        reason: `carte/autre ${cat} — TVA estimée ${Math.round(this.rate * 100)}% (JUSTIFICATIF À FOURNIR)`,
+        status: 'a_justifier'
+      };
+    }
+    return { vat: 0, reason: `non classé (${cat})`, status: 'exclu' };
+  }
+
+  collectedForMonth(clientInvoices, month) {
+    let ttc = 0, vat = 0;
+    const lines = [];
+    for (const c of clientInvoices) {
+      if (c.status === 'draft') continue;
+      const key = this.base === 'encaissements'
+        ? monthOf(c.paid_at)
+        : monthOf(c.finalized_at || c.issue_date);
+      if (key !== month) continue;
+      ttc += cents(c.total_amount);
+      vat += cents(c.vat_amount);
+      lines.push(c);
+    }
+    return { htCents: ttc - vat, vatCents: vat, ttcCents: ttc, lines };
+  }
+
+  run(months, transactions, clientInvoices, supplierInvoices) {
+    const tx = transactions.filter(t => t.status === 'completed');
+    const out = {};
+    for (const month of months) {
+      const coll = this.collectedForMonth(clientInvoices, month);
+      let certain = 0, aJustifier = 0, autoHt = 0;
+      const linesC = [], linesA = [];
+      const debits = tx
+        .filter(t => t.side === 'debit' && monthOf(t.settled_at) === month)
+        .sort((a, b) => String(a.settled_at).localeCompare(String(b.settled_at)));
+      for (const t of debits) {
+        const r = this.classifyExpense(t, supplierInvoices);
+        if (r.status === 'auto') autoHt += cents(t.amount);
+        else if (r.status === 'certain' && r.vat > 0) { certain += r.vat; linesC.push({ t, vat: r.vat, reason: r.reason }); }
+        else if (r.status === 'a_justifier') { aJustifier += r.vat; linesA.push({ t, vat: r.vat, reason: r.reason }); }
+      }
+      const autoVat = Math.round(autoHt * this.rate);
+      out[month] = {
+        htCents: coll.htCents, vatCents: coll.vatCents, ttcCents: coll.ttcCents,
+        certainCents: certain, aJustifierCents: aJustifier,
+        autoHtCents: autoHt, autoVatCents: autoVat,
+        netCents: coll.vatCents - certain,
+        linesC, linesA, invoices: coll.lines
+      };
+    }
+    return out;
+  }
+}
+
+// ----------------------------- rendu CA3 -----------------------------
+function ca3Boxes(R) {
+  const base08 = R.htCents + R.autoHtCents;
+  const tvaBrute = R.vatCents + R.autoVatCents;
+  const ded = R.certainCents + R.autoVatCents;
+  return {
+    '01_base_ht_ventes_prestations': round0(R.htCents),
+    'A3_base_ht_services_intra_ue': round0(R.autoHtCents),
+    '08_base_taux_normal': round0(base08),
+    '08_tva_due': round0(tvaBrute),
+    '16_tva_brute_due': round0(tvaBrute),
+    '19_deductible_immobilisations': 0,
+    '20_deductible_abs': round0(ded),
+    '22_report_credit_precedent': 0,
+    '23_deductible_total': round0(ded),
+    '28_tva_nette_due': round0(tvaBrute - ded),
+    '32_total_a_payer': round0(tvaBrute - ded)
+  };
+}
+
+function renderText(company, months, results, engine) {
+  const L = [];
+  L.push(`DÉCLARATION DE TVA — ${company.name || '—'} — régime ${((company.tax || {}).regime_tva) || 'réel normal'} / base ${engine.base}`);
+  L.push(`taux normal ${Math.round(engine.rate * 100)}%  ·  SIREN ${company.siren || '—'}`);
+  L.push(`⚠️  BROUILLON — à valider par un humain avant dépôt. Rien n'est télédéclaré.`);
+  for (const month of months) {
+    const R = results[month];
+    const c = ca3Boxes(R);
+    L.push(`\n${'='.repeat(64)}\n  ${month}\n${'='.repeat(64)}`);
+    L.push(`  COLLECTÉE (base ${engine.base}): HT ${eur(R.htCents)} | TVA ${eur(R.vatCents)} | TTC ${eur(R.ttcCents)}`);
+    L.push(`  DÉDUCTIBLE CERTAINE: ${eur(R.certainCents)}`);
+    for (const x of R.linesC) {
+      L.push(`      · ${dateOnly(x.t.settled_at)}  TVA ${eur(x.vat).padStart(8)}  ${(x.t.label || '').slice(0, 20).padEnd(20)} ${x.reason}`);
+    }
+    if (R.linesA.length) {
+      L.push(`  DÉDUCTIBLE À JUSTIFIER (récupérer le justificatif): ${eur(R.aJustifierCents)}`);
+      for (const x of R.linesA) {
+        L.push(`      ? ${dateOnly(x.t.settled_at)}  TVA~${eur(x.vat).padStart(7)}  ${(x.t.label || '').slice(0, 20).padEnd(20)} (TTC ${eur(cents(x.t.amount))})`);
+      }
+    }
+    if (R.autoHtCents > 0) {
+      L.push(`  AUTOLIQ. services intra-UE: base A3 ${eur(R.autoHtCents)} → TVA ${eur(R.autoVatCents)} (collectée+déductible, net 0) + DES à déposer`);
+    }
+    L.push(`  ── CASES CA3 (arrondies €) ──`);
+    L.push(`     01 ${String(c['01_base_ht_ventes_prestations']).padStart(7)}  | A3 ${String(c['A3_base_ht_services_intra_ue']).padStart(6)}`);
+    L.push(`     08 base ${String(c['08_base_taux_normal']).padStart(7)}  → TVA due ${String(c['08_tva_due']).padStart(6)}   16 ${String(c['16_tva_brute_due']).padStart(6)}`);
+    L.push(`     19 ${String(c['19_deductible_immobilisations']).padStart(4)}  20 ${String(c['20_deductible_abs']).padStart(6)}  22 ${String(c['22_report_credit_precedent']).padStart(4)}  23 ${String(c['23_deductible_total']).padStart(6)}`);
+    L.push(`     >>> 28/32 TVA NETTE À PAYER : ${c['28_tva_nette_due']} €`);
+    if (R.aJustifierCents > 0) {
+      L.push(`         (si tous justificatifs validés : ~ ${round0(R.netCents - R.aJustifierCents)} €)`);
+    }
+  }
+  return L.join('\n');
+}
+
+// ----------------------------- périodes -----------------------------
+function monthsBetween(from, to) {
+  let [y, m] = [parseInt(from.slice(0, 4), 10), parseInt(from.slice(5, 7), 10)];
+  const [ye, me] = [parseInt(to.slice(0, 4), 10), parseInt(to.slice(5, 7), 10)];
+  const out = [];
+  while (y < ye || (y === ye && m <= me)) {
+    out.push(`${y}-${String(m).padStart(2, '0')}`);
+    m++; if (m > 12) { m = 1; y++; }
+  }
+  return out;
+}
+
+// ----------------------------- CLI -----------------------------
+function parseArgs(argv) {
+  const a = { from: null, to: null, offline: null, config: null, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--from') a.from = argv[++i];
+    else if (argv[i] === '--to') a.to = argv[++i];
+    else if (argv[i] === '--offline') a.offline = argv[++i];
+    else if (argv[i] === '--config') a.config = argv[++i];
+    else if (argv[i] === '--json') a.json = true;
+  }
+  return a;
+}
+
+async function loadData(company, months, offline) {
+  if (offline) {
+    const d = path.resolve(offline);
+    const read = f => JSON.parse(fs.readFileSync(path.join(d, f), 'utf-8'));
+    return {
+      transactions: read('transactions.json'),
+      clientInvoices: read('client_invoices.json'),
+      supplierInvoices: read('supplier_invoices.json')
+    };
+  }
+  const qonto = require(path.join(__dirname, '..', 'integrations', 'qonto', 'fetch.js'));
+  const org = (await qonto.getOrganization()).organization;
+  const iban = (company.vat && company.vat.qonto_iban) || org.bank_accounts[0].iban;
+  const from = `${months[0]}-01T00:00:00.000Z`;
+  let [y, m] = [parseInt(months[months.length - 1].slice(0, 4), 10), parseInt(months[months.length - 1].slice(5, 7), 10)];
+  m++; if (m > 12) { m = 1; y++; }
+  const to = `${y}-${String(m).padStart(2, '0')}-01T00:00:00.000Z`;
+  const transactions = await qonto.getAllTransactions(iban, { settled_at_from: from, settled_at_to: to });
+  const clientInvoices = await qonto.getAllClientInvoices();
+  const supplierInvoices = await qonto.getAllSupplierInvoices();
+  return { transactions, clientInvoices, supplierInvoices };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.from || !args.to) {
+    console.error('Usage : node scripts/declaration-tva.js --from YYYY-MM --to YYYY-MM [--offline <dir>] [--config <company.json>] [--json]');
+    process.exit(1);
+  }
+  const company = loadCompany(args.config);
+  const months = monthsBetween(args.from, args.to);
+  const { transactions, clientInvoices, supplierInvoices } = await loadData(company, months, args.offline);
+  const engine = new VatEngine(company);
+  const results = engine.run(months, transactions, clientInvoices, supplierInvoices);
+
+  console.log(renderText(company, months, results, engine));
+
+  const payload = {
+    entity: company.name, base: engine.base,
+    months: Object.fromEntries(months.map(mo => [mo, ca3Boxes(results[mo])]))
+  };
+  if (args.json) console.log('\n--- CA3 JSON ---\n' + JSON.stringify(payload, null, 2));
+
+  const outDir = path.join(__dirname, '..', 'data', 'declarations-tva');
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, `ca3-${args.from}_${args.to}.json`), JSON.stringify(payload, null, 2));
+  console.log(`\n[écrit] data/declarations-tva/ca3-${args.from}_${args.to}.json`);
+}
+
+module.exports = { VatEngine, ca3Boxes, monthsBetween, cents };
+
+if (require.main === module) {
+  main().catch(err => { console.error('Erreur :', err.message); process.exit(1); });
+}

--- a/scripts/declaration-tva.js
+++ b/scripts/declaration-tva.js
@@ -8,7 +8,7 @@
  *   - la TVA DÉDUCTIBLE, ancrée sur les décaissements (1 TVA par transaction), rapprochée des
  *     factures fournisseurs analysées par Qonto, complétée par les postes hors factures
  *     (carburant, frais bancaires) et une liste « à justifier » ;
- *   - l'autoliquidation des services intra-UE reçus (net 0, ligne A3 + DES) ;
+ *   - l'autoliquidation des services intra-UE reçus (net 0, ligne A3 ; pas de DES côté preneur) ;
  *   - les cases CA3 (01, A3, 08, 16, 19, 20, 22, 23, 28) et un net à payer par mois.
  *
  * LECTURE SEULE. Ne télédéclare rien, n'écrit rien chez un tiers. La sortie est un BROUILLON à
@@ -236,7 +236,7 @@ function renderText(company, months, results, engine) {
       }
     }
     if (R.autoHtCents > 0) {
-      L.push(`  AUTOLIQ. services intra-UE: base A3 ${eur(R.autoHtCents)} → TVA ${eur(R.autoVatCents)} (collectée+déductible, net 0) + DES à déposer`);
+      L.push(`  AUTOLIQ. services intra-UE reçus: base A3 ${eur(R.autoHtCents)} → TVA ${eur(R.autoVatCents)} (collectée+déductible, net 0). Pas de DES (obligation du prestataire, pas du preneur).`);
     }
     L.push(`  ── CASES CA3 (arrondies €) ──`);
     L.push(`     01 ${String(c['01_base_ht_ventes_prestations']).padStart(7)}  | A3 ${String(c['A3_base_ht_services_intra_ue']).padStart(6)}`);


### PR DESCRIPTION
## Résumé

Ajoute la **reconstitution d'une déclaration de TVA CA3** (régime réel normal, `3310-CA3`) à partir du compte **Qonto** : TVA collectée, TVA déductible, autoliquidation des services intra-UE et cases CA3 prêtes à reporter.

**Aligné sur la doctrine `CONTRIBUTING.md` « skill = métier, pas outil »** : ce n'est **pas** un nouveau skill (la déclaration de TVA n'est pas un métier). C'est une **brique du `comptable`** — un script partagé + une référence + un câblage dans son `SKILL.md`, qui réutilise l'intégration Qonto existante.

## Contenu

| Fichier | Rôle |
|---|---|
| `scripts/declaration-tva.js` | Moteur : collectée (encaissements/débits) + déductible **ancrée sur les décaissements** (rapprochement factures fournisseurs analysées + carburant + frais bancaires + « à justifier ») + **autoliquidation intra-UE** (ligne A3, net 0) + cases CA3 (01, A3, 08, 16, 19, 20, 22, 23, 28). Calcul en centimes entiers. |
| `integrations/qonto/fetch.js` | Ajout `getAllClientInvoices` / `getAllSupplierInvoices` (pagination). **Additif, rétro-compatible.** |
| `comptable/references/declaration-tva.md` | Workflow + mapping CA3, **validé contre la notice officielle `3310-CA3-SD` et la localisation Odoo `l10n_fr`**. |
| `company.example.json` | Bloc `vat` (base d'exigibilité + règles de classement regex). |
| `comptable/SKILL.md`, `package.json` | Câblage (référence, table des scripts, `npm run declaration:tva`). |
| `comptable/evals/` | Cas 11 + fixtures **anonymisées** (`DEMO SERVICES SAS`). |

## Sécurité / périmètre

- **Lecture seule.** Le script ne télédéclare rien et n'écrit rien chez un tiers. La sortie est un **brouillon à valider par un humain** avant dépôt sur impots.gouv.fr.
- Il **remonte ses hypothèses** (base encaissements/débits, report de crédit case 22, % déductible du carburant, postes « à justifier », autoliquidation + DES).
- Hors périmètre (déféré au reste du `comptable` / à un humain) : crédit de TVA remboursable, acquisitions intra-UE de biens, régularisations sur immobilisations, prorata < 100 %.

## Test

```bash
node scripts/declaration-tva.js --from 2026-05 --to 2026-05 \
  --config comptable/evals/files/company-demo-tva.json \
  --offline comptable/evals/files/tva-demo
# => TVA collectée 300 €, déductible certaine 34,17 €, autoliq A3 50 € (net 0), NET À PAYER 266 €
```

`node --check` OK sur les deux fichiers JS ; tous les JSON valident.

## Notes

- Le connecteur Qonto extrait aussi désormais `client_invoices` / `supplier_invoices`, utiles au-delà de la TVA (rapprochement, contrôle des pièces).
- Le mapping CA3 croise 2 sources indépendantes (notice DGFiP + Odoo `l10n_fr`) — notamment : services intra-UE reçus en **A3** (pas B2, réservée aux biens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)