### PR TITLE
fiscaliste : ne pas appliquer l'abattement 10 % aux sorties en capital de PER (cases 1AI/1BI)

### DIFF
--- a/fiscaliste/evals/evals.json
+++ b/fiscaliste/evals/evals.json
@@ -288,6 +288,20 @@
         "Le skill précise que la distinction 1AP vs 1AJ porte sur la nature du revenu (remplacement vs activité), pas sur l'abattement",
         "L'abattement suit le régime des salaires (plancher commun 509 € / plafond commun 14 555 € sur le total salaires + ARE)"
       ]
+    },
+    {
+      "id": 21,
+      "name": "ir-sortie-capital-per-1ai-sans-abattement",
+      "prompt": "Je suis en couple avec 2 enfants à charge (2 parts, je déclare seul). Mon salaire net imposable (case 1AJ) est de 100 000 €. J'ai débloqué mon PER en capital pour l'achat de ma résidence principale : 10 000 €, correspondant à des versements qui avaient été déduits à l'entrée. Calcule mon impôt sur le revenu pour les revenus 2025.",
+      "expected_output": "Les 100 000 € de salaire subissent l'abattement 10 % (RNI salaires 90 000 €). Les 10 000 € de sortie en capital se déclarent en case 1AI et entrent EN ENTIER dans le RNI, SANS abattement de 10 % — contrairement aux pensions 1AS. RNI total 100 000 €. Barème, plafonnement du quotient familial, décote le cas échéant.",
+      "files": [],
+      "assertions": [
+        "Le skill identifie la case 1AI (et non 1AS) pour une sortie en capital de PER correspondant à des versements déduits",
+        "AUCUN abattement de 10 % n'est appliqué sur les 10 000 € : ils entrent en entier dans le RNI",
+        "Le RNI total est de 100 000 € (90 000 de salaires nets + 10 000 de 1AI), et non 99 000 €",
+        "Le skill distingue explicitement le régime 1AS/1BS (abattement 10 %, plafond 4 446 € par foyer) du régime 1AI/1BI (aucun abattement)",
+        "Le gain de quotient familial est plafonné et le plafonnement est vérifié"
+      ]
     }
   ]
 }

--- a/fiscaliste/foyer.example.json
+++ b/fiscaliste/foyer.example.json
@@ -24,6 +24,9 @@
 
     "pensions_declarant1": 0,
     "pensions_declarant2": 0,
+    "pensions_capital_per_declarant1": 0,
+    "pensions_capital_per_declarant2": 0,
+    "_commentaire_pensions_capital_per": "Cases 1AI/1BI : sortie en CAPITAL d'un PER ou d'un article 83, pour la part correspondant aux versements DEDUITS a l'entree. Imposable au bareme SANS abattement 10 %, contrairement aux pensions 1AS/1BS. Ne pas melanger avec pensions_declarant*.",
 
     "bnc_regime_normal": 0,
     "_commentaire_bnc": "Case 5QC — BNC professionnels régime normal",

--- a/fiscaliste/scripts/calc_ir.py
+++ b/fiscaliste/scripts/calc_ir.py
@@ -263,14 +263,24 @@ def from_foyer(foyer, bareme, pfu_data):
     base_traitements = salaires + chomage
     net_salaires = abattement_salaires(base_traitements, bareme) if base_traitements else 0
 
+    # Pensions et retraites case 1AS/1BS : abattement 10 % (plafond par foyer).
     pensions = r.get("pensions_declarant1", 0) + r.get("pensions_declarant2", 0)
     net_pensions = abattement_pensions(pensions, bareme) if pensions else 0
+
+    # Cases 1AI/1BI — sorties en CAPITAL d'un PER / art. 83, part correspondant
+    # aux versements DÉDUITS à l'entrée. Imposables au barème comme des pensions
+    # mais SANS abattement de 10 % (brochure pratique IR, rubrique pensions).
+    # Les intégrer à `pensions_declarant*` surestime l'abattement et sous-estime le RNI.
+    pensions_sans_abattement = (
+        r.get("pensions_capital_per_declarant1", 0)
+        + r.get("pensions_capital_per_declarant2", 0)
+    )
 
     # Revenus fonciers : déjà au net (micro post-abattement / réel post-charges).
     fonciers = r.get("revenus_fonciers_reels", 0) + r.get("revenus_fonciers_micro", 0)
 
     # Revenus imposables au barème (hors revenus du capital si PFU)
