### PR TITLE
Corrige le bilan pour les numéros de comptes complétés (455100, 281000…)

### DIFF
--- a/scripts/generate-statements.js
+++ b/scripts/generate-statements.js
@@ -270,20 +270,41 @@ function generateBilan(accounts, company, pcgNames, plData) {
   let totalImmoBrut = 0;
   let totalAmort = 0;
 
-  if (immoAccounts.length > 0) {
-    md += '| **ACTIF IMMOBILISE** | | | |\n';
+  // Les 28x/29x suivent la meme ventilation que le compte d'immobilisation
+  // (PCG), mais les exports completent les numeros a 6 chiffres : 281000
+  // amortit 210000, 281830 amortit 218300, 28183 amortit 2183. On apparie
+  // donc par racine (zeros finaux retires, 8/9 en 2e position retire).
+  // Sans appariement sur : '28'/'29' nus (non ventiles dans le PCG) et
+  // racines ambigues (ex. 21 et 210000 dans la meme balance) -> ligne propre.
+  const rootOf = (acct) => acct.replace(/0+$/, '') || acct;
+  const immoByRoot = new Map();
+  const ambiguousRoots = new Set();
+  for (const [acct] of immoAccounts) {
+    const root = rootOf(acct);
+    if (immoByRoot.has(root)) ambiguousRoots.add(root);
+    else immoByRoot.set(root, acct);
+  }
+  const amortByImmo = new Map();
+  const orphanAmort = [];
+  for (const [acct, bal] of amortAccounts) {
+    const amount = round2(bal.credit - bal.debit);
+    const targetRoot = '2' + rootOf(acct).substring(2);
+    const target = (acct === '28' || acct === '29' || ambiguousRoots.has(targetRoot))
+      ? undefined
+      : immoByRoot.get(targetRoot);
+    if (target !== undefined) {
+      amortByImmo.set(target, round2((amortByImmo.get(target) || 0) + amount));
+    } else if (Math.abs(amount) > 0.01) {
+      orphanAmort.push([acct, amount]);
+    }
+  }
 
-    const matchedAmort = new Set();
+  if (immoAccounts.length > 0 || orphanAmort.length > 0) {
+    md += '| **ACTIF IMMOBILISE** | | | |\n';
 
     for (const [acct, bal] of immoAccounts) {
       const brut = round2(bal.debit - bal.credit);
-      // Find corresponding amortization account (28 + suffix)
-      const amortAcct = '28' + acct.substring(1);
-      let amort = 0;
-      if (accounts[amortAcct]) {
-        matchedAmort.add(amortAcct);
-        amort = round2(accounts[amortAcct].credit - accounts[amortAcct].debit);
-      }
+      const amort = amortByImmo.get(acct) || 0;
       const net = round2(brut - amort);
       const name = pcgNames[acct] || acct;
 
@@ -292,16 +313,12 @@ function generateBilan(accounts, company, pcgNames, plData) {
       totalAmort += amort;
     }
 
-    // 28x/29x accounts not matched above (subdivided charts use e.g. 281000 for
-    // 210000, and 29x were counted nowhere): own line so the total stays exact
-    for (const [acct, bal] of amortAccounts) {
-      if (matchedAmort.has(acct)) continue;
-      const amort = round2(bal.credit - bal.debit);
-      if (Math.abs(amort) > 0.01) {
-        const name = pcgNames[acct] || acct;
-        md += '| &nbsp;&nbsp;' + acct + ' — ' + name + ' | | ' + fmt(amort) + ' | ' + fmt(round2(-amort)) + ' |\n';
-        totalAmort += amort;
-      }
+    // 28x/29x sans immobilisation brute appariee : ligne propre pour que la
+    // depreciation reste visible et que le total actif reste exact
+    for (const [acct, amort] of orphanAmort) {
+      const name = pcgNames[acct] || acct;
+      md += '| &nbsp;&nbsp;' + acct + ' — ' + name + ' | | ' + fmt(amort) + ' | ' + fmt(round2(-amort)) + ' |\n';
+      totalAmort += amort;
     }
 
     md += '| **Total actif immobilise** | **' + fmt(totalImmoBrut) + '** | **' + fmt(totalAmort) + '** | **' + fmt(round2(totalImmoBrut - totalAmort)) + '** |\n';
@@ -582,4 +599,8 @@ function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { computeBalances, generatePL, generateBilan, generateBalance };

--- a/scripts/generate-statements.js
+++ b/scripts/generate-statements.js
@@ -264,7 +264,7 @@ function generateBilan(accounts, company, pcgNames, plData) {
     .sort(([a], [b]) => a.localeCompare(b));
 
   const amortAccounts = Object.entries(accounts)
-    .filter(([a]) => a.startsWith('28'))
+    .filter(([a]) => a.startsWith('28') || a.startsWith('29'))
     .sort(([a], [b]) => a.localeCompare(b));
 
   let totalImmoBrut = 0;
@@ -273,17 +273,35 @@ function generateBilan(accounts, company, pcgNames, plData) {
   if (immoAccounts.length > 0) {
     md += '| **ACTIF IMMOBILISE** | | | |\n';
 
+    const matchedAmort = new Set();
+
     for (const [acct, bal] of immoAccounts) {
       const brut = round2(bal.debit - bal.credit);
       // Find corresponding amortization account (28 + suffix)
       const amortAcct = '28' + acct.substring(1);
-      const amort = accounts[amortAcct] ? round2(accounts[amortAcct].credit - accounts[amortAcct].debit) : 0;
+      let amort = 0;
+      if (accounts[amortAcct]) {
+        matchedAmort.add(amortAcct);
+        amort = round2(accounts[amortAcct].credit - accounts[amortAcct].debit);
+      }
       const net = round2(brut - amort);
       const name = pcgNames[acct] || acct;
 
       md += '| &nbsp;&nbsp;' + acct + ' — ' + name + ' | ' + fmt(brut) + ' | ' + fmt(amort) + ' | ' + fmt(net) + ' |\n';
       totalImmoBrut += brut;
       totalAmort += amort;
+    }
+
+    // 28x/29x accounts not matched above (subdivided charts use e.g. 281000 for
+    // 210000, and 29x were counted nowhere): own line so the total stays exact
+    for (const [acct, bal] of amortAccounts) {
+      if (matchedAmort.has(acct)) continue;
+      const amort = round2(bal.credit - bal.debit);
+      if (Math.abs(amort) > 0.01) {
+        const name = pcgNames[acct] || acct;
+        md += '| &nbsp;&nbsp;' + acct + ' — ' + name + ' | | ' + fmt(amort) + ' | ' + fmt(round2(-amort)) + ' |\n';
+        totalAmort += amort;
+      }
     }
 
     md += '| **Total actif immobilise** | **' + fmt(totalImmoBrut) + '** | **' + fmt(totalAmort) + '** | **' + fmt(round2(totalImmoBrut - totalAmort)) + '** |\n';
@@ -407,10 +425,10 @@ function generateBilan(accounts, company, pcgNames, plData) {
     .filter(([a]) => {
       if (a.startsWith('16')) return true; // Emprunts
       if (a.startsWith('40')) return true; // Fournisseurs
-      if (a === '455') return true; // Compte courant associe
+      if (a.startsWith('455')) return true; // Compte courant associe
       if (a.startsWith('43')) return true; // Organismes sociaux
       if (a.startsWith('44') && !a.startsWith('445') && !a.startsWith('4456')) return true; // Etat (IS, TVA collectee)
-      if (a === '487') return true; // PCA
+      if (a.startsWith('487')) return true; // PCA
       return false;
     })
     .sort(([a], [b]) => a.localeCompare(b));

--- a/scripts/test-deterministic-calculations.js
+++ b/scripts/test-deterministic-calculations.js
@@ -74,6 +74,108 @@ function testProrata() {
   assert.match(output, /Resultat: 136,99 EUR/);
 }
 
+// ---------------------------------------------------------------------------
+// Bilan : appariement immobilisations / amortissements-depreciations
+// ---------------------------------------------------------------------------
+
+const { generateBilan } = require(path.join(ROOT, "scripts", "generate-statements.js"));
+
+const FIXTURE_COMPANY = {
+  fiscal_year: { start: "2025-01-01", end: "2025-12-31", is_first_year: false },
+};
+
+function runBilan(accounts) {
+  return generateBilan(accounts, FIXTURE_COMPANY, {}, { resultatNet: 0 });
+}
+
+function bilanRow(md, acct) {
+  const line = md.split("\n").find((l) => l.includes(acct + " —"));
+  assert.ok(line, "ligne " + acct + " absente du bilan:\n" + md);
+  return line;
+}
+
+// Cellules [brut, amort, net] d'une ligne d'actif, espaces de milliers retires
+// (verrouille l'ordre des colonnes, insensible a la locale)
+function rowCells(md, acct) {
+  return bilanRow(md, acct)
+    .split("|")
+    .slice(2, 5)
+    .map((c) => c.replace(/[\s  ]/g, ""));
+}
+
+function testBilanAmortComptesCompletes() {
+  // Plan de comptes a 6 chiffres : 281000 amortit 210000 (et non 2810000)
+  const { md, totalActif } = runBilan({
+    "210000": { debit: 10000, credit: 0 },
+    "281000": { debit: 0, credit: 1200 },
+  });
+  assert.deepStrictEqual(rowCells(md, "210000"), ["10000,00", "1200,00", "8800,00"],
+    "amortissement 281000 non apparie a 210000:\n" + md);
+  assert.ok(!md.includes("281000 —"), "281000 ne doit pas avoir de ligne separee:\n" + md);
+  assert.strictEqual(totalActif, 8800, "total actif attendu 8800: " + totalActif);
+}
+
+function testBilanAmortSubdivision() {
+  // Subdivision : 281830 amortit 218300
+  const { md, totalActif } = runBilan({
+    "218300": { debit: 3000, credit: 0 },
+    "281830": { debit: 0, credit: 500 },
+  });
+  assert.deepStrictEqual(rowCells(md, "218300"), ["3000,00", "500,00", "2500,00"],
+    "amortissement 281830 non apparie a 218300:\n" + md);
+  assert.ok(!md.includes("281830 —"), "281830 ne doit pas avoir de ligne separee:\n" + md);
+  assert.strictEqual(totalActif, 2500, "total actif attendu 2500: " + totalActif);
+}
+
+function testBilanDepreciation29x() {
+  // Depreciation 29x apparie a l'immobilisation correspondante
+  const { md, totalActif } = runBilan({
+    "210000": { debit: 10000, credit: 0 },
+    "291000": { debit: 0, credit: 700 },
+  });
+  assert.deepStrictEqual(rowCells(md, "210000"), ["10000,00", "700,00", "9300,00"],
+    "depreciation 291000 non appariee a 210000:\n" + md);
+  assert.ok(!md.includes("291000 —"), "291000 ne doit pas avoir de ligne separee:\n" + md);
+  assert.strictEqual(totalActif, 9300, "total actif attendu 9300: " + totalActif);
+}
+
+function testBilanAmortOrphelin() {
+  // 28x sans immobilisation brute : doit rester visible au bilan, pas disparaitre
+  const { md, totalActif } = runBilan({
+    "281000": { debit: 0, credit: 1200 },
+    "512000": { debit: 1200, credit: 0 },
+  });
+  assert.deepStrictEqual(rowCells(md, "281000"), ["", "1200,00", "-1200,00"],
+    "amortissement orphelin absent ou mal presente:\n" + md);
+  assert.strictEqual(totalActif, 0, "total actif attendu 0 (1200 - 1200): " + totalActif);
+}
+
+function testBilanAmortNu() {
+  // '28' nu (non ventile dans le PCG) : pas d'affectation arbitraire a 20
+  const { md, totalActif } = runBilan({
+    "20": { debit: 10000, credit: 0 },
+    "21": { debit: 20000, credit: 0 },
+    "28": { debit: 0, credit: 3000 },
+  });
+  assert.deepStrictEqual(rowCells(md, "20"), ["10000,00", "0,00", "10000,00"],
+    "le 28 nu ne doit pas etre affecte a 20:\n" + md);
+  assert.deepStrictEqual(rowCells(md, "28"), ["", "3000,00", "-3000,00"],
+    "le 28 nu doit rester orphelin:\n" + md);
+  assert.strictEqual(totalActif, 27000, "total actif attendu 27000: " + totalActif);
+}
+
+function testBilanCollisionRacines() {
+  // 21 et 210000 dans la meme balance : appariement ambigu refuse
+  const { md, totalActif } = runBilan({
+    "21": { debit: 5000, credit: 0 },
+    "210000": { debit: 8000, credit: 0 },
+    "281000": { debit: 0, credit: 1200 },
+  });
+  assert.deepStrictEqual(rowCells(md, "281000"), ["", "1200,00", "-1200,00"],
+    "appariement ambigu : 281000 doit rester orphelin:\n" + md);
+  assert.strictEqual(totalActif, 11800, "total actif attendu 11800: " + totalActif);
+}
+
 function main() {
   testCCA();
   testAmortissementLineaire();
@@ -83,6 +185,12 @@ function main() {
   testISProratedReducedRate();
   testTVAAcomptesRS();
   testProrata();
+  testBilanAmortComptesCompletes();
+  testBilanAmortSubdivision();
+  testBilanDepreciation29x();
+  testBilanAmortOrphelin();
+  testBilanAmortNu();
+  testBilanCollisionRacines();
   console.log("Deterministic calculation tests passed.");
 }
 


### PR DESCRIPTION

Closes #65

## Problème

Avec un plan de comptes aux numéros complétés à 6 chiffres ou plus — la forme
standard des exports FEC des logiciels comptables (`455100`, `281000`/`210000`…) —
le gabarit bilan de `generate-statements.js` affiche un bilan faussement
déséquilibré alors que la balance est équilibrée. Détail et reproduction minimale
dans l'issue liée.

## Correctif (volontairement minimal — 22+/4−, un seul fichier)

- **Dettes** : `a === '455'` → `a.startsWith('455')` (compte courant d'associé et
  ses subdivisions PCG, ex. 4551 « Principal ») ; même correction pour `487x` (PCA).
- **Amortissements/dépréciations** : la règle historique d'appariement
  `'28' + suffixe` est **conservée telle quelle** ; les comptes `28x`/`29x` qu'elle
  ne rattache à aucune ligne d'immobilisation sont désormais ajoutés sur leur
  propre ligne dans la colonne Amort./Déprec. — le total actif reste donc exact
  quel que soit le plan de comptes.
- **Dépréciations `29x`** : incluses dans ce même traitement (elles étaient
  exclues de l'actif immobilisé sans jamais être réintégrées).

## Tests effectués

1. **Non-régression sur le journal d'exemple du repo** — `bilan.md` généré
   avant/après le patch est **byte-identique** (`diff` vide) :

   ```
   $ node scripts/generate-statements.js   # avant puis après
   Actif  : 12 914,77 EUR / Passif : 12 914,77 EUR   (identiques)
   $ diff bilan-avant.md bilan-apres.md              (vide)
   ```

2. **Reproduction minimale de l'issue** (journal 5 lignes) :

   ```
   avant : Actif 1 300,00 / Passif 100,00 — ATTENTION : bilan desequilibre de 1 200,00 EUR
   après : Actif 1 200,00 / Passif 1 200,00 — Le bilan est equilibre.
   ```

3. **Comptabilité réelle** (SASU au régime réel, plan de comptes à 6 chiffres,
   33 écritures, 20 comptes) :

   ```
   avant : Actif 3 181,39 / Passif -1 047,98 — Ecart de 4 229,37 EUR
   après : Actif 3 039,91 / Passif 3 039,91 — Le bilan est equilibre.
   ```

   avec `455100` au passif (4 087,89) et l'amortissement `281000` (141,48)
   déduit de l'actif ; la balance générée concorde compte par compte avec celle
   du logiciel comptable d'origine.

4. **Suite de tests du repo** :

   ```
   $ npm run test:calc
   Deterministic calculation tests passed.
   ```
