### PR TITLE
Corrige le plan comptable du skill syndic d'après l'arrêté du 14 mars 2005

### DIFF
--- a/syndic/SKILL.md
+++ b/syndic/SKILL.md
@@ -114,7 +114,7 @@ AG — {{copro.name}} — {{date}}
 Clôture — {{copro.name}} — Exercice {{dates}}
 - [ ] Toutes les factures enregistrées
 - [ ] Rapprochement bancaire (solde comptable = relevé)
-- [ ] Contrôle comptes copropriétaires (411, 412, 413, 414)
+- [ ] Contrôle comptes copropriétaires (450, subdivisions 450-1 à 450-5)
 - [ ] Provisions pour charges à payer
 - [ ] Calcul régularisation (réel vs budget)
 - [ ] Affectation du résultat
@@ -203,7 +203,7 @@ Si une vérification échoue, corriger avant de présenter le résultat.
 
 | Fichier | Contenu |
 |---------|---------|
-| `data/plan-comptable-copro.json` | Plan comptable copro, classes 1 à 7 (décret 2005) |
+| `data/plan-comptable-copro.json` | Plan comptable copro (arrêté du 14 mars 2005, art. 7), classes 1, 4, 5, 6, 7 |
 | `data/majorites.json` | Matrice décision/majorité (art. 24 à 26-1) |
 
 ## Templates

