### PR TITLE
feat(integrations): add Pennylane transaction fetcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,7 @@ STRIPE_SECRET=sk_live_...
 # Si Stripe Connect (une cle plateforme pour tous les sous-comptes) :
 # STRIPE_PLATFORM_SECRET=sk_live_...
 # Les stripe_account_id (acct_xxx) se configurent dans company.json
+
+# Pennylane (transactions bancaires via l'API Company v2)
+# Token Company avec le scope transactions:readonly
+PENNYLANE_API_TOKEN=votre-token-company

--- a/README.md
+++ b/README.md
@@ -135,17 +135,18 @@ Les 4 skills s'enchaînent pour couvrir tout le cycle comptable :
 
 ---
 
-## Intégrations (Qonto, Stripe)
+## Intégrations (Qonto, Stripe, Pennylane)
 
 Des connecteurs pour récupérer automatiquement les transactions bancaires et les paiements. Configuration dans `company.json`, clés API en variables d'environnement.
 
 ```bash
-npm run fetch          # Récupère Qonto + Stripe
-npm run fetch:qonto    # Qonto seulement
-npm run fetch:stripe   # Stripe seulement
+npm run fetch           # Récupère Qonto + Stripe
+npm run fetch:qonto     # Qonto seulement
+npm run fetch:stripe    # Stripe seulement
+npm run fetch:pennylane # Transactions bancaires Pennylane seulement
 ```
 
-Supporte plusieurs comptes Stripe et Stripe Connect. Voir `integrations/` pour le détail de la configuration.
+Supporte plusieurs comptes Stripe, Stripe Connect et les transactions bancaires Pennylane. Voir `integrations/` pour le détail de la configuration.
 
 ---
 

--- a/company.example.json
+++ b/company.example.json
@@ -36,6 +36,10 @@
     "enabled": false,
     "_comment": "Mettre enabled a true si vous utilisez Qonto. Env vars: QONTO_ID, QONTO_API_SECRET"
   },