-    revenu_global = net_salaires + net_pensions + fonciers
+    revenu_global = net_salaires + net_pensions + pensions_sans_abattement + fonciers
 
     # Déductions (PER + pension alimentaire + CSG déductible)
     per = d.get("per_declarant1", 0) + d.get("per_declarant2", 0)


### PR DESCRIPTION
## Le problème

`calc_ir.py` applique l'abattement de 10 % à `pensions_declarant1/2` sans condition :

```python
pensions = r.get("pensions_declarant1", 0) + r.get("pensions_declarant2", 0)
net_pensions = abattement_pensions(pensions, bareme) if pensions else 0
```

Or la **sortie en capital d'un PER ou d'un article 83**, pour la part correspondant aux versements déduits à l'entrée, se déclare en **case 1AI/1BI** et est imposable au barème **sans aucun abattement** — contrairement aux pensions et retraites 1AS/1BS.

La documentation de la skill est correcte et cohérente sur ce point : elle cadre systématiquement l'abattement sur 1AS.

- `references/ir-mecanisme.md` — `| Pensions / retraites | 1AS/1BS | 10% (min 450 €, max 4 446 €) par foyer |`
- `data/bareme-ir-2025.json` — `"description": "Abattement sur pensions et retraites (case 1AS). Plafond par foyer."`
- La signature elle-même : `def abattement_pensions(brut_1as, bareme)`

**C'est donc le schéma qui manque, plus que le calcul.** `foyer.example.json` n'expose que `pensions_declarant1/2`, sans moyen de distinguer 1AS de 1AI. Un utilisateur ayant débloqué son PER — motif résidence principale, cas très courant — n'a pas d'autre endroit où le saisir, et obtient un abattement auquel il n'a pas droit.

## Reproduction

Foyer à 2 parts, 100 000 € de salaires, 10 000 € de sortie en capital de PER (versements déduits à l'entrée) :

| | RNI | Impôt après décote |
|---|---|---|
| Avant — saisi dans `pensions_declarant1` | 99 000 € | 20 777 € |
| Après — saisi dans `pensions_capital_per_declarant1` | **100 000 €** | **21 187 €** |

**410 € d'impôt sous-estimé** sur ce cas. L'écart vaut toujours 10 % du montant 1AI, donc jusqu'à **4 446 € de RNI** lorsque le plafond de l'abattement est atteint.

## Ce que fait cette PR

Un **champ dédié** plutôt qu'un drapeau, pour que les deux natures coexistent dans un même foyer — une pension de retraite *et* un déblocage la même année est un cas fréquent :

- `calc_ir.py` : lecture de `pensions_capital_per_declarant1/2`, ajoutés au revenu global **sans abattement**, avec un commentaire renvoyant à la règle.
- `foyer.example.json` : les deux champs et un `_commentaire_pensions_capital_per` qui explique la distinction et met en garde contre le mélange avec `pensions_declarant*`.
- `evals/evals.json` : un eval de non-régression (#21) couvrant explicitement la distinction 1AI/1AS.

**Rétro-compatible** : un foyer sans le nouveau champ produit exactement le même RNI et le même impôt qu'avant — vérifié.

## Deux points laissés de côté, à votre appréciation

1. **La part correspondant aux versements NON déduits** d'une sortie en capital relève encore d'un autre régime (seuls les gains sont imposés, au PFU). Un troisième champ serait plus complet, mais je n'ai pas voulu élargir le correctif sans avis.
2. **`references/per.md` et `SKILL.md`** gagneraient à mentionner 1AI à côté de 1AS, puisque c'est le cas de figure que rencontre quiconque débloque un PER.

Merci pour ces skills — le bug a été trouvé en les utilisant sur un cas réel de déblocage pour résidence principale.