--- a/syndic/data/plan-comptable-copro.json
+++ b/syndic/data/plan-comptable-copro.json
@@ -1,119 +1,422 @@
 {
-  "source": "Décret n°2005-240 du 14 mars 2005 relatif à la comptabilité des syndicats de copropriétaires",
-  "last_updated": "2026-03-26",
-  "description": "Plan comptable spécifique aux syndicats de copropriétaires (classes 1 à 7)",
+  "source": "Arrêté du 14 mars 2005 relatif aux comptes du syndicat des copropriétaires, article 7",
+  "source_url": "https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000042413155",
+  "texte_parent": "Décret n°2005-240 du 14 mars 2005",
+  "texte_parent_url": "https://www.legifrance.gouv.fr/loda/id/LEGITEXT000006051416",
+  "derniere_modification_du_texte": "2020-12-31",
+  "verifie_le": "2026-08-06",
+  "verifie_contre": "texte intégral de l'article 7 lu sur Légifrance",
+  "avertissement": "Nomenclature FERMÉE. L'article 7 dispose que les comptes retenus sont les seuls utilisables par le syndic. Les subdivisions doivent conserver la racine imposée, et les sous-comptes du 450 requièrent une décision d'assemblée générale. Avant d'affirmer qu'un compte est hors nomenclature, vérifier ici ET sur l'URL source.",
   "classes": [
     {
       "class": 1,
-      "label": "Provisions, avances, subventions, emprunts",
+      "label": "Provisions, avances, subventions et emprunts",
       "accounts": [
-        { "number": "102", "label": "Provisions pour travaux décidés non encore clôturés" },
-        { "number": "103", "label": "Avances" },
-        { "number": "1031", "label": "Avances de trésorerie" },
-        { "number": "1032", "label": "Avances travaux (art. 18-6 loi 1965)" },
-        { "number": "105", "label": "Fonds de travaux (art. 14-2 loi 1965)" },
-        { "number": "110", "label": "Solde en attente sur travaux et opérations exceptionnelles" },
-        { "number": "112", "label": "Solde en attente sur budget prévisionnel" },
-        { "number": "12", "label": "Solde des comptes de gestion" },
-        { "number": "13", "label": "Subventions" },
-        { "number": "16", "label": "Emprunts et dettes assimilées" },
-        { "number": "164", "label": "Emprunts collectifs" }
+        {
+          "number": "102",
+          "label": "Provisions pour travaux décidés"
+        },
+        {
+          "number": "103",
+          "label": "Avances"
+        },
+        {
+          "number": "1031",
+          "label": "Avances de trésorerie"
+        },
+        {
+          "number": "1032",
+          "label": "(supprimé)"
+        },
+        {
+          "number": "1033",
+          "label": "Autres avances"
+        },
+        {
+          "number": "105",
+          "label": "Fonds de travaux"
+        },
+        {
+          "number": "106",
+          "label": "Provisions pour travaux au titre de la délégation de pouvoirs accordée au conseil syndical"
+        },
+        {
+          "number": "12-1",
+          "label": "Solde en attente sur travaux décidés par l'assemblée générale"
+        },
+        {
+          "number": "12-2",
+          "label": "Solde en attente sur travaux délégués au conseil syndical"
+        },
+        {
+          "number": "131",
+          "label": "Subventions accordées en instance de versement"
+        }
       ]
     },
     {
       "class": 4,
       "label": "Copropriétaires et tiers",
       "accounts": [
-        { "number": "401", "label": "Fournisseurs" },
-        { "number": "408", "label": "Fournisseurs - factures non parvenues" },
-        { "number": "411", "label": "Copropriétaires - provisions sur opérations courantes" },
-        { "number": "412", "label": "Copropriétaires - provisions sur travaux de l'art. 14-2" },
-        { "number": "413", "label": "Copropriétaires - avances" },
-        { "number": "414", "label": "Copropriétaires - fonds de travaux" },
-        { "number": "418", "label": "Copropriétaires - produits à recevoir" },
-        { "number": "420", "label": "Personnel - rémunérations dues" },
-        { "number": "421", "label": "Personnel - charges sociales" },
-        { "number": "431", "label": "Sécurité sociale et autres organismes sociaux" },
-        { "number": "432", "label": "État - impôts et taxes" },
-        { "number": "450", "label": "Compte d'attente" },
-        { "number": "459", "label": "Copropriétaires - créditeurs" },
-        { "number": "46", "label": "Débiteurs et créditeurs divers" },
-        { "number": "47", "label": "Comptes transitoires" },
-        { "number": "486", "label": "Charges constatées d'avance" },
-        { "number": "487", "label": "Produits constatés d'avance" }
+        {
+          "number": "401",
+          "label": "Fournisseurs"
+        },
+        {
+          "number": "408",
+          "label": "Fournisseurs - factures non parvenues"
+        },
+        {
+          "number": "409",
+          "label": "Fournisseurs débiteurs"
+        },
+        {
+          "number": "421",
+          "label": "Personnel"
+        },
+        {
+          "number": "431",
+          "label": "Sécurité sociale"
+        },
+        {
+          "number": "432",
+          "label": "Autres organismes sociaux"
+        },
+        {
+          "number": "441",
+          "label": "État et collectivités"
+        },
+        {
+          "number": "442",
+          "label": "État et collectivités"
+        },
+        {
+          "number": "443",
+          "label": "État et collectivités"
+        },
+        {
+          "number": "450",
+          "label": "Copropriétaire individualisé",
+          "note": "C'EST LE COMPTE DES COPROPRIÉTAIRES. Ne pas le confondre avec un compte d'attente : ce sont les 471 et 472."
+        },
+        {
+          "number": "450-1",
+          "label": "Copropriétaire - budget prévisionnel",
+          "creation": "sur décision de l'assemblée générale"
+        },
+        {
+          "number": "450-2",
+          "label": "Copropriétaire - travaux de l'article 14-2 de la loi et opérations exceptionnelles",
+          "creation": "sur décision de l'assemblée générale"
+        },
+        {
+          "number": "450-3",
+          "label": "Copropriétaire - avances",
+          "creation": "sur décision de l'assemblée générale"
+        },
+        {
+          "number": "450-4",
+          "label": "Copropriétaire - emprunts",
+          "creation": "sur décision de l'assemblée générale"
+        },
+        {
+          "number": "450-5",
+          "label": "Copropriétaire - fonds de travaux",
+          "creation": "sur décision de l'assemblée générale"
+        },
+        {
+          "number": "459",
+          "label": "Copropriétaire - créances douteuses"
+        },
+        {
+          "number": "461",
+          "label": "Débiteurs divers"
+        },
+        {
+          "number": "462",
+          "label": "Créditeurs divers"
+        },
+        {
+          "number": "471",
+          "label": "Compte en attente d'imputation débiteur"
+        },
+        {
+          "number": "472",
+          "label": "Compte en attente d'imputation créditeur"
+        },
+        {
+          "number": "486",
+          "label": "Charges payées d'avance"
+        },
+        {
+          "number": "487",
+          "label": "Produits encaissés d'avance",
+          "note": "La classe 48 s'arrête ici. Il n'existe NI 488 NI 489."
+        },
+        {
+          "number": "491",
+          "label": "Dépréciation"
+        },
+        {
+          "number": "492",
+          "label": "Dépréciation"
+        }
       ]
     },
     {
       "class": 5,
-      "label": "Trésorerie",
+      "label": "Comptes financiers",
       "accounts": [
-        { "number": "501", "label": "Banque - compte courant" },
-        { "number": "502", "label": "Banque - livret A" },
-        { "number": "503", "label": "Banque - fonds de placement" },
-        { "number": "51", "label": "Caisse" }
+        {
+          "number": "501",
+          "label": "Fonds placés"
+        },
+        {
+          "number": "502",
+          "label": "Fonds placés"
+        },
+        {
+          "number": "512",
+          "label": "Banques"
+        },
+        {
+          "number": "514",
+          "label": "Banques"
+        },
+        {
+          "number": "53",
+          "label": "Caisse"
+        }
       ]
     },
     {
       "class": 6,
-      "label": "Charges",
+      "label": "Comptes de charges",
       "accounts": [
-        { "number": "60", "label": "Achats de matières et fournitures" },
-        { "number": "601", "label": "Fournitures d'entretien" },
-        { "number": "602", "label": "Fournitures de bureau et documentation" },
-        { "number": "61", "label": "Services extérieurs" },
-        { "number": "611", "label": "Assurance de l'immeuble" },
-        { "number": "612", "label": "Nettoyage des locaux" },
-        { "number": "613", "label": "Espaces verts" },
-        { "number": "614", "label": "Digicode / interphone / vidéosurveillance" },
-        { "number": "615", "label": "Ascenseur - contrat d'entretien" },
-        { "number": "616", "label": "Chauffage collectif - fourniture d'énergie (P1)" },
-        { "number": "617", "label": "Chauffage collectif - entretien (P2/P3)" },
-        { "number": "618", "label": "Eau froide" },
-        { "number": "619", "label": "Électricité parties communes" },
-        { "number": "62", "label": "Autres services extérieurs" },
-        { "number": "621", "label": "Honoraires du syndic" },
-        { "number": "622", "label": "Honoraires - avocat, huissier" },
-        { "number": "623", "label": "Honoraires - expert, géomètre, diagnostiqueur" },
-        { "number": "624", "label": "Frais de recouvrement" },
-        { "number": "625", "label": "Frais postaux et de télécommunications" },
-        { "number": "626", "label": "Frais de copies et de reprographie" },
-        { "number": "63", "label": "Impôts et taxes" },
-        { "number": "631", "label": "Taxe foncière (si applicable)" },
-        { "number": "633", "label": "Taxe d'enlèvement des ordures ménagères" },
-        { "number": "64", "label": "Frais de personnel" },
-        { "number": "641", "label": "Rémunérations - gardien / employé d'immeuble" },
-        { "number": "645", "label": "Charges sociales" },
-        { "number": "65", "label": "Autres charges de gestion courante" },
-        { "number": "66", "label": "Charges financières" },
-        { "number": "661", "label": "Intérêts d'emprunt collectif" },
-        { "number": "662", "label": "Frais bancaires" },
-        { "number": "67", "label": "Charges exceptionnelles" },
-        { "number": "671", "label": "Créances irrécouvrables" },
-        { "number": "672", "label": "Pénalités et amendes" },
-        { "number": "68", "label": "Dotations aux amortissements et provisions" },
-        { "number": "681", "label": "Dotation provision pour impayés" }
+        {
+          "number": "601",
+          "label": "Eau"
+        },
+        {
+          "number": "602",
+          "label": "Electricité"
+        },
+        {
+          "number": "603",
+          "label": "Chauffage, énergie et combustibles"
+        },
+        {
+          "number": "604",
+          "label": "Achats produits d'entretien et petits équipements"
+        },
+        {
+          "number": "605",
+          "label": "Matériel"
+        },
+        {
+          "number": "606",
+          "label": "Fournitures"
+        },
+        {
+          "number": "611",
+          "label": "Nettoyage des locaux"
+        },
+        {
+          "number": "612",
+          "label": "Locations immobilières"
+        },
+        {
+          "number": "613",
+          "label": "Locations mobilières"
+        },
+        {
+          "number": "614",
+          "label": "Contrats de maintenance"
+        },
+        {
+          "number": "615",
+          "label": "Entretien et petites réparations"
+        },
+        {
+          "number": "616",
+          "label": "Primes d'assurances"
+        },
+        {
+          "number": "621",
+          "label": "Rémunérations du syndic sur gestion copropriété"
+        },
+        {
+          "number": "6211",
+          "label": "Rémunération du syndic"
+        },
+        {
+          "number": "6212",
+          "label": "Débours"
+        },
+        {
+          "number": "6213",
+          "label": "Frais postaux"
+        },
+        {
+          "number": "622",
+          "label": "Autres honoraires du syndic"
+        },
+        {
+          "number": "6221",
+          "label": "Honoraires travaux"
+        },
+        {
+          "number": "6222",
+          "label": "Prestations particulières"
+        },
+        {
+          "number": "6223",
+          "label": "Autres honoraires"
+        },
+        {
+          "number": "623",
+          "label": "Rémunérations de tiers intervenants"
+        },
+        {
+          "number": "624",
+          "label": "Frais du conseil syndical"
+        },
+        {
+          "number": "632",
+          "label": "Taxe de balayage"
+        },
+        {
+          "number": "633",
+          "label": "Taxe foncière"
+        },
+        {
+          "number": "634",
+          "label": "Autres impôts et taxes"
+        },
+        {
+          "number": "641",
+          "label": "Salaires"
+        },
+        {
+          "number": "642",
+          "label": "Charges sociales et organismes sociaux"
+        },
+        {
+          "number": "643",
+          "label": "Taxe sur les salaires"
+        },
+        {
+          "number": "644",
+          "label": "Autres"
+        },
+        {
+          "number": "65",
+          "label": "Montant spécifique alloué au conseil syndical"
+        },
+        {
+          "number": "661",
+          "label": "Remboursement d'annuités d'emprunt"
+        },
+        {
+          "number": "662",
+          "label": "Autres charges financières et agios"
+        },
+        {
+          "number": "671",
+          "label": "Travaux décidés par l'assemblée générale"
+        },
+        {
+          "number": "672",
+          "label": "Travaux urgents"
+        },
+        {
+          "number": "673",
+          "label": "Études techniques, diagnostic, consultation"
+        },
+        {
+          "number": "674",
+          "label": "Travaux délégués au conseil syndical"
+        },
+        {
+          "number": "677",
+          "label": "Pertes sur créances irrécouvrables"
+        },
+        {
+          "number": "678",
+          "label": "Charges exceptionnelles"
+        },
+        {
+          "number": "68",
+          "label": "Dotations aux dépréciations sur créances douteuses"
+        }
       ]
     },
     {
       "class": 7,
-      "label": "Produits",
+      "label": "Comptes de produits",
       "accounts": [
-        { "number": "701", "label": "Provisions sur opérations courantes" },
-        { "number": "702", "label": "Provisions sur travaux et opérations exceptionnelles" },
-        { "number": "703", "label": "Cotisations fonds de travaux" },
-        { "number": "71", "label": "Produits liés aux travaux" },
-        { "number": "72", "label": "Produits financiers" },
-        { "number": "721", "label": "Intérêts sur placements" },
-        { "number": "73", "label": "Produits divers" },
-        { "number": "731", "label": "Indemnités d'assurance" },
-        { "number": "732", "label": "Revenus des parties communes (location)" },
-        { "number": "74", "label": "Subventions" },
-        { "number": "741", "label": "Subventions ANAH" },
-        { "number": "742", "label": "MaPrimeRénov' Copropriété" },
-        { "number": "743", "label": "CEE (Certificats d'Économies d'Énergie)" },
-        { "number": "78", "label": "Reprises de provisions" },
-        { "number": "781", "label": "Reprise provision pour impayés" }
+        {
+          "number": "701",
+          "label": "Provisions sur opérations courantes"
+        },
+        {
+          "number": "702",
+          "label": "Provisions sur travaux et opérations exceptionnelles"
+        },
+        {
+          "number": "703",
+          "label": "Avances"
+        },
+        {
+          "number": "704",
+          "label": "Remboursements d'annuités d'emprunts"
+        },
+        {
+          "number": "705",
+          "label": "Affectation du fonds de travaux"
+        },
+        {
+          "number": "706",
+          "label": "Provisions au titre de la délégation de pouvoirs"
+        },
+        {
+          "number": "706-1",
+          "label": "Provisions sur opérations courantes"
+        },
+        {
+          "number": "706-2",
+          "label": "Provisions sur travaux et opérations exceptionnelles"
+        },
+        {
+          "number": "711",
+          "label": "Subventions"
+        },
+        {
+          "number": "712",
+          "label": "Emprunts"
+        },
+        {
+          "number": "713",
+          "label": "Indemnités d'assurances"
+        },
+        {
+          "number": "714",
+          "label": "Produits divers"
+        },
+        {
+          "number": "716",
+          "label": "Produits financiers"
+        },
+        {
+          "number": "718",
+          "label": "Produits exceptionnels"
+        },
+        {
+          "number": "78",
+          "label": "Reprises de dépréciations sur créances douteuses"
+        }
       ]
     }
-  ]
+  ],
+  "note": "Nomenclature reprise integralement de l'article 7 de l'arrete. Avant la correction de 2026-08, ce fichier reprenait le plan comptable general adapte : les copropriétaires y figuraient en 411 a 414 (inexistants en copropriete, le compte est le 450), le 450 etait donne comme compte d'attente (ce sont les 471 et 472) et le 671 comme creances irrecouvrables (c'est le compte des travaux votes, les creances irrecouvrables sont au 677)."
 }