+  "pennylane": {
+    "enabled": false,
+    "_comment": "Mettre enabled a true si vous utilisez Pennylane. Env var: PENNYLANE_API_TOKEN (scope transactions:readonly)"
+  },
   "stripe_accounts": [
     {
       "id": "main",

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -8,6 +8,7 @@ Connecteurs pour récupérer automatiquement les transactions bancaires et les o
 |------------|-------------|-------------------|
 | [Qonto](qonto/) | Transactions bancaires via l'API Qonto | `QONTO_ID`, `QONTO_API_SECRET` |
 | [Stripe](stripe/) | Charges, payouts, fees via l'API Stripe | Variable par compte (configurable) |
+| [Pennylane](pennylane/) | Transactions bancaires via l'API Company v2 | `PENNYLANE_API_TOKEN` |
 
 ## Configuration
 
@@ -63,6 +64,27 @@ Tous les sous-comptes peuvent partager la même clé plateforme (`env_key`). Le 
 
 Vous pouvez mixer les deux modes (comptes séparés + Connect) dans le même tableau.
 
+### Pennylane
+
+Le connecteur couvre volontairement un périmètre réduit : la lecture des transactions
+bancaires déjà agrégées dans Pennylane. Il ne crée ni ne modifie aucune donnée distante.
+
+1. Dans Pennylane, créez un **token API Company**.
+2. Accordez-lui uniquement le scope `transactions:readonly`.
+3. Définissez le token dans votre environnement :
+   ```bash
+   export PENNYLANE_API_TOKEN="votre-token-company"
+   ```
+4. Activez Pennylane dans `company.json` :
+   ```json
+   "pennylane": {
+     "enabled": true
+   }
+   ```
+
+Documentation officielle : [création d'un token Company](https://pennylane.readme.io/docs/generating-my-api-token)
+et [endpoint transactions v2](https://pennylane.readme.io/reference/gettransactions).
+
 ## Usage
 
 ```bash
@@ -78,9 +100,19 @@ npm run fetch:stripe
 # Stripe : filtrer par date et compte
 node integrations/stripe/fetch.js --start 2025-01-01 --end 2025-12-31 --account main
 
+# Pennylane : récupérer et normaliser les transactions bancaires
+npm run fetch:pennylane
+
+# Pennylane : filtrer par date comptable
+node integrations/pennylane/fetch.js --start 2025-01-01 --end 2025-12-31
+
 # Tout récupérer
 npm run fetch
 ```
+
+`npm run fetch` conserve son comportement historique Qonto + Stripe. Pennylane
+n'est appelé que par `fetch:pennylane`, afin qu'aucun accès à ses données ne soit
+déclenché sans demande explicite.
 
 ## Format de sortie
 
@@ -103,6 +135,15 @@ Chaque transaction suit le format standard Paperasse :
 
 Le champ `our_category` est rempli par le skill `comptable` lors de la catégorisation (mappage vendor vers compte PCG).
 
+Pennylane écrit `data/transactions/pennylane.json`. Pour une opération en devise,
+`amount` et `fee` conservent les montants dans `currency`, tandis que `amount_eur`
+et `fee_eur` contiennent leurs contre-valeurs en euros fournies par Pennylane. La
+pagination par curseur est suivie automatiquement.
+
 ## Sécurité
 
 Les clés API ne sont jamais stockées dans le repo. Elles sont lues depuis les variables d'environnement au moment de l'exécution. Ne commitez jamais de fichier `.env` contenant des secrets.
+
+Les fixtures de test Pennylane sont entièrement fictives. Les sorties réelles sous
+`data/transactions/` peuvent contenir des libellés et contreparties sensibles : ne les
+commitez pas.

--- a/integrations/pennylane/fetch.js
+++ b/integrations/pennylane/fetch.js
@@ -1,0 +1,230 @@
+/**
+ * Connecteur Pennylane
+ * Récupère les transactions bancaires depuis l'API Company v2 et les normalise
+ * au format data/transactions/ de Paperasse.
+ *
+ * Variable d'environnement requise :
+ * - PENNYLANE_API_TOKEN (token Company avec le scope transactions:readonly)
+ *
+ * Usage :
+ *   node integrations/pennylane/fetch.js
+ *   node integrations/pennylane/fetch.js --start 2025-01-01 --end 2025-12-31
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PENNYLANE_API_BASE = 'https://app.pennylane.com/api/external/v2';
+
+function getHeaders(token = process.env.PENNYLANE_API_TOKEN) {
+  if (!token) {
+    throw new Error(
+      'Variable PENNYLANE_API_TOKEN manquante.\n' +
+      'Créez un token Company Pennylane avec le scope transactions:readonly.'
+    );
+  }
+
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/json'
+  };
+}
+
+function validateDate(value, flag) {
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(value) ||
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== value
+  ) {
+    throw new Error(`${flag} doit être une date au format YYYY-MM-DD`);
+  }
+}
+
+/**
+ * Construit les paramètres de l'endpoint GET /transactions.
+ * Le filtre Pennylane est un tableau JSON de triplets field/operator/value.
+ */
+function buildTransactionsParams(options = {}) {
+  const params = new URLSearchParams({
+    limit: '100',
+    sort: 'id'
+  });
+  const filters = [];
+
+  if (options.startDate) {
+    validateDate(options.startDate, '--start');
+    filters.push({ field: 'date', operator: 'gteq', value: options.startDate });
+  }
+  if (options.endDate) {
+    validateDate(options.endDate, '--end');
+    filters.push({ field: 'date', operator: 'lteq', value: options.endDate });
+  }
+  if (filters.length > 0) params.set('filter', JSON.stringify(filters));
+  if (options.cursor) params.set('cursor', options.cursor);
+
+  return params;
+}
+
+async function getTransactionsPage(options = {}) {
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('Cette intégration nécessite Node.js 18 ou supérieur (fetch indisponible).');
+  }
+
+  const params = buildTransactionsParams(options);
+  const apiBase = options.apiBase || PENNYLANE_API_BASE;
+  const response = await fetchImpl(`${apiBase}/transactions?${params}`, {
+    headers: getHeaders(options.token)
+  });
+
+  if (!response.ok) {
+    throw new Error(`Erreur API Pennylane : ${response.status} ${response.statusText}`);
+  }
+
+  const page = await response.json();
+  if (!page || !Array.isArray(page.items) || typeof page.has_more !== 'boolean') {
+    throw new Error('Réponse API Pennylane invalide : pagination ou liste de transactions absente.');
+  }
+  return page;
+}
+
+/** Récupère toutes les pages, en protégeant contre un curseur absent ou répété. */
+async function getAllTransactions(options = {}) {
+  const transactions = [];
+  const seenCursors = new Set();
+  let cursor;
+
+  while (true) {
+    const page = await getTransactionsPage({ ...options, cursor });
+    transactions.push(...page.items);
+
+    if (!page.has_more) break;
+    if (!page.next_cursor || page.next_cursor === cursor || seenCursors.has(page.next_cursor)) {
+      throw new Error('Pagination Pennylane invalide : next_cursor absent ou répété.');
+    }
+    seenCursors.add(page.next_cursor);
+    cursor = page.next_cursor;
+  }
+
+  return transactions;
+}
+
+function toNumber(value, field, transactionId, nullable = false) {
+  if (nullable && (value === null || value === undefined || value === '')) return null;
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    throw new Error(`Transaction Pennylane ${transactionId} invalide : ${field} n'est pas un montant.`);
+  }
+  return number;
+}
+
+/** Transforme une transaction Pennylane au format standard Paperasse. */
+function transformTransaction(tx) {
+  if (tx.id === null || tx.id === undefined || !tx.date) {
+    throw new Error('Transaction Pennylane invalide : id ou date absent.');
+  }
+
+  const categoryLabels = Array.isArray(tx.categories)
+    ? tx.categories.map(category => category.label).filter(Boolean)
+    : [];
+
+  return {
+    id: `pennylane-${tx.id}`,
+    source: 'pennylane',
+    account_id: tx.bank_account && tx.bank_account.id != null
+      ? String(tx.bank_account.id)
+      : null,
+    date: tx.date,
+    amount: toNumber(tx.currency_amount, 'currency_amount', tx.id),
+    amount_eur: toNumber(tx.amount, 'amount', tx.id),
+    currency: tx.currency,
+    fee: toNumber(tx.currency_fee, 'currency_fee', tx.id, true),
+    fee_eur: toNumber(tx.fee, 'fee', tx.id, true),
+    label: tx.label || `Transaction Pennylane ${tx.id}`,
+    reference: tx.interbank_code || null,
+    counterparty: tx.label || null,
+    category: categoryLabels[0] || null,
+    categories: categoryLabels,
+    our_category: null,
+    status: tx.archived_at ? 'archived' : 'completed',
+    attachment_required: Boolean(tx.attachment_required),
+    raw: tx
+  };
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let i = 0; i < args.length; i++) {
+    if ((args[i] === '--start' || args[i] === '--end') && !args[i + 1]) {
+      throw new Error(`Valeur manquante pour ${args[i]}`);
+    }
+    if (args[i] === '--start') {
+      options.startDate = args[++i];
+    } else if (args[i] === '--end') {
+      options.endDate = args[++i];
+    } else {
+      throw new Error(`Option inconnue : ${args[i]}`);
+    }
+  }
+
+  if (options.startDate) validateDate(options.startDate, '--start');
+  if (options.endDate) validateDate(options.endDate, '--end');
+  if (options.startDate && options.endDate && options.startDate > options.endDate) {
+    throw new Error('--start doit être antérieure ou égale à --end');
+  }
+  return options;
+}
+
+function isPennylaneDisabled(companyPath) {
+  if (!fs.existsSync(companyPath)) return false;
+  const company = JSON.parse(fs.readFileSync(companyPath, 'utf-8'));
+  return Boolean(company.pennylane && company.pennylane.enabled === false);
+}
+
+function writeTransactionsFile(transactions, outputFile) {
+  const transformed = transactions.map(transformTransaction);
+  fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+  fs.writeFileSync(outputFile, JSON.stringify(transformed, null, 2));
+  return transformed;
+}
+
+async function main() {
+  const companyPath = path.join(__dirname, '../../company.json');
+  if (isPennylaneDisabled(companyPath)) {
+    console.log('Pennylane est désactivé dans company.json. Ignoré.');
+    return;
+  }
+
+  if (!process.env.PENNYLANE_API_TOKEN) {
+    console.log('Variable PENNYLANE_API_TOKEN non définie. Pennylane ignoré.');
+    console.log('Créez un token Company avec le scope transactions:readonly pour activer le connecteur.');
+    return;
+  }
+
+  const options = parseArgs(process.argv.slice(2));
+  console.log('Récupération des transactions Pennylane...');
+  const transactions = await getAllTransactions(options);
+
+  const outputFile = path.join(__dirname, '../../data/transactions/pennylane.json');
+  const transformed = writeTransactionsFile(transactions, outputFile);
+
+  console.log(`${transformed.length} transaction(s) enregistrée(s) dans ${outputFile}`);
+}
+
+module.exports = {
+  buildTransactionsParams,
+  getTransactionsPage,
+  getAllTransactions,
+  transformTransaction,
+  parseArgs,
+  isPennylaneDisabled,
+  writeTransactionsFile
+};
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error('Erreur :', err.message);
+    process.exit(1);
+  });
+}