--- a/syndic/evals/evals.json
+++ b/syndic/evals/evals.json
@@ -60,7 +60,7 @@
         "Le fonds de travaux trimestriel est de 350 EUR au total",
         "L'appel travaux ravalement est de 5 000 EUR (15 000 / 3)",
         "Chaque copropriétaire paie au prorata de ses tantièmes",
-        "Les écritures comptables sont indiquées (comptes 411/701 pour provisions courantes, 414/105 pour fonds travaux, 412/702 pour travaux votés)",
+        "Les écritures comptables sont indiquées (comptes 450-1/701 pour provisions courantes, 450-5/105 pour fonds travaux, 450-2/702 pour travaux votés)",
         "La date d'exigibilité (1er avril) est précisée",
         "L'appel est présenté de façon structurée avec le détail par copropriétaire ou par lot"
       ]

--- a/syndic/references/comptabilite-copro.md
+++ b/syndic/references/comptabilite-copro.md
@@ -2,80 +2,150 @@
 
 ## Cadre Réglementaire
 
-**Décret n2005-240 du 14 mars 2005** : toute copropriété doit tenir une comptabilité en partie double, selon un plan comptable spécifique.
+**Décret n° 2005-240 du 14 mars 2005** : toute copropriété tient une comptabilité en partie double, selon un plan comptable qui lui est propre.
+
+**Arrêté du 14 mars 2005, article 7** : fixe la nomenclature des comptes. Elle est **fermée**. Les comptes qu'elle énumère sont les seuls utilisables par le syndic, et une subdivision n'est admise que si elle conserve la racine imposée. Les sous-comptes du 450 requièrent en outre une décision d'assemblée générale.
+
+Texte de référence, à consulter avant tout constat de non-conformité :
+https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000042413155
+
+Ce n'est pas le plan comptable général. Les numéros ne se recoupent pas : en copropriété le copropriétaire est au 450 et non au 411, et le 671 est le compte des travaux votés, non celui des créances irrécouvrables.
 
 ## Plan Comptable des Copropriétés
 
-### Classe 1 : Provisions, avances, subventions
+### Classe 1 : Provisions, avances, subventions et emprunts
 
 | Compte | Libellé |
 |--------|---------|
-| 102 | Provisions pour travaux décidés (art. 14-2 loi 1965) |
+| 102 | Provisions pour travaux décidés |
 | 103 | Avances |
-| 105 | Fonds de travaux (cotisations art. 14-2) |
-| 110 | Solde en attente sur travaux et opérations exceptionnelles |
-| 112 | Solde en attente sur budget prévisionnel |
-| 12 | Solde des comptes de gestion |
-| 13 | Subventions |
+| 103-1 | Avances de trésorerie |
+| 103-3 | Autres avances |
+| 105 | Fonds de travaux (art. 14-2) |
+| 106 | Provisions pour travaux au titre de la délégation de pouvoirs au conseil syndical |
+| 12-1 | Solde en attente sur travaux décidés par l'assemblée générale |
+| 12-2 | Solde en attente sur travaux délégués au conseil syndical |
+| 131 | Subventions accordées en instance de versement |
+
+Le 103-2 a été supprimé du texte.
 
 ### Classe 4 : Copropriétaires et tiers
 
 | Compte | Libellé |
 |--------|---------|
 | 401 | Fournisseurs |