--- a/integrations/pennylane/fetch.test.js
+++ b/integrations/pennylane/fetch.test.js
@@ -1,0 +1,205 @@
+/**
+ * Tests du connecteur Pennylane. Aucun appel réseau ni donnée réelle.
+ * Exécution : node integrations/pennylane/fetch.test.js
+ */
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const fixture = require('./fixtures/transactions-pages.json');
+const {
+  buildTransactionsParams,
+  getAllTransactions,
+  transformTransaction,
+  parseArgs,
+  isPennylaneDisabled,
+  writeTransactionsFile
+} = require('./fetch');
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log(`  ✓ ${name}`);
+}
+
+async function run() {
+  console.log('buildTransactionsParams');
+
+  await test('encode les dates dans le filtre JSON attendu par Pennylane', () => {
+    const params = buildTransactionsParams({
+      startDate: '2025-01-01',
+      endDate: '2025-12-31',
+      cursor: 'next-page'
+    });
+    assert.strictEqual(params.get('limit'), '100');
+    assert.strictEqual(params.get('sort'), 'id');
+    assert.strictEqual(params.get('cursor'), 'next-page');
+    assert.deepStrictEqual(JSON.parse(params.get('filter')), [
+      { field: 'date', operator: 'gteq', value: '2025-01-01' },
+      { field: 'date', operator: 'lteq', value: '2025-12-31' }
+    ]);
+  });
+
+  await test('rejette une période inversée ou une option inconnue', () => {
+    assert.throws(
+      () => parseArgs(['--start', '2025-12-31', '--end', '2025-01-01']),
+      /--start doit être antérieure/
+    );
+    assert.throws(() => parseArgs(['--start', '2025-02-31']), /format YYYY-MM-DD/);
+    assert.throws(() => parseArgs(['--token', 'secret']), /Option inconnue/);
+  });
+
+  console.log('getAllTransactions');
+
+  await test('suit next_cursor et transmet le token sans le placer dans l’URL', async () => {
+    const requestedUrls = [];
+    const requestedHeaders = [];
+    let pageIndex = 0;
+    const fetchImpl = async (url, init) => {
+      requestedUrls.push(url);
+      requestedHeaders.push(init.headers);
+      const page = fixture.pages[pageIndex++];
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => page
+      };
+    };
+
+    const transactions = await getAllTransactions({
+      token: 'test-token-not-a-secret',
+      fetchImpl,
+      apiBase: 'https://example.invalid/api',
+      startDate: '2025-01-01'
+    });
+
+    assert.strictEqual(transactions.length, 2);
+    assert.strictEqual(requestedUrls.length, 2);
+    assert.match(requestedUrls[1], /cursor=cursor-page-2/);
+    assert.ok(requestedUrls.every(url => !url.includes('test-token-not-a-secret')));
+    assert.ok(requestedHeaders.every(headers => headers.Authorization === 'Bearer test-token-not-a-secret'));
+  });
+
+  await test('échoue si has_more ne fournit pas de nouveau curseur', async () => {
+    const fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ has_more: true, next_cursor: null, items: [] })
+    });
+    await assert.rejects(
+      getAllTransactions({ token: 'test', fetchImpl }),
+      /next_cursor absent ou répété/
+    );
+  });
+
+  await test('échoue aussi si Pennylane répète le même curseur', async () => {
+    let calls = 0;
+    const fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ has_more: true, next_cursor: 'same-cursor', items: [{ id: ++calls }] })
+    });
+    await assert.rejects(
+      getAllTransactions({ token: 'test', fetchImpl }),
+      /next_cursor absent ou répété/
+    );
+    assert.strictEqual(calls, 2);
+  });
+
+  console.log('transformTransaction');
+
+  await test('normalise montant, compte, catégorie et statut au format Paperasse', () => {
+    const normalized = transformTransaction(fixture.pages[0].items[0]);
+    assert.deepStrictEqual(
+      {
+        id: normalized.id,
+        source: normalized.source,
+        account_id: normalized.account_id,
+        date: normalized.date,
+        amount: normalized.amount,
+        amount_eur: normalized.amount_eur,
+        currency: normalized.currency,
+        fee: normalized.fee,
+        fee_eur: normalized.fee_eur,
+        label: normalized.label,
+        reference: normalized.reference,
+        category: normalized.category,
+        categories: normalized.categories,
+        status: normalized.status,
+        attachment_required: normalized.attachment_required,
+        our_category: normalized.our_category
+      },
+      {
+        id: 'pennylane-101',
+        source: 'pennylane',
+        account_id: '53',
+        date: '2025-02-14',
+        amount: -120.5,
+        amount_eur: -120.5,
+        currency: 'EUR',
+        fee: -0.5,
+        fee_eur: -0.5,
+        label: 'VIR SEPA FOURNISSEUR DEMO',
+        reference: 'VIR-DEMO-101',
+        category: 'Hébergement',
+        categories: ['Hébergement'],
+        status: 'completed',
+        attachment_required: true,
+        our_category: null
+      }
+    );
+    assert.strictEqual(normalized.raw.id, 101);
+  });
+
+  await test('préserve le montant en devise et le montant EUR', () => {
+    const normalized = transformTransaction(fixture.pages[1].items[0]);
+    assert.strictEqual(normalized.amount, 50);
+    assert.strictEqual(normalized.amount_eur, 45);
+    assert.strictEqual(normalized.currency, 'USD');
+    assert.strictEqual(normalized.fee, null);
+    assert.strictEqual(normalized.fee_eur, null);
+    assert.strictEqual(normalized.label, 'Transaction Pennylane 102');
+    assert.strictEqual(normalized.status, 'archived');
+  });
+
+  console.log('configuration et écriture');
+
+  await test('respecte enabled=false dans company.json', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'paperasse-pennylane-config-'));
+    const companyPath = path.join(tempDir, 'company.json');
+    try {
+      assert.strictEqual(isPennylaneDisabled(companyPath), false);
+      fs.writeFileSync(companyPath, JSON.stringify({ pennylane: { enabled: false } }));
+      assert.strictEqual(isPennylaneDisabled(companyPath), true);
+      fs.writeFileSync(companyPath, JSON.stringify({ pennylane: { enabled: true } }));
+      assert.strictEqual(isPennylaneDisabled(companyPath), false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  await test('écrit le tableau JSON normalisé complet dans le fichier cible', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'paperasse-pennylane-output-'));
+    const outputFile = path.join(tempDir, 'data', 'transactions', 'pennylane.json');
+    try {
+      const written = writeTransactionsFile([fixture.pages[0].items[0]], outputFile);
+      const saved = JSON.parse(fs.readFileSync(outputFile, 'utf-8'));
+      assert.deepStrictEqual(saved, written);
+      assert.deepStrictEqual(saved[0], transformTransaction(fixture.pages[0].items[0]));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  console.log(`\n${passed} test(s) OK`);
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/integrations/pennylane/fixtures/transactions-pages.json
+++ b/integrations/pennylane/fixtures/transactions-pages.json
@@ -1,0 +1,62 @@
+{
+  "pages": [
+    {
+      "has_more": true,
+      "next_cursor": "cursor-page-2",
+      "items": [
+        {
+          "id": 101,
+          "label": "VIR SEPA FOURNISSEUR DEMO",
+          "attachment_required": true,
+          "date": "2025-02-14",
+          "outstanding_balance": "1275.50",
+          "created_at": "2025-02-14T09:00:00Z",
+          "updated_at": "2025-02-14T09:00:00Z",
+          "archived_at": null,
+          "currency": "EUR",
+          "currency_amount": "-120.50",
+          "amount": "-120.50",
+          "currency_fee": "-0.50",
+          "fee": "-0.50",
+          "journal": { "id": 12 },
+          "bank_account": { "id": 53 },
+          "customer": null,
+          "supplier": { "id": 88 },
+          "categories": [
+            { "id": 4, "label": "Hébergement", "weight": "1.0" }
+          ],
+          "matched_invoices": { "url": "https://example.invalid/matched" },
+          "interbank_code": "VIR-DEMO-101"
+        }
+      ]
+    },
+    {
+      "has_more": false,
+      "next_cursor": null,
+      "items": [
+        {
+          "id": 102,
+          "label": null,
+          "attachment_required": false,
+          "date": "2025-02-15",
+          "outstanding_balance": "1320.50",
+          "created_at": "2025-02-15T09:00:00Z",
+          "updated_at": "2025-02-15T09:00:00Z",
+          "archived_at": "2025-03-01T10:00:00Z",
+          "currency": "USD",
+          "currency_amount": "50.00",
+          "amount": "45.00",
+          "currency_fee": null,
+          "fee": null,
+          "journal": { "id": 12 },
+          "bank_account": { "id": 53 },
+          "customer": { "id": 77 },
+          "supplier": null,
+          "categories": [],
+          "matched_invoices": { "url": "https://example.invalid/matched" },
+          "interbank_code": null
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "fetch": "node integrations/stripe/fetch.js; node integrations/qonto/fetch.js",
     "fetch:qonto": "node integrations/qonto/fetch.js",
     "test:qonto": "node integrations/qonto/fetch.test.js",
-    "fetch:stripe": "node integrations/stripe/fetch.js"
+    "fetch:stripe": "node integrations/stripe/fetch.js",
+    "fetch:pennylane": "node integrations/pennylane/fetch.js",
+    "test:pennylane": "node integrations/pennylane/fetch.test.js"
   },
   "dependencies": {
     "marked": "^15.0.0",


### PR DESCRIPTION
## Résumé

Ajoute une intégration Pennylane autonome sur le modèle explicitement retenu par le mainteneur dans l'issue #18 : un script Node fin et indépendamment révisable qui normalise les transactions vers le format partagé de Paperasse, sans introduire de framework central.

Closes part of #18.

## Fonctionnement

- lit les transactions via l'API Company v2 `GET /transactions` ;
- utilise uniquement le scope minimal `transactions:readonly` ;
- suit la pagination opaque `next_cursor` et détecte les curseurs absents ou répétés ;
- accepte des bornes `--start` et `--end` validées ;
- normalise montant et frais dans la devise d'origine, avec contre-valeurs EUR ;
- écrit `data/transactions/pennylane.json` ;
- ne déclenche aucun appel Pennylane depuis `npm run fetch` : l'accès reste explicite via `npm run fetch:pennylane` ;
- n'effectue aucune mutation distante.

## Configuration

```json
"pennylane": {
  "enabled": true
}
```

```bash
export PENNYLANE_API_TOKEN="..."
npm run fetch:pennylane
```

Le token n'est jamais placé dans l'URL ou dans les fichiers générés. Les données réelles sous `data/transactions/` restent ignorées par Git.

## Validation

- `node --test integrations/pennylane/fetch.test.js` : 9 tests passés ;
- pagination multi-page, curseur manquant/répété, filtres de dates, absence de token dans l'URL ;
- normalisation des montants et frais en devise et en EUR ;
- configuration `enabled=false` et écriture JSON ;
- fixtures entièrement fictives ;
- vérification de l'endpoint, des scopes, champs et règles de pagination contre la documentation officielle Pennylane Company API v2 ;
- `git diff --check` propre.

## Périmètre volontaire

Cette PR suit la direction donnée par le mainteneur le 7 juillet 2026 dans #18 : des scripts `fetch.js` autonomes plutôt qu'une migration de Qonto et Stripe vers une interface centralisée. Elle ne crée ni facture, ni fournisseur, ni écriture comptable dans Pennylane.