-| 411 | Copropriétaires : provisions sur opérations courantes |
-| 412 | Copropriétaires : provisions sur travaux |
-| 413 | Copropriétaires : avances |
-| 414 | Copropriétaires : fonds de travaux |
-| 420 | Personnel |
-| 421 | Charges sociales |
-| 431 | État (TVA, impôts) |
-| 450 | Compte d'attente |
-| 459 | Copropriétaires : créditeurs |
-| 46 | Débiteurs et créditeurs divers |
-| 47 | Comptes transitoires |
+| 408 | Fournisseurs, factures non parvenues |
+| 409 | Fournisseurs débiteurs |
+| 421 | Personnel |
+| 431 | Sécurité sociale |
+| 432 | Autres organismes sociaux |
+| 441 à 443 | État et collectivités |
+| **450** | **Copropriétaire individualisé** |
+| 450-1 | Copropriétaire, budget prévisionnel |
+| 450-2 | Copropriétaire, travaux de l'art. 14-2 et opérations exceptionnelles |
+| 450-3 | Copropriétaire, avances |
+| 450-4 | Copropriétaire, emprunts |
+| 450-5 | Copropriétaire, fonds de travaux |
+| 459 | Copropriétaire, créances douteuses |
+| 461 | Débiteurs divers |
+| 462 | Créditeurs divers |
+| 471 | Compte en attente d'imputation débiteur |
+| 472 | Compte en attente d'imputation créditeur |
+| 486 | Charges payées d'avance |
+| 487 | Produits encaissés d'avance |
+| 491, 492 | Dépréciation |
 
-### Classe 5 : Trésorerie
+Trois pièges. Le compte du copropriétaire est le **450**, pas le 411 : les comptes 411 à 414 appartiennent au plan comptable général et n'existent pas ici. Les **comptes d'attente sont les 471 et 472**, le 450 n'en est pas un. Les subdivisions 450-1 à 450-5 ne s'ouvrent que **sur décision d'assemblée générale**. La classe 48 s'arrête au 487 : il n'existe ni 488 ni 489.
+
+### Classe 5 : Comptes financiers
 
 | Compte | Libellé |
 |--------|---------|
-| 501 | Compte courant (banque) |
-| 502 | Livret A syndic |
-| 503 | Fonds de placement |
-| 51 | Caisse |
+| 501, 502 | Fonds placés |
+| 512, 514 | Banques |
+| 53 | Caisse |
 
-### Classe 6 : Charges
+Le compte bancaire courant du syndicat est en **512 ou 514**, pas en 501 : les 501 et 502 sont les fonds placés, typiquement le livret sur lequel le fonds de travaux doit être déposé (art. 14-2).
 
-| Compte | Libellé | Exemples |
-|--------|---------|----------|
-| 60 | Achats | Fournitures, produits d'entretien |
-| 61 | Services extérieurs | Assurance, nettoyage, espaces verts |
-| 62 | Autres services extérieurs | Honoraires syndic, avocat, géomètre |
-| 63 | Impôts et taxes | Taxe foncière (si applicable), ordures ménagères |
-| 64 | Frais de personnel | Gardien, employé d'immeuble |
-| 65 | Autres charges de gestion | Frais postaux, fournitures bureau |
-| 66 | Charges financières | Intérêts d'emprunt, frais bancaires |
-| 67 | Charges exceptionnelles | Sinistres, contentieux |
-| 68 | Dotations amortissements et provisions | Provisions pour impayés |
+### Classe 6 : Comptes de charges
 
-### Classe 7 : Produits
+Les comptes 60 à 66 portent les **charges courantes** de l'article 14-1, couvertes par le budget prévisionnel voté. Les comptes 67 portent les **travaux et opérations exceptionnelles** de l'article 14-2, qui font l'objet d'un vote propre. La distinction commande la base légale, l'appel de fonds, la clé de répartition et l'annexe : ne jamais loger l'un dans l'autre.
 
-| Compte | Libellé | Exemples |
-|--------|---------|----------|
-| 70 | Appels de fonds | Provisions sur charges courantes |
-| 71 | Produits liés aux travaux | Appels pour travaux votés |
-| 72 | Produits financiers | Intérêts livret, placements |
-| 73 | Produits divers | Indemnités d'assurance, locations |
-| 74 | Subventions | Aides ANAH, MaPrimeRénov' collectif |
-| 78 | Reprises de provisions | |
+| Compte | Libellé |
+|--------|---------|
+| 601 | Eau |
+| 602 | Électricité |
+| 603 | Chauffage, énergie et combustibles |
+| 604 | Achats produits d'entretien et petits équipements |
+| 605 | Matériel |
+| 606 | Fournitures |
+| 611 | Nettoyage des locaux |
+| 612 | Locations immobilières |
+| 613 | Locations mobilières |
+| 614 | Contrats de maintenance |
+| 615 | Entretien et petites réparations |
+| 616 | Primes d'assurances |
+| 621 | Rémunérations du syndic sur gestion copropriété |
+| 621-1 | Rémunération du syndic |
+| 621-2 | Débours |
+| 621-3 | Frais postaux |
+| 622 | Autres honoraires du syndic |
+| 622-1 | Honoraires travaux |
+| 622-2 | Prestations particulières |
+| 622-3 | Autres honoraires |
+| 623 | Rémunérations de tiers intervenants |
+| 624 | Frais du conseil syndical |
+| 632 | Taxe de balayage |
+| 633 | Taxe foncière |
+| 634 | Autres impôts et taxes |
+| 641 | Salaires |
+| 642 | Charges sociales et organismes sociaux |
+| 643 | Taxe sur les salaires |
+| 644 | Autres |
+| 65 | Montant spécifique alloué au conseil syndical |
+| 661 | Remboursement d'annuités d'emprunt |
+| 662 | Autres charges financières et agios |
+| **671** | **Travaux décidés par l'assemblée générale** |
+| 672 | Travaux urgents |
+| 673 | Études techniques, diagnostic, consultation |
+| 674 | Travaux délégués au conseil syndical |
+| 677 | Pertes sur créances irrécouvrables |
+| 678 | Charges exceptionnelles |
+| 68 | Dotations aux dépréciations sur créances douteuses |
+
+Un compte 671 ouvert sur plusieurs exercices n'est pas une anomalie : l'opération de travaux reste ouverte jusqu'à sa clôture et son approbation.
+
+### Classe 7 : Comptes de produits
+
+| Compte | Libellé |
+|--------|---------|
+| 701 | Provisions sur opérations courantes |
+| 702 | Provisions sur travaux et opérations exceptionnelles |
+| 703 | Avances |
+| 704 | Remboursements d'annuités d'emprunts |
+| 705 | Affectation du fonds de travaux |
+| 706 | Provisions au titre de la délégation de pouvoirs |
+| 706-1 | Provisions sur opérations courantes |
+| 706-2 | Provisions sur travaux et opérations exceptionnelles |
+| 711 | Subventions |
+| 712 | Emprunts |
+| 713 | Indemnités d'assurances |
+| 714 | Produits divers |
+| 716 | Produits financiers |
+| 718 | Produits exceptionnels |
+| 78 | Reprises de dépréciations sur créances douteuses |
+
+Le **701 est l'appel de charges courantes**, le **702 l'appel de travaux**. C'est le pendant, côté produits, de la séparation 60-66 contre 67.
 
 ## Écritures Types
 
-### Appel de fonds trimestriel
+Le copropriétaire est toujours le **450**, subdivisé selon la nature de l'appel.
+
+### Appel de fonds trimestriel (charges courantes, art. 14-1)
 
 ```
-Débit  411 - Copropriétaires (provisions courantes)    X
-Crédit 701 - Provisions sur charges courantes              X
+Débit  450-1 - Copropriétaire, budget prévisionnel       X
+Crédit 701   - Provisions sur opérations courantes           X
 ```
 
 Ventilation par copropriétaire selon les tantièmes de la clé de répartition concernée.
@@ -83,53 +153,71 @@ Ventilation par copropriétaire selon les tantièmes de la clé de répartition 
 ### Paiement d'un copropriétaire
 
 ```
-Débit  501 - Banque                                     X
-Crédit 411 - Copropriétaires                                X
+Débit  512   - Banque                                    X
+Crédit 450-1 - Copropriétaire, budget prévisionnel           X
 ```
 
 ### Facture fournisseur
 
 ```
-Débit  6xx - Charge correspondante                      X
-Crédit 401 - Fournisseurs                                   X
+Débit  6xx - Charge correspondante                       X
+Crédit 401 - Fournisseurs                                    X
 ```
 
-### Règlement fournisseur
+La charge entre par le compte fournisseur, puis elle est répartie entre les copropriétaires selon les tantièmes. Un crédit ultérieur sur le compte 6xx signifie que la dépense **sort de cette répartition** : la contrepartie en donne la raison, et il ne faut pas la qualifier d'annulation sans l'avoir lue.
+
+### Appel pour travaux votés (art. 14-2)
 
 ```
-Débit  401 - Fournisseurs                               X
-Crédit 501 - Banque                                         X
+Débit  450-2 - Copropriétaire, travaux art. 14-2         X
+Crédit 702   - Provisions sur travaux et op. except.         X
 ```
 
-### Appel pour travaux votés
+Ventilation selon les tantièmes et l'échéancier voté en AG.
+
+### Cotisation au fonds de travaux (art. 14-2)
 
 ```
-Débit  412 - Copropriétaires (provisions sur travaux)   X
-Crédit 702 - Provisions sur travaux et opérations except.    X
+Débit  450-5 - Copropriétaire, fonds de travaux          X
+Crédit 105   - Fonds de travaux                              X
 ```
 
-Ventilation par copropriétaire selon les tantièmes et l'échéancier voté en AG.
+Le fonds est attaché au lot et non à la personne : en cas de vente, les cotisations restent acquises au syndicat.
 
-### Cotisation fonds de travaux
+### Dépense de travaux votés
 
 ```
-Débit  414 - Copropriétaires (fonds de travaux)         X
-Crédit 105 - Fonds de travaux                               X
+Débit  671 - Travaux décidés par l'assemblée générale    X
+Crédit 401 - Fournisseurs                                    X
 ```
 
 ### Régularisation annuelle (trop-perçu)
 
 ```
-Débit  701 - Provisions sur charges courantes           X
-Crédit 459 - Copropriétaires créditeurs                     X
+Débit  701   - Provisions sur opérations courantes       X
+Crédit 450-1 - Copropriétaire, budget prévisionnel           X
 ```
+
+Le solde du 450-1 devient créditeur. Il n'est exigible ou restituable qu'après approbation des comptes en assemblée.
 
 ### Régularisation annuelle (insuffisance)
 
 ```
-Débit  411 - Copropriétaires (solde débiteur)           X
-Crédit 701 - Provisions sur charges courantes               X
+Débit  450-1 - Copropriétaire, budget prévisionnel       X
+Crédit 701   - Provisions sur opérations courantes           X
 ```
+
+### Créance douteuse, puis irrécouvrable
+
+```
+Débit  459 - Copropriétaire, créances douteuses          X
+Crédit 450 - Copropriétaire individualisé                    X
+
+Débit  68  - Dotations aux dépréciations                 X
+Crédit 491 - Dépréciation                                    X
+```
+
+Et si la créance est définitivement perdue, elle passe au **677**, pas au 671.
 
 ## Clôture Annuelle
 
@@ -137,7 +225,7 @@ Crédit 701 - Provisions sur charges courantes               X
 
 1. Vérifier l'exhaustivité des écritures (toutes les factures enregistrées)
 2. Rapprochement bancaire (solde comptable vs relevé bancaire)
-3. Contrôler les comptes copropriétaires (411, 412, 413, 414)
+3. Contrôler les comptes copropriétaires (450 et ses subdivisions 450-1 a 450-5)
 4. Provisions pour charges à payer (factures reçues après clôture)
 5. Calcul de la régularisation (réel vs budget prévisionnel)
 6. Affectation du résultat (report, remboursement, ou appel complémentaire)

--- a/syndic/references/integration-qonto.md
+++ b/syndic/references/integration-qonto.md
@@ -54,7 +54,7 @@ Les transactions sont catégorisées selon le plan comptable des copropriétés 
 ## Rapprochement bancaire
 
 Croiser les transactions Qonto avec :
-1. Les appels de fonds émis (comptes 411, 412, 414)
+1. Les appels de fonds émis (comptes 450-1, 450-2, 450-5)
 2. Les paiements fournisseurs (compte 401)
 3. Le solde comptable (compte 501)
 


### PR DESCRIPTION
Corrige #67.

Le plan comptable du skill `syndic` était celui du plan comptable général des entreprises, avec des libellés adaptés. La comptabilité des syndicats de copropriétaires suit une nomenclature propre et **fermée**, fixée par l'[article 7 de l'arrêté du 14 mars 2005](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000042413155) : les comptes qu'il énumère sont les seuls utilisables par le syndic, une subdivision n'étant admise que si elle conserve la racine imposée.

## Ce que ça change

| | avant | après (arrêté, art. 7) |
|---|---|---|
| Copropriétaire | 411 à 414 | **450**, subdivisé 450-1 à 450-5 sur décision d'AG |
| 450 | Compte d'attente | **Copropriétaire individualisé** |
| Comptes d'attente | absents | **471** débiteur, **472** créditeur |
| 671 | Créances irrécouvrables | **Travaux décidés par l'assemblée générale** |
| Créances irrécouvrables | 671 | **677** |
| 601 / 611 / 616 / 623 | Fournitures / Assurance / Chauffage P1 / Expert | **Eau / Nettoyage / Primes d'assurances / Rémunérations de tiers intervenants** |
| Banque | 501 | **512, 514** (les 501 et 502 sont les fonds placés) |
| 459 | Copropriétaires créditeurs | **Copropriétaire, créances douteuses** |

Les classes 6 et 7 de `comptabilite-copro.md` reprenaient en outre les intitulés du PCG (« 60 Achats », « 61 Services extérieurs », « 70 Appels de fonds »), remplacés par la nomenclature réelle.

## Fichiers

`syndic/data/plan-comptable-copro.json` est repris intégralement du texte, 93 comptes sur 5 classes, avec `source_url` vers Légifrance, la date de vérification et un avertissement rappelant que la nomenclature est fermée. L'intention est qu'un agent puisse toujours remonter à la source avant d'écrire qu'un compte est non conforme.

`syndic/references/comptabilite-copro.md` voit ses cinq tables de classes refaites et ses écritures types réécrites sur le 450. J'ai ajouté la distinction entre les charges courantes de l'article 14-1 (comptes 60 à 66, appels 701) et les travaux de l'article 14-2 (comptes 67, appels 702), parce que c'est elle qui commande la base légale, la clé de répartition et l'annexe, et qu'elle n'apparaissait pas. Deux écritures manquantes sont ajoutées, la dépense de travaux votés et le passage en créance douteuse puis irrécouvrable.

`syndic/evals/evals.json` : l'assertion 3 exigeait les comptes 411, 412 et 414. Elle aurait fait échouer une réponse correcte, elle attend maintenant les 450-1, 450-2 et 450-5.

`syndic/SKILL.md` et `syndic/references/integration-qonto.md` : les checklists qui citaient les 411 à 414.

Aucune modification hors du répertoire `syndic/`.

## Vérification

Les deux JSON modifiés parsent. La nomenclature a été confrontée compte par compte au texte de l'article 7, puis au grand livre et à la balance d'une copropriété réelle de 266 lots dont j'assiste le contrôle des comptes : les 402 lignes de balance se rattachent toutes à une racine de l'arrêté, à deux exceptions près qui sont de vraies non-conformités du syndic.

Je reste disponible si vous préférez un autre découpage, par exemple séparer la correction du JSON de la réécriture du markdown